### PR TITLE
Add CI workflow and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew build
+
+  dependabot-automerge:
+    name: Dependabot Auto-Merge
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: |
+      always() &&
+      github.actor == 'dependabot[bot]' &&
+      github.event_name == 'pull_request' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+          echo "Auto-merge enabled for ${{ steps.metadata.outputs.update-type }} update"
+          echo "Will merge automatically when all required checks pass"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "${{ github.event.pull_request.html_url }}" --body "**Major version update detected** - requires manual review before merge.
+
+          This update may contain breaking changes. Please:
+          1. Review the changelog/release notes
+          2. Verify CI passes
+          3. Manually approve and merge when ready"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds GitHub Actions CI and Dependabot to the project.

## CI Workflow (`.github/workflows/ci.yml`)
- Runs on push to `main` and all PRs targeting `main`
- **Build and Test** job: Java 21 (Temurin), Gradle build cache, `./gradlew build`
- **Dependabot Auto-Merge** job:
  - Runs after build succeeds
  - Auto-merges patch and minor Dependabot updates via squash merge
  - Posts a review comment on major version updates requiring manual action

## Dependabot (`.github/dependabot.yml`)
- Gradle dependency checks: weekly, Mondays
  - Minor and patch updates grouped into a single PR
- GitHub Actions version checks: weekly, Mondays