### PR TITLE
Issue #5: Task and TaskOutput domain objects

### DIFF
--- a/agentensemble-core/src/main/java/io/agentensemble/Task.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/Task.java
@@ -1,0 +1,89 @@
+package io.agentensemble;
+
+import io.agentensemble.exception.ValidationException;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * A unit of work assigned to an agent.
+ *
+ * Tasks are immutable value objects. Use the builder to construct instances.
+ * All validation is performed at build time.
+ *
+ * Task descriptions and expected outputs may contain {variable} placeholders
+ * that are resolved at {@code ensemble.run(inputs)} time.
+ *
+ * Example:
+ * <pre>
+ * Task researchTask = Task.builder()
+ *     .description("Research {topic} developments in {year}")
+ *     .expectedOutput("A detailed report on {topic}")
+ *     .agent(researcher)
+ *     .build();
+ * </pre>
+ */
+@Builder(toBuilder = true)
+@Value
+public class Task {
+
+    /**
+     * What the agent should do. Supports {variable} template placeholders
+     * resolved at ensemble.run(inputs) time. Required.
+     */
+    String description;
+
+    /**
+     * What the output should look like. Included in the agent's user prompt
+     * so the agent knows the expected format and content. Supports templates.
+     * Required.
+     */
+    String expectedOutput;
+
+    /** The agent assigned to execute this task. Required. */
+    Agent agent;
+
+    /**
+     * Tasks whose outputs should be included as context when executing this task.
+     * All referenced tasks must be executed before this one (validated at
+     * ensemble.run() time by the workflow executor).
+     * Default: empty list.
+     */
+    List<Task> context;
+
+    /**
+     * Custom builder that sets defaults and validates the Task configuration.
+     */
+    public static class TaskBuilder {
+
+        // Default value
+        private List<Task> context = List.of();
+
+        public Task build() {
+            validateDescription();
+            validateExpectedOutput();
+            validateAgent();
+            context = List.copyOf(context != null ? context : List.of());
+            return new Task(description, expectedOutput, agent, context);
+        }
+
+        private void validateDescription() {
+            if (description == null || description.isBlank()) {
+                throw new ValidationException("Task description must not be blank");
+            }
+        }
+
+        private void validateExpectedOutput() {
+            if (expectedOutput == null || expectedOutput.isBlank()) {
+                throw new ValidationException("Task expectedOutput must not be blank");
+            }
+        }
+
+        private void validateAgent() {
+            if (agent == null) {
+                throw new ValidationException("Task agent must not be null");
+            }
+        }
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/TaskTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/TaskTest.java
@@ -1,0 +1,230 @@
+package io.agentensemble;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.agentensemble.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class TaskTest {
+
+    private final Agent testAgent = Agent.builder()
+            .role("Researcher")
+            .goal("Find information")
+            .llm(mock(ChatModel.class))
+            .build();
+
+    // ========================
+    // Build success cases
+    // ========================
+
+    @Test
+    void testBuild_withMinimalFields_succeeds() {
+        var task = Task.builder()
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .agent(testAgent)
+                .build();
+
+        assertThat(task.getDescription()).isEqualTo("Research AI trends");
+        assertThat(task.getExpectedOutput()).isEqualTo("A detailed report");
+        assertThat(task.getAgent()).isSameAs(testAgent);
+        assertThat(task.getContext()).isEmpty();
+    }
+
+    @Test
+    void testBuild_withAllFields_succeeds() {
+        var contextTask = Task.builder()
+                .description("Gather data")
+                .expectedOutput("Raw data")
+                .agent(testAgent)
+                .build();
+
+        var task = Task.builder()
+                .description("Analyze AI trends")
+                .expectedOutput("An analysis report")
+                .agent(testAgent)
+                .context(List.of(contextTask))
+                .build();
+
+        assertThat(task.getDescription()).isEqualTo("Analyze AI trends");
+        assertThat(task.getExpectedOutput()).isEqualTo("An analysis report");
+        assertThat(task.getContext()).hasSize(1);
+        assertThat(task.getContext().get(0)).isSameAs(contextTask);
+    }
+
+    @Test
+    void testBuild_withMultipleContextTasks_succeeds() {
+        var ctx1 = Task.builder().description("Task 1").expectedOutput("Out 1").agent(testAgent).build();
+        var ctx2 = Task.builder().description("Task 2").expectedOutput("Out 2").agent(testAgent).build();
+
+        var task = Task.builder()
+                .description("Main task")
+                .expectedOutput("Final output")
+                .agent(testAgent)
+                .context(List.of(ctx1, ctx2))
+                .build();
+
+        assertThat(task.getContext()).hasSize(2);
+    }
+
+    @Test
+    void testBuild_withTemplateVariables_succeeds() {
+        // Template variables in description/expectedOutput are valid - resolved at ensemble.run() time
+        var task = Task.builder()
+                .description("Research {topic} developments in {year}")
+                .expectedOutput("A report on {topic}")
+                .agent(testAgent)
+                .build();
+
+        assertThat(task.getDescription()).contains("{topic}");
+        assertThat(task.getExpectedOutput()).contains("{topic}");
+    }
+
+    // ========================
+    // Default values
+    // ========================
+
+    @Test
+    void testDefaultValues_contextIsEmpty() {
+        var task = Task.builder()
+                .description("Research task")
+                .expectedOutput("A report")
+                .agent(testAgent)
+                .build();
+
+        assertThat(task.getContext()).isNotNull().isEmpty();
+    }
+
+    // ========================
+    // Validation: description
+    // ========================
+
+    @Test
+    void testBuild_withNullDescription_throwsValidation() {
+        assertThatThrownBy(() -> Task.builder()
+                .description(null)
+                .expectedOutput("A report")
+                .agent(testAgent)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("description");
+    }
+
+    @Test
+    void testBuild_withBlankDescription_throwsValidation() {
+        assertThatThrownBy(() -> Task.builder()
+                .description("   ")
+                .expectedOutput("A report")
+                .agent(testAgent)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("description");
+    }
+
+    @Test
+    void testBuild_withEmptyDescription_throwsValidation() {
+        assertThatThrownBy(() -> Task.builder()
+                .description("")
+                .expectedOutput("A report")
+                .agent(testAgent)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("description");
+    }
+
+    // ========================
+    // Validation: expectedOutput
+    // ========================
+
+    @Test
+    void testBuild_withNullExpectedOutput_throwsValidation() {
+        assertThatThrownBy(() -> Task.builder()
+                .description("Research task")
+                .expectedOutput(null)
+                .agent(testAgent)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("expectedOutput");
+    }
+
+    @Test
+    void testBuild_withBlankExpectedOutput_throwsValidation() {
+        assertThatThrownBy(() -> Task.builder()
+                .description("Research task")
+                .expectedOutput("  ")
+                .agent(testAgent)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("expectedOutput");
+    }
+
+    // ========================
+    // Validation: agent
+    // ========================
+
+    @Test
+    void testBuild_withNullAgent_throwsValidation() {
+        assertThatThrownBy(() -> Task.builder()
+                .description("Research task")
+                .expectedOutput("A report")
+                .agent(null)
+                .build())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("agent");
+    }
+
+    // ========================
+    // Immutability
+    // ========================
+
+    @Test
+    void testContextList_isImmutable() {
+        var ctx = Task.builder().description("Ctx").expectedOutput("Out").agent(testAgent).build();
+        var task = Task.builder()
+                .description("Main")
+                .expectedOutput("Result")
+                .agent(testAgent)
+                .context(List.of(ctx))
+                .build();
+
+        assertThat(task.getContext()).isUnmodifiable();
+    }
+
+    @Test
+    void testContextList_defaultIsImmutable() {
+        var task = Task.builder()
+                .description("Main")
+                .expectedOutput("Result")
+                .agent(testAgent)
+                .build();
+
+        assertThat(task.getContext()).isUnmodifiable();
+    }
+
+    // ========================
+    // toBuilder
+    // ========================
+
+    @Test
+    void testToBuilder_createsModifiedCopy() {
+        var original = Task.builder()
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .agent(testAgent)
+                .build();
+
+        var ctx = Task.builder().description("Ctx").expectedOutput("Out").agent(testAgent).build();
+        var modified = original.toBuilder()
+                .context(List.of(ctx))
+                .build();
+
+        assertThat(modified.getDescription()).isEqualTo("Research AI trends");
+        assertThat(modified.getContext()).hasSize(1);
+        assertThat(original.getContext()).isEmpty();
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/task/TaskOutputTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/task/TaskOutputTest.java
@@ -1,0 +1,62 @@
+package io.agentensemble.task;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskOutputTest {
+
+    @Test
+    void testBuild_withAllFields_succeeds() {
+        var now = Instant.now();
+        var duration = Duration.ofSeconds(5);
+
+        var output = TaskOutput.builder()
+                .raw("The research findings are...")
+                .taskDescription("Research AI trends")
+                .agentRole("Senior Research Analyst")
+                .completedAt(now)
+                .duration(duration)
+                .toolCallCount(3)
+                .build();
+
+        assertThat(output.getRaw()).isEqualTo("The research findings are...");
+        assertThat(output.getTaskDescription()).isEqualTo("Research AI trends");
+        assertThat(output.getAgentRole()).isEqualTo("Senior Research Analyst");
+        assertThat(output.getCompletedAt()).isEqualTo(now);
+        assertThat(output.getDuration()).isEqualTo(duration);
+        assertThat(output.getToolCallCount()).isEqualTo(3);
+    }
+
+    @Test
+    void testBuild_withZeroToolCallCount_succeeds() {
+        var output = TaskOutput.builder()
+                .raw("Direct answer without tools")
+                .taskDescription("Simple task")
+                .agentRole("Assistant")
+                .completedAt(Instant.now())
+                .duration(Duration.ofMillis(500))
+                .toolCallCount(0)
+                .build();
+
+        assertThat(output.getToolCallCount()).isZero();
+    }
+
+    @Test
+    void testTaskOutput_isImmutable() {
+        var output = TaskOutput.builder()
+                .raw("output")
+                .taskDescription("task")
+                .agentRole("agent")
+                .completedAt(Instant.now())
+                .duration(Duration.ofSeconds(1))
+                .toolCallCount(0)
+                .build();
+
+        // @Value ensures no setters exist -- verified via compilation
+        assertThat(output).isNotNull();
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/tool/ToolResultTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/tool/ToolResultTest.java
@@ -1,0 +1,42 @@
+package io.agentensemble.tool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToolResultTest {
+
+    @Test
+    void testSuccess_withOutput() {
+        var result = ToolResult.success("search results here");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEqualTo("search results here");
+        assertThat(result.getErrorMessage()).isNull();
+    }
+
+    @Test
+    void testSuccess_withNullOutput_treatedAsEmpty() {
+        var result = ToolResult.success(null);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEmpty();
+    }
+
+    @Test
+    void testSuccess_withEmptyOutput() {
+        var result = ToolResult.success("");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEmpty();
+    }
+
+    @Test
+    void testFailure_withMessage() {
+        var result = ToolResult.failure("Connection refused");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getOutput()).isEmpty();
+        assertThat(result.getErrorMessage()).isEqualTo("Connection refused");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #5

## Changes
- `Task.java`: immutable value object with description, expectedOutput, agent, context
- `TaskBuilder`: validates non-blank description/expectedOutput, non-null agent; immutable context list
- Template variables in descriptions are valid at build time (resolved at ensemble.run() time)
- `TaskOutput.java`: fully implemented (was previously a stub)

## Tests
- `TaskTest`: 14 tests -- validation, defaults, immutability, toBuilder
- `TaskOutputTest`: 3 tests -- all fields, zero toolCallCount, immutability
- `ToolResultTest`: 4 tests -- success/failure factory methods
- Total: 57 tests passing