### PR TITLE
Issue #7: TemplateResolver

### DIFF
--- a/agentensemble-core/src/main/java/io/agentensemble/config/TemplateResolver.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/config/TemplateResolver.java
@@ -1,0 +1,116 @@
+package io.agentensemble.config;
+
+import io.agentensemble.exception.PromptTemplateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves {variable} template placeholders in strings.
+ *
+ * Variables are denoted by {name} where name contains only word characters
+ * (letters, digits, underscores). Escaped variables {{name}} are converted
+ * to literal {name} without substitution.
+ *
+ * Example:
+ * <pre>
+ * String resolved = TemplateResolver.resolve(
+ *     "Research {topic} developments in {year}",
+ *     Map.of("topic", "AI agents", "year", "2026"));
+ * // Result: "Research AI agents developments in 2026"
+ * </pre>
+ */
+public final class TemplateResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(TemplateResolver.class);
+
+    /** Sentinel prefix used to protect escaped {{ }} from being processed as variables. */
+    private static final String SENTINEL_PREFIX = "__AGENTENSEMBLE_ESCAPED_";
+    private static final String SENTINEL_SUFFIX = "__";
+
+    /** Matches {{word}} -- escaped variables. */
+    private static final Pattern ESCAPED_PATTERN = Pattern.compile("\\{\\{(\\w+)}}");
+
+    /** Matches {word} -- template variables. */
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{(\\w+)}");
+
+    /** Maximum length of template shown in error messages. */
+    private static final int ERROR_TEMPLATE_MAX_LENGTH = 100;
+
+    private TemplateResolver() {
+        // Utility class -- not instantiable
+    }
+
+    /**
+     * Resolve template variables in the given string.
+     *
+     * @param template a string with {variable} placeholders; null is returned as-is
+     * @param inputs map of variable names to replacement values; null treated as empty
+     * @return the resolved string
+     * @throws PromptTemplateException if any unescaped variables are not found in inputs
+     */
+    public static String resolve(String template, Map<String, String> inputs) {
+        if (template == null) {
+            return null;
+        }
+        if (template.isEmpty() || template.isBlank()) {
+            return template;
+        }
+
+        Map<String, String> effectiveInputs = inputs != null ? inputs : Map.of();
+
+        log.debug("Resolving template ({} chars) with {} input variables",
+                template.length(), effectiveInputs.size());
+
+        // Step 1: Protect escaped {{ }} by replacing with sentinels
+        String working = ESCAPED_PATTERN.matcher(template)
+                .replaceAll(m -> SENTINEL_PREFIX + m.group(1) + SENTINEL_SUFFIX);
+
+        // Step 2: Find all unescaped {variable} references (preserving order, deduplicating)
+        Matcher matcher = VARIABLE_PATTERN.matcher(working);
+        LinkedHashSet<String> foundVariables = new LinkedHashSet<>();
+        while (matcher.find()) {
+            foundVariables.add(matcher.group(1));
+        }
+
+        // Step 3: Collect missing variables (report ALL, not just the first)
+        List<String> missingVariables = new ArrayList<>();
+        for (String name : foundVariables) {
+            if (!effectiveInputs.containsKey(name)) {
+                missingVariables.add(name);
+            }
+        }
+
+        if (!missingVariables.isEmpty()) {
+            String truncated = template.length() > ERROR_TEMPLATE_MAX_LENGTH
+                    ? template.substring(0, ERROR_TEMPLATE_MAX_LENGTH) + "..."
+                    : template;
+            throw new PromptTemplateException(
+                    "Missing template variables: " + missingVariables
+                    + ". Provide them in ensemble.run(inputs). Template: '" + truncated + "'",
+                    missingVariables,
+                    template);
+        }
+
+        // Step 4: Replace each {variable} with its value
+        for (String name : foundVariables) {
+            String value = effectiveInputs.get(name);
+            working = working.replace("{" + name + "}", value != null ? value : "");
+        }
+
+        // Step 5: Restore escaped sentinels as literal {name}
+        working = Pattern.compile(SENTINEL_PREFIX + "(\\w+)" + SENTINEL_SUFFIX)
+                .matcher(working)
+                .replaceAll(m -> "{" + m.group(1) + "}");
+
+        log.debug("Resolved {} variables in template", foundVariables.size());
+
+        return working;
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/config/TemplateResolverTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/config/TemplateResolverTest.java
@@ -1,0 +1,163 @@
+package io.agentensemble.config;
+
+import io.agentensemble.exception.PromptTemplateException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TemplateResolverTest {
+
+    // ========================
+    // Null / blank pass-through
+    // ========================
+
+    @Test
+    void testResolve_nullTemplate_returnsNull() {
+        assertThat(TemplateResolver.resolve(null, Map.of())).isNull();
+    }
+
+    @Test
+    void testResolve_emptyTemplate_returnsEmpty() {
+        assertThat(TemplateResolver.resolve("", Map.of())).isEmpty();
+    }
+
+    @Test
+    void testResolve_whitespaceOnlyTemplate_returnsUnchanged() {
+        assertThat(TemplateResolver.resolve("   ", Map.of())).isEqualTo("   ");
+    }
+
+    // ========================
+    // No variables
+    // ========================
+
+    @Test
+    void testResolve_noVariables_returnsUnchanged() {
+        assertThat(TemplateResolver.resolve("Hello world", Map.of())).isEqualTo("Hello world");
+    }
+
+    @Test
+    void testResolve_noVariables_extraInputsIgnored() {
+        assertThat(TemplateResolver.resolve("Hello world", Map.of("unused", "value")))
+                .isEqualTo("Hello world");
+    }
+
+    // ========================
+    // Simple substitution
+    // ========================
+
+    @Test
+    void testResolve_simpleVariable() {
+        assertThat(TemplateResolver.resolve("Research {topic}", Map.of("topic", "AI")))
+                .isEqualTo("Research AI");
+    }
+
+    @Test
+    void testResolve_multipleVariables() {
+        assertThat(TemplateResolver.resolve("Research {topic} in {year}",
+                Map.of("topic", "AI", "year", "2026")))
+                .isEqualTo("Research AI in 2026");
+    }
+
+    @Test
+    void testResolve_sameVariableMultipleTimes() {
+        assertThat(TemplateResolver.resolve("{a} and {a}", Map.of("a", "X")))
+                .isEqualTo("X and X");
+    }
+
+    @Test
+    void testResolve_underscoreInName() {
+        assertThat(TemplateResolver.resolve("{under_score}", Map.of("under_score", "ok")))
+                .isEqualTo("ok");
+    }
+
+    @Test
+    void testResolve_emptyValue_replacesWithEmpty() {
+        assertThat(TemplateResolver.resolve("Hello {name}", Map.of("name", "")))
+                .isEqualTo("Hello ");
+    }
+
+    @Test
+    void testResolve_nullValue_treatedAsEmpty() {
+        Map<String, String> inputs = new java.util.HashMap<>();
+        inputs.put("name", null);
+        assertThat(TemplateResolver.resolve("Hello {name}", inputs))
+                .isEqualTo("Hello ");
+    }
+
+    // ========================
+    // Missing variables
+    // ========================
+
+    @Test
+    void testResolve_missingVariable_throwsPromptTemplateException() {
+        assertThatThrownBy(() -> TemplateResolver.resolve("{topic}", Map.of()))
+                .isInstanceOf(PromptTemplateException.class)
+                .hasMessageContaining("topic");
+    }
+
+    @Test
+    void testResolve_multipleMissingVariables_reportsAll() {
+        assertThatThrownBy(() ->
+                TemplateResolver.resolve("{a} and {b}", Map.of()))
+                .isInstanceOf(PromptTemplateException.class)
+                .satisfies(ex -> {
+                    var pte = (PromptTemplateException) ex;
+                    assertThat(pte.getMissingVariables()).containsExactlyInAnyOrder("a", "b");
+                });
+    }
+
+    @Test
+    void testResolve_partialInputs_reportsOnlyMissing() {
+        assertThatThrownBy(() ->
+                TemplateResolver.resolve("{a} and {b}", Map.of("a", "X")))
+                .isInstanceOf(PromptTemplateException.class)
+                .satisfies(ex -> {
+                    var pte = (PromptTemplateException) ex;
+                    assertThat(pte.getMissingVariables()).containsExactly("b");
+                });
+    }
+
+    @Test
+    void testResolve_missingVariable_exceptionContainsTemplate() {
+        String template = "Research {topic} in detail";
+        assertThatThrownBy(() -> TemplateResolver.resolve(template, Map.of()))
+                .isInstanceOf(PromptTemplateException.class)
+                .satisfies(ex -> {
+                    var pte = (PromptTemplateException) ex;
+                    assertThat(pte.getTemplate()).isEqualTo(template);
+                });
+    }
+
+    @Test
+    void testResolve_nullInputs_treatedAsEmpty_throwsOnMissingVariables() {
+        assertThatThrownBy(() -> TemplateResolver.resolve("{topic}", null))
+                .isInstanceOf(PromptTemplateException.class)
+                .hasMessageContaining("topic");
+    }
+
+    // ========================
+    // Escaped variables
+    // ========================
+
+    @Test
+    void testResolve_escapedBraces_returnsLiteral() {
+        assertThat(TemplateResolver.resolve("{{topic}}", Map.of()))
+                .isEqualTo("{topic}");
+    }
+
+    @Test
+    void testResolve_escapedBraces_notSubstitutedEvenIfInputExists() {
+        assertThat(TemplateResolver.resolve("{{topic}}", Map.of("topic", "AI")))
+                .isEqualTo("{topic}");
+    }
+
+    @Test
+    void testResolve_mixedEscapedAndNormal() {
+        assertThat(TemplateResolver.resolve("{{escaped}} and {normal}",
+                Map.of("normal", "substituted")))
+                .isEqualTo("{escaped} and substituted");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #7

- `TemplateResolver.java`: static utility resolving `{variable}` placeholders
- Sentinel-based escape handling for `{{var}}` -> literal `{var}`
- Reports ALL missing variables at once via `PromptTemplateException`
- Null-safe, handles empty templates, null inputs, null values

## Tests: 19 tests, all passing (87 total)