### PR TITLE
Issue #4: Agent domain object

### DIFF
--- a/agentensemble-core/src/main/java/io/agentensemble/Agent.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/Agent.java
@@ -1,0 +1,161 @@
+package io.agentensemble;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.agentensemble.exception.ValidationException;
+import io.agentensemble.tool.AgentTool;
+import lombok.Builder;
+import lombok.Value;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * An AI agent with a defined role, goal, and optional tools.
+ *
+ * Agents are immutable value objects. Use the builder to construct instances.
+ * All validation is performed at build time -- a successfully constructed Agent
+ * is guaranteed to be in a valid state.
+ *
+ * Example:
+ * <pre>
+ * Agent researcher = Agent.builder()
+ *     .role("Senior Research Analyst")
+ *     .goal("Find the latest developments in AI")
+ *     .background("You are a veteran researcher...")
+ *     .llm(openAiModel)
+ *     .build();
+ * </pre>
+ */
+@Builder(toBuilder = true)
+@Value
+public class Agent {
+
+    /** The agent's role/title. Used in prompts and logging. Required. */
+    String role;
+
+    /** The agent's primary objective. Included in the system prompt. Required. */
+    String goal;
+
+    /**
+     * Background context for the agent persona. Included in the system prompt
+     * when non-null and non-blank. Optional.
+     */
+    String background;
+
+    /**
+     * Tools available to this agent. Each entry must be either an
+     * {@link AgentTool} instance or an object with
+     * {@code @dev.langchain4j.agent.tool.Tool} annotated methods.
+     * Default: empty list (agent uses pure LLM reasoning, no tool loop).
+     */
+    List<Object> tools;
+
+    /** The LLM to use for this agent. Any LangChain4j ChatModel. Required. */
+    ChatModel llm;
+
+    /**
+     * Whether this agent may delegate subtasks to other agents.
+     * Default: false. Reserved for Phase 2 (agent delegation).
+     */
+    boolean allowDelegation;
+
+    /**
+     * When true, prompts and LLM responses are logged at INFO level.
+     * Default: false.
+     */
+    boolean verbose;
+
+    /**
+     * Maximum number of tool call iterations before the agent is forced to
+     * produce a final answer. Prevents infinite tool-call loops.
+     * Must be greater than zero. Default: 25.
+     */
+    int maxIterations;
+
+    /**
+     * Optional formatting instructions appended to the system prompt.
+     * Example: "Always respond in bullet points."
+     * Default: empty string (omitted from prompt).
+     */
+    String responseFormat;
+
+    /**
+     * Custom builder that sets defaults and validates the Agent configuration
+     * before constructing the immutable instance.
+     *
+     * Field initializers here define the default values (Lombok respects these
+     * when it generates the builder methods).
+     */
+    public static class AgentBuilder {
+
+        // Default values -- declared here so Lombok does not overwrite them
+        private List<Object> tools = List.of();
+        private boolean allowDelegation = false;
+        private boolean verbose = false;
+        private int maxIterations = 25;
+        private String responseFormat = "";
+
+        public Agent build() {
+            validateRole();
+            validateGoal();
+            validateLlm();
+            validateMaxIterations();
+            validateTools();
+            tools = List.copyOf(tools);
+            return new Agent(role, goal, background, tools, llm, allowDelegation, verbose,
+                    maxIterations, responseFormat);
+        }
+
+        private void validateRole() {
+            if (role == null || role.isBlank()) {
+                throw new ValidationException("Agent role must not be blank");
+            }
+        }
+
+        private void validateGoal() {
+            if (goal == null || goal.isBlank()) {
+                throw new ValidationException("Agent goal must not be blank");
+            }
+        }
+
+        private void validateLlm() {
+            if (llm == null) {
+                throw new ValidationException("Agent llm must not be null");
+            }
+        }
+
+        private void validateMaxIterations() {
+            if (maxIterations <= 0) {
+                throw new ValidationException(
+                        "Agent maxIterations must be > 0, got: " + maxIterations);
+            }
+        }
+
+        private void validateTools() {
+            if (tools == null) {
+                tools = List.of();
+                return;
+            }
+            for (int i = 0; i < tools.size(); i++) {
+                Object tool = tools.get(i);
+                if (tool == null) {
+                    throw new ValidationException("Tool at index " + i + " must not be null");
+                }
+                if (!(tool instanceof AgentTool) && !hasToolAnnotatedMethods(tool)) {
+                    throw new ValidationException(
+                            "Tool at index " + i + " (" + tool.getClass().getSimpleName()
+                            + ") is neither an AgentTool nor has @Tool-annotated methods");
+                }
+            }
+        }
+
+        private static boolean hasToolAnnotatedMethods(Object obj) {
+            for (Method method : obj.getClass().getMethods()) {
+                if (method.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/agentensemble-core/src/main/java/io/agentensemble/tool/AgentTool.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/tool/AgentTool.java
@@ -1,0 +1,47 @@
+package io.agentensemble.tool;
+
+/**
+ * A tool that an agent can use during task execution.
+ *
+ * Implement this interface to create custom tools. The tool name is used by
+ * the LLM to select and invoke the tool. The description is shown to the LLM
+ * to help it decide when to use the tool.
+ *
+ * Example:
+ * <pre>
+ * public class CalculatorTool implements AgentTool {
+ *     public String name() { return "calculator"; }
+ *     public String description() { return "Performs arithmetic. Input: a math expression."; }
+ *     public ToolResult execute(String input) {
+ *         double result = evaluate(input);
+ *         return ToolResult.success(String.valueOf(result));
+ *     }
+ * }
+ * </pre>
+ *
+ * Alternatively, use the {@code @dev.langchain4j.agent.tool.Tool} annotation
+ * on methods in a plain Java object. Both approaches can be mixed in a single
+ * agent's tool list.
+ */
+public interface AgentTool {
+
+    /**
+     * Unique tool name used by the LLM to select this tool.
+     * Must be non-null and non-blank.
+     */
+    String name();
+
+    /**
+     * Description of what this tool does and when to use it.
+     * Shown to the LLM in the tool specification.
+     */
+    String description();
+
+    /**
+     * Execute the tool with the given text input.
+     *
+     * @param input the input string from the LLM tool call
+     * @return a ToolResult indicating success or failure
+     */
+    ToolResult execute(String input);
+}

--- a/agentensemble-core/src/main/java/io/agentensemble/tool/ToolResult.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/tool/ToolResult.java
@@ -1,0 +1,55 @@
+package io.agentensemble.tool;
+
+/**
+ * The result of a tool execution.
+ *
+ * Use the factory methods {@link #success(String)} and {@link #failure(String)}
+ * to create instances.
+ */
+public final class ToolResult {
+
+    private final String output;
+    private final boolean success;
+    private final String errorMessage;
+
+    private ToolResult(String output, boolean success, String errorMessage) {
+        this.output = output;
+        this.success = success;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Create a successful tool result.
+     *
+     * @param output the text output from the tool; null is treated as empty string
+     * @return a successful ToolResult
+     */
+    public static ToolResult success(String output) {
+        return new ToolResult(output != null ? output : "", true, null);
+    }
+
+    /**
+     * Create a failure tool result.
+     *
+     * @param errorMessage description of what went wrong
+     * @return a failed ToolResult
+     */
+    public static ToolResult failure(String errorMessage) {
+        return new ToolResult("", false, errorMessage);
+    }
+
+    /** The text output from the tool. Empty string if the tool failed. */
+    public String getOutput() {
+        return output;
+    }
+
+    /** Whether the tool executed successfully. */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /** Error message when {@link #isSuccess()} is false. Null on success. */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/AgentTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/AgentTest.java
@@ -1,0 +1,303 @@
+package io.agentensemble;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.model.chat.ChatModel;
+import io.agentensemble.exception.ValidationException;
+import io.agentensemble.tool.AgentTool;
+import io.agentensemble.tool.ToolResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class AgentTest {
+
+    private final ChatModel mockLlm = mock(ChatModel.class);
+
+    // ========================
+    // Build success cases
+    // ========================
+
+    @Test
+    void testBuild_withMinimalFields_succeeds() {
+        var agent = Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(mockLlm)
+                .build();
+
+        assertThat(agent.getRole()).isEqualTo("Researcher");
+        assertThat(agent.getGoal()).isEqualTo("Find information");
+        assertThat(agent.getLlm()).isSameAs(mockLlm);
+    }
+
+    @Test
+    void testBuild_withAllFields_succeeds() {
+        var tool = stubAgentTool("search");
+
+        var agent = Agent.builder()
+                .role("Senior Research Analyst")
+                .goal("Find cutting-edge developments")
+                .background("You are an expert researcher with 20 years of experience.")
+                .tools(List.of(tool))
+                .llm(mockLlm)
+                .allowDelegation(true)
+                .verbose(true)
+                .maxIterations(10)
+                .responseFormat("Respond in bullet points.")
+                .build();
+
+        assertThat(agent.getRole()).isEqualTo("Senior Research Analyst");
+        assertThat(agent.getGoal()).isEqualTo("Find cutting-edge developments");
+        assertThat(agent.getBackground()).isEqualTo("You are an expert researcher with 20 years of experience.");
+        assertThat(agent.getTools()).hasSize(1);
+        assertThat(agent.getLlm()).isSameAs(mockLlm);
+        assertThat(agent.isAllowDelegation()).isTrue();
+        assertThat(agent.isVerbose()).isTrue();
+        assertThat(agent.getMaxIterations()).isEqualTo(10);
+        assertThat(agent.getResponseFormat()).isEqualTo("Respond in bullet points.");
+    }
+
+    @Test
+    void testDefaultValues_areCorrect() {
+        var agent = Agent.builder()
+                .role("Analyst")
+                .goal("Analyze data")
+                .llm(mockLlm)
+                .build();
+
+        assertThat(agent.getBackground()).isNull();
+        assertThat(agent.getTools()).isEmpty();
+        assertThat(agent.isAllowDelegation()).isFalse();
+        assertThat(agent.isVerbose()).isFalse();
+        assertThat(agent.getMaxIterations()).isEqualTo(25);
+        assertThat(agent.getResponseFormat()).isEmpty();
+    }
+
+    @Test
+    void testBuild_withAnnotatedToolObject_succeeds() {
+        var annotatedTools = new AnnotatedToolObject();
+        var agent = Agent.builder()
+                .role("Analyst")
+                .goal("Analyze data")
+                .tools(List.of(annotatedTools))
+                .llm(mockLlm)
+                .build();
+
+        assertThat(agent.getTools()).hasSize(1);
+    }
+
+    @Test
+    void testBuild_withMixedTools_succeeds() {
+        var agentTool = stubAgentTool("calculator");
+        var annotatedTool = new AnnotatedToolObject();
+
+        var agent = Agent.builder()
+                .role("Analyst")
+                .goal("Analyze data")
+                .tools(List.of(agentTool, annotatedTool))
+                .llm(mockLlm)
+                .build();
+
+        assertThat(agent.getTools()).hasSize(2);
+    }
+
+    // ========================
+    // Validation: role
+    // ========================
+
+    @Test
+    void testBuild_withNullRole_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role(null)
+                .goal("Find information")
+                .llm(mockLlm)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("role");
+    }
+
+    @Test
+    void testBuild_withBlankRole_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("   ")
+                .goal("Find information")
+                .llm(mockLlm)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("role");
+    }
+
+    @Test
+    void testBuild_withEmptyRole_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("")
+                .goal("Find information")
+                .llm(mockLlm)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("role");
+    }
+
+    // ========================
+    // Validation: goal
+    // ========================
+
+    @Test
+    void testBuild_withNullGoal_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("Researcher")
+                .goal(null)
+                .llm(mockLlm)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("goal");
+    }
+
+    @Test
+    void testBuild_withBlankGoal_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("Researcher")
+                .goal("  ")
+                .llm(mockLlm)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("goal");
+    }
+
+    // ========================
+    // Validation: llm
+    // ========================
+
+    @Test
+    void testBuild_withNullLlm_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(null)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("llm");
+    }
+
+    // ========================
+    // Validation: maxIterations
+    // ========================
+
+    @Test
+    void testBuild_withZeroMaxIterations_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(mockLlm)
+                .maxIterations(0)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("maxIterations");
+    }
+
+    @Test
+    void testBuild_withNegativeMaxIterations_throwsValidation() {
+        assertThatThrownBy(() -> Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(mockLlm)
+                .maxIterations(-1)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("maxIterations");
+    }
+
+    @Test
+    void testBuild_withMaxIterationsEqualToOne_succeeds() {
+        var agent = Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(mockLlm)
+                .maxIterations(1)
+                .build();
+
+        assertThat(agent.getMaxIterations()).isEqualTo(1);
+    }
+
+    // ========================
+    // Validation: tools
+    // ========================
+
+    @Test
+    void testBuild_withInvalidToolObject_throwsValidation() {
+        var invalidTool = new Object(); // neither AgentTool nor @Tool-annotated
+
+        assertThatThrownBy(() -> Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .tools(List.of(invalidTool))
+                .llm(mockLlm)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Object");
+    }
+
+    // ========================
+    // Immutability
+    // ========================
+
+    @Test
+    void testToolsList_isImmutable() {
+        var agent = Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(mockLlm)
+                .build();
+
+        assertThat(agent.getTools()).isUnmodifiable();
+    }
+
+    // ========================
+    // toBuilder
+    // ========================
+
+    @Test
+    void testToBuilder_createsModifiedCopy() {
+        var original = Agent.builder()
+                .role("Researcher")
+                .goal("Find information")
+                .llm(mockLlm)
+                .build();
+
+        var modified = original.toBuilder()
+                .verbose(true)
+                .build();
+
+        assertThat(modified.isVerbose()).isTrue();
+        assertThat(original.isVerbose()).isFalse();
+        assertThat(modified.getRole()).isEqualTo("Researcher");
+        assertThat(modified.getLlm()).isSameAs(mockLlm);
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private static AgentTool stubAgentTool(String name) {
+        return new AgentTool() {
+            @Override
+            public String name() { return name; }
+            @Override
+            public String description() { return "A test tool"; }
+            @Override
+            public ToolResult execute(String input) { return ToolResult.success("ok"); }
+        };
+    }
+
+    /** A plain Java class with a LangChain4j @Tool-annotated method. */
+    static class AnnotatedToolObject {
+        @Tool("Search the web for information")
+        public String search(String query) {
+            return "results for: " + query;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #4

## Changes
- `Agent.java`: immutable value object with Lombok `@Builder`/`@Value`
- Custom `AgentBuilder` with field-initializer defaults and full build-time validation
- `AgentTool.java`: tool interface (stub, full implementation in #8)
- `ToolResult.java`: tool execution result with success/failure factories

## Validation (all at build time)
- role/goal: non-null, non-blank
- llm: non-null
- maxIterations: > 0
- tools: each entry must be `AgentTool` or have `@Tool`-annotated methods

## API Note
LangChain4j 1.11.0 renamed `ChatLanguageModel` to `ChatModel`. Updated throughout.

## Tests
- `AgentTest`: 17 tests -- all passing
- All fields, defaults, validation paths, immutability, and toBuilder() covered