### PR TITLE
Issues #8 and #9: Tool system and AgentPromptBuilder

### DIFF
--- a/agentensemble-core/src/main/java/io/agentensemble/agent/AgentPromptBuilder.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/agent/AgentPromptBuilder.java
@@ -1,0 +1,151 @@
+package io.agentensemble.agent;
+
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+import io.agentensemble.task.TaskOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Constructs system and user prompts for agent-LLM interactions.
+ *
+ * The system prompt establishes the agent's identity (role, background, goal)
+ * and standard instructions. The user prompt presents the task and any
+ * relevant context from prior tasks.
+ */
+public final class AgentPromptBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentPromptBuilder.class);
+
+    /** Log a WARN when a single context output exceeds this character count. */
+    private static final int CONTEXT_LENGTH_WARN_THRESHOLD = 10_000;
+
+    private AgentPromptBuilder() {
+        // Utility class -- not instantiable
+    }
+
+    /**
+     * Build the system prompt for an agent.
+     *
+     * <p>Format:
+     * <pre>
+     * You are {role}.
+     * {background -- only if non-null and non-blank}
+     *
+     * Your personal goal is: {goal}
+     *
+     * You must produce a final answer...
+     * Output format instructions: {responseFormat -- only if non-blank}
+     * </pre>
+     *
+     * @param agent the agent whose prompt to build
+     * @return the system prompt string
+     */
+    public static String buildSystemPrompt(Agent agent) {
+        StringBuilder sb = new StringBuilder();
+
+        // Role line
+        sb.append("You are ").append(agent.getRole()).append(".");
+
+        // Background (optional)
+        String background = agent.getBackground();
+        if (background != null && !background.isBlank()) {
+            sb.append("\n").append(background);
+        }
+
+        // Goal
+        sb.append("\n\n");
+        sb.append("Your personal goal is: ").append(agent.getGoal());
+
+        // Standard instructions
+        sb.append("\n\n");
+        sb.append("You must produce a final answer that satisfies the expected output described in the task.\n");
+        sb.append("Focus on quality and accuracy. ");
+        sb.append("Do not add unnecessary preamble or postscript to your final answer.");
+
+        // Response format (optional)
+        String responseFormat = agent.getResponseFormat();
+        if (responseFormat != null && !responseFormat.isBlank()) {
+            sb.append("\nOutput format instructions: ").append(responseFormat);
+        }
+
+        String prompt = sb.toString();
+        log.debug("Built system prompt ({} chars) for agent '{}'", prompt.length(), agent.getRole());
+        return prompt;
+    }
+
+    /**
+     * Build the user prompt for a task, including context from prior tasks.
+     *
+     * <p>Format (with context):
+     * <pre>
+     * ## Context from Previous Tasks
+     * The following results from previous tasks may be relevant:
+     *
+     * ---
+     * ### {agentRole}: {taskDescription}
+     * {raw}
+     * ---
+     *
+     * ## Task
+     * {description}
+     *
+     * ## Expected Output
+     * {expectedOutput}
+     * </pre>
+     *
+     * @param task the task to build the prompt for
+     * @param contextOutputs outputs from prior tasks to include as context
+     * @return the user prompt string
+     */
+    public static String buildUserPrompt(Task task, List<TaskOutput> contextOutputs) {
+        StringBuilder sb = new StringBuilder();
+
+        // Context section (only if there are context outputs)
+        if (contextOutputs != null && !contextOutputs.isEmpty()) {
+            sb.append("## Context from Previous Tasks\n");
+            sb.append("The following results from previous tasks may be relevant:\n");
+
+            for (TaskOutput ctx : contextOutputs) {
+                warnIfLargeContext(ctx);
+                sb.append("\n---\n");
+                sb.append("### ").append(ctx.getAgentRole())
+                        .append(": ").append(ctx.getTaskDescription()).append("\n");
+                sb.append(ctx.getRaw()).append("\n");
+                sb.append("---");
+            }
+
+            sb.append("\n\n");
+        }
+
+        // Task section
+        sb.append("## Task\n");
+        sb.append(task.getDescription());
+
+        // Expected output section
+        sb.append("\n\n## Expected Output\n");
+        sb.append(task.getExpectedOutput());
+
+        String prompt = sb.toString();
+        log.debug("Built user prompt ({} chars) for task '{}'",
+                prompt.length(), truncate(task.getDescription(), 80));
+        return prompt;
+    }
+
+    private static void warnIfLargeContext(TaskOutput ctx) {
+        if (ctx.getRaw() != null && ctx.getRaw().length() > CONTEXT_LENGTH_WARN_THRESHOLD) {
+            log.warn("Context from task '{}' is {} characters (>{}). "
+                    + "Consider breaking into smaller tasks.",
+                    truncate(ctx.getTaskDescription(), 80),
+                    ctx.getRaw().length(),
+                    CONTEXT_LENGTH_WARN_THRESHOLD);
+        }
+    }
+
+    private static String truncate(String text, int maxLength) {
+        if (text == null) return "";
+        return text.length() > maxLength ? text.substring(0, maxLength) + "..." : text;
+    }
+}

--- a/agentensemble-core/src/main/java/io/agentensemble/tool/LangChain4jToolAdapter.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/tool/LangChain4jToolAdapter.java
@@ -1,0 +1,191 @@
+package io.agentensemble.tool;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agent.tool.ToolSpecifications;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adapts {@link AgentTool} instances to LangChain4j's tool specification model,
+ * and provides execution of AgentTool instances from JSON arguments.
+ *
+ * Also exposes a utility to extract specifications from objects annotated with
+ * {@code @dev.langchain4j.agent.tool.Tool}.
+ */
+public final class LangChain4jToolAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(LangChain4jToolAdapter.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private static final String INPUT_PARAM_NAME = "input";
+    private static final String INPUT_PARAM_DESCRIPTION = "The input to pass to the tool";
+
+    private LangChain4jToolAdapter() {
+        // Utility class -- not instantiable
+    }
+
+    /**
+     * Convert an {@link AgentTool} to a LangChain4j {@link ToolSpecification}.
+     *
+     * The generated specification has a single required string parameter named "input",
+     * which the LLM uses to pass input text to the tool.
+     *
+     * @param tool the AgentTool to adapt
+     * @return a ToolSpecification for use with ChatModel.chat(ChatRequest)
+     */
+    public static ToolSpecification toSpecification(AgentTool tool) {
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addStringProperty(INPUT_PARAM_NAME, INPUT_PARAM_DESCRIPTION)
+                .required(List.of(INPUT_PARAM_NAME))
+                .build();
+
+        var spec = ToolSpecification.builder()
+                .name(tool.name())
+                .description(tool.description())
+                .parameters(parameters)
+                .build();
+
+        log.debug("Adapted AgentTool '{}' to LangChain4j ToolSpecification", tool.name());
+
+        return spec;
+    }
+
+    /**
+     * Execute an {@link AgentTool} with arguments provided as a JSON string.
+     *
+     * The arguments JSON is expected to contain an "input" key with the string value
+     * to pass to {@link AgentTool#execute(String)}. If the JSON is malformed or the
+     * "input" key is absent, the raw arguments string is passed directly to execute().
+     *
+     * @param tool the AgentTool to execute
+     * @param argumentsJson the JSON arguments from the LLM tool call
+     * @return the tool's output, or an "Error: ..." string on failure
+     */
+    public static String execute(AgentTool tool, String argumentsJson) {
+        String input = extractInput(argumentsJson);
+        try {
+            ToolResult result = tool.execute(input);
+            if (result == null) {
+                return "";
+            }
+            if (result.isSuccess()) {
+                return result.getOutput();
+            } else {
+                return "Error: " + result.getErrorMessage();
+            }
+        } catch (Exception e) {
+            log.warn("AgentTool '{}' threw exception during execution: {}", tool.name(), e.getMessage());
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Extract tool specifications from an object with {@code @Tool}-annotated methods.
+     *
+     * @param annotatedObject an object with one or more @Tool-annotated methods
+     * @return list of ToolSpecification extracted via reflection
+     */
+    public static List<ToolSpecification> specificationsFrom(Object annotatedObject) {
+        return ToolSpecifications.toolSpecificationsFrom(annotatedObject);
+    }
+
+    /**
+     * Execute a @Tool-annotated method on an object via reflection.
+     *
+     * @param toolObject the object containing the @Tool-annotated method
+     * @param methodName the name of the method to call
+     * @param argumentsJson the JSON arguments from the LLM tool call
+     * @return the method's return value as a string, or "Error: ..." on failure
+     */
+    public static String executeAnnotatedTool(Object toolObject, String methodName, String argumentsJson) {
+        try {
+            // Parse arguments as a map
+            Map<String, Object> args = parseArgs(argumentsJson);
+
+            // Find the method by name
+            java.lang.reflect.Method method = findMethod(toolObject, methodName);
+            if (method == null) {
+                return "Error: Tool method '" + methodName + "' not found";
+            }
+
+            // Build argument array in parameter order
+            java.lang.reflect.Parameter[] params = method.getParameters();
+            Object[] argValues = new Object[params.length];
+            for (int i = 0; i < params.length; i++) {
+                String paramName = params[i].getName();
+                Object value = args.get(paramName);
+                argValues[i] = convertToType(value, params[i].getType());
+            }
+
+            method.setAccessible(true);
+            Object result = method.invoke(toolObject, argValues);
+            return result != null ? result.toString() : "";
+
+        } catch (Exception e) {
+            log.warn("Annotated tool '{}' threw exception: {}", methodName, e.getMessage());
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    // ========================
+    // Private helpers
+    // ========================
+
+    private static String extractInput(String argumentsJson) {
+        try {
+            Map<String, Object> args = OBJECT_MAPPER.readValue(argumentsJson, MAP_TYPE);
+            Object input = args.get(INPUT_PARAM_NAME);
+            return input != null ? input.toString() : argumentsJson;
+        } catch (Exception e) {
+            // Not valid JSON or no "input" key -- pass the raw string
+            return argumentsJson;
+        }
+    }
+
+    private static Map<String, Object> parseArgs(String argumentsJson) {
+        try {
+            return OBJECT_MAPPER.readValue(argumentsJson, MAP_TYPE);
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    private static java.lang.reflect.Method findMethod(Object obj, String methodName) {
+        for (java.lang.reflect.Method m : obj.getClass().getMethods()) {
+            if (m.getName().equals(methodName)
+                    && m.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class)) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    private static Object convertToType(Object value, Class<?> targetType) {
+        if (value == null) {
+            return null;
+        }
+        if (targetType == String.class) {
+            return value.toString();
+        }
+        if (targetType == int.class || targetType == Integer.class) {
+            return ((Number) value).intValue();
+        }
+        if (targetType == long.class || targetType == Long.class) {
+            return ((Number) value).longValue();
+        }
+        if (targetType == double.class || targetType == Double.class) {
+            return ((Number) value).doubleValue();
+        }
+        if (targetType == boolean.class || targetType == Boolean.class) {
+            return Boolean.valueOf(value.toString());
+        }
+        return value;
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/agent/AgentPromptBuilderTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/agent/AgentPromptBuilderTest.java
@@ -1,0 +1,229 @@
+package io.agentensemble.agent;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+import io.agentensemble.task.TaskOutput;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AgentPromptBuilderTest {
+
+    private Agent minimalAgent(String role, String goal) {
+        return Agent.builder()
+                .role(role)
+                .goal(goal)
+                .llm(mock(ChatModel.class))
+                .build();
+    }
+
+    private TaskOutput taskOutput(String agentRole, String description, String raw) {
+        return TaskOutput.builder()
+                .agentRole(agentRole)
+                .taskDescription(description)
+                .raw(raw)
+                .completedAt(Instant.now())
+                .duration(Duration.ofSeconds(1))
+                .toolCallCount(0)
+                .build();
+    }
+
+    // ========================
+    // System prompt
+    // ========================
+
+    @Test
+    void testBuildSystemPrompt_withAllFields() {
+        var agent = Agent.builder()
+                .role("Senior Research Analyst")
+                .goal("Find cutting-edge developments")
+                .background("You are a veteran researcher with 20 years experience.")
+                .responseFormat("Respond in bullet points.")
+                .llm(mock(ChatModel.class))
+                .build();
+
+        String prompt = AgentPromptBuilder.buildSystemPrompt(agent);
+
+        assertThat(prompt)
+                .startsWith("You are Senior Research Analyst.")
+                .contains("You are a veteran researcher with 20 years experience.")
+                .contains("Your personal goal is: Find cutting-edge developments")
+                .contains("Output format instructions: Respond in bullet points.");
+    }
+
+    @Test
+    void testBuildSystemPrompt_withoutBackground() {
+        var agent = minimalAgent("Writer", "Write articles");
+
+        String prompt = AgentPromptBuilder.buildSystemPrompt(agent);
+
+        assertThat(prompt)
+                .startsWith("You are Writer.")
+                .contains("Your personal goal is: Write articles")
+                .doesNotContain("null");
+    }
+
+    @Test
+    void testBuildSystemPrompt_withEmptyBackground() {
+        var agent = Agent.builder()
+                .role("Writer")
+                .goal("Write articles")
+                .background("")  // empty, should be omitted
+                .llm(mock(ChatModel.class))
+                .build();
+
+        String prompt = AgentPromptBuilder.buildSystemPrompt(agent);
+
+        // No extra blank line from empty background
+        assertThat(prompt)
+                .startsWith("You are Writer.")
+                .doesNotContain("background");
+    }
+
+    @Test
+    void testBuildSystemPrompt_withoutResponseFormat() {
+        var agent = minimalAgent("Analyst", "Analyze data");
+
+        String prompt = AgentPromptBuilder.buildSystemPrompt(agent);
+
+        assertThat(prompt)
+                .doesNotContain("Output format instructions");
+    }
+
+    @Test
+    void testBuildSystemPrompt_minimalAgent_hasRequiredParts() {
+        var agent = minimalAgent("Assistant", "Help users");
+
+        String prompt = AgentPromptBuilder.buildSystemPrompt(agent);
+
+        assertThat(prompt)
+                .contains("You are Assistant.")
+                .contains("Your personal goal is: Help users")
+                .contains("You must produce a final answer");
+    }
+
+    @Test
+    void testBuildSystemPrompt_withBackground_hasBlankLineSeparation() {
+        var agent = Agent.builder()
+                .role("Researcher")
+                .goal("Find info")
+                .background("Expert researcher.")
+                .llm(mock(ChatModel.class))
+                .build();
+
+        String prompt = AgentPromptBuilder.buildSystemPrompt(agent);
+
+        // Background appears after role, before goal
+        int rolePos = prompt.indexOf("You are Researcher.");
+        int bgPos = prompt.indexOf("Expert researcher.");
+        int goalPos = prompt.indexOf("Your personal goal");
+        assertThat(rolePos).isLessThan(bgPos);
+        assertThat(bgPos).isLessThan(goalPos);
+    }
+
+    // ========================
+    // User prompt
+    // ========================
+
+    @Test
+    void testBuildUserPrompt_withoutContext() {
+        var agent = minimalAgent("Researcher", "Find info");
+        var task = Task.builder()
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .agent(agent)
+                .build();
+
+        String prompt = AgentPromptBuilder.buildUserPrompt(task, List.of());
+
+        assertThat(prompt)
+                .contains("## Task")
+                .contains("Research AI trends")
+                .contains("## Expected Output")
+                .contains("A detailed report")
+                .doesNotContain("## Context");
+    }
+
+    @Test
+    void testBuildUserPrompt_withSingleContext() {
+        var agent = minimalAgent("Writer", "Write content");
+        var task = Task.builder()
+                .description("Write a blog post")
+                .expectedOutput("A 1000-word blog post")
+                .agent(agent)
+                .build();
+        var contextOutput = taskOutput("Researcher", "Research AI trends", "AI is growing fast...");
+
+        String prompt = AgentPromptBuilder.buildUserPrompt(task, List.of(contextOutput));
+
+        assertThat(prompt)
+                .contains("## Context from Previous Tasks")
+                .contains("Researcher")
+                .contains("Research AI trends")
+                .contains("AI is growing fast...")
+                .contains("## Task")
+                .contains("Write a blog post")
+                .contains("## Expected Output");
+    }
+
+    @Test
+    void testBuildUserPrompt_withMultipleContexts() {
+        var agent = minimalAgent("Editor", "Edit content");
+        var task = Task.builder()
+                .description("Edit the article")
+                .expectedOutput("Polished article")
+                .agent(agent)
+                .build();
+        var ctx1 = taskOutput("Researcher", "Research task", "Research findings...");
+        var ctx2 = taskOutput("Writer", "Write task", "Draft article...");
+
+        String prompt = AgentPromptBuilder.buildUserPrompt(task, List.of(ctx1, ctx2));
+
+        assertThat(prompt)
+                .contains("Researcher")
+                .contains("Research findings...")
+                .contains("Writer")
+                .contains("Draft article...");
+    }
+
+    @Test
+    void testBuildUserPrompt_contextOrderPreserved() {
+        var agent = minimalAgent("Editor", "Edit content");
+        var task = Task.builder()
+                .description("Edit the article")
+                .expectedOutput("Polished article")
+                .agent(agent)
+                .build();
+        var ctx1 = taskOutput("First", "First task", "First output");
+        var ctx2 = taskOutput("Second", "Second task", "Second output");
+
+        String prompt = AgentPromptBuilder.buildUserPrompt(task, List.of(ctx1, ctx2));
+
+        int firstPos = prompt.indexOf("First output");
+        int secondPos = prompt.indexOf("Second output");
+        assertThat(firstPos).isLessThan(secondPos);
+    }
+
+    @Test
+    void testBuildUserPrompt_contextBeforeTask() {
+        var agent = minimalAgent("Writer", "Write content");
+        var task = Task.builder()
+                .description("Write a blog post")
+                .expectedOutput("A blog post")
+                .agent(agent)
+                .build();
+        var contextOutput = taskOutput("Researcher", "Research", "Findings...");
+
+        String prompt = AgentPromptBuilder.buildUserPrompt(task, List.of(contextOutput));
+
+        int contextPos = prompt.indexOf("## Context");
+        int taskPos = prompt.indexOf("## Task");
+        assertThat(contextPos).isLessThan(taskPos);
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/tool/LangChain4jToolAdapterTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/tool/LangChain4jToolAdapterTest.java
@@ -1,0 +1,127 @@
+package io.agentensemble.tool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LangChain4jToolAdapterTest {
+
+    private AgentTool mockTool(String name, String description) {
+        AgentTool tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn(name);
+        when(tool.description()).thenReturn(description);
+        return tool;
+    }
+
+    // ========================
+    // ToolSpecification creation
+    // ========================
+
+    @Test
+    void testToSpecification_hasCorrectName() {
+        var tool = mockTool("web_search", "Search the web");
+        var spec = LangChain4jToolAdapter.toSpecification(tool);
+
+        assertThat(spec.name()).isEqualTo("web_search");
+    }
+
+    @Test
+    void testToSpecification_hasCorrectDescription() {
+        var tool = mockTool("calculator", "Performs arithmetic");
+        var spec = LangChain4jToolAdapter.toSpecification(tool);
+
+        assertThat(spec.description()).isEqualTo("Performs arithmetic");
+    }
+
+    @Test
+    void testToSpecification_hasSingleInputParameter() {
+        var tool = mockTool("web_search", "Search the web");
+        var spec = LangChain4jToolAdapter.toSpecification(tool);
+
+        assertThat(spec.parameters()).isNotNull();
+        assertThat(spec.parameters().properties()).containsKey("input");
+        assertThat(spec.parameters().required()).contains("input");
+    }
+
+    // ========================
+    // Tool execution
+    // ========================
+
+    @Test
+    void testExecute_callsAgentToolWithInputValue() {
+        var tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn("search");
+        when(tool.description()).thenReturn("Search");
+        when(tool.execute("AI trends")).thenReturn(ToolResult.success("Search results"));
+
+        String result = LangChain4jToolAdapter.execute(tool, "{\"input\": \"AI trends\"}");
+
+        verify(tool).execute("AI trends");
+        assertThat(result).isEqualTo("Search results");
+    }
+
+    @Test
+    void testExecute_withSuccessResult_returnsOutput() {
+        var tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn("calc");
+        when(tool.description()).thenReturn("Calculate");
+        when(tool.execute(anyString())).thenReturn(ToolResult.success("42"));
+
+        String result = LangChain4jToolAdapter.execute(tool, "{\"input\": \"6 * 7\"}");
+
+        assertThat(result).isEqualTo("42");
+    }
+
+    @Test
+    void testExecute_withFailureResult_returnsErrorString() {
+        var tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn("search");
+        when(tool.description()).thenReturn("Search");
+        when(tool.execute(anyString())).thenReturn(ToolResult.failure("Network timeout"));
+
+        String result = LangChain4jToolAdapter.execute(tool, "{\"input\": \"query\"}");
+
+        assertThat(result).startsWith("Error:").contains("Network timeout");
+    }
+
+    @Test
+    void testExecute_whenToolThrows_returnsErrorString() {
+        var tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn("search");
+        when(tool.description()).thenReturn("Search");
+        when(tool.execute(anyString())).thenThrow(new RuntimeException("Service unavailable"));
+
+        String result = LangChain4jToolAdapter.execute(tool, "{\"input\": \"query\"}");
+
+        assertThat(result).startsWith("Error:").contains("Service unavailable");
+    }
+
+    @Test
+    void testExecute_whenToolReturnsNull_returnsEmpty() {
+        var tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn("search");
+        when(tool.description()).thenReturn("Search");
+        when(tool.execute(anyString())).thenReturn(null);
+
+        String result = LangChain4jToolAdapter.execute(tool, "{\"input\": \"query\"}");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testExecute_withMalformedJson_passesRawString() {
+        var tool = mock(AgentTool.class);
+        when(tool.name()).thenReturn("search");
+        when(tool.description()).thenReturn("Search");
+        when(tool.execute("not valid json")).thenReturn(ToolResult.success("ok"));
+
+        String result = LangChain4jToolAdapter.execute(tool, "not valid json");
+
+        verify(tool).execute("not valid json");
+        assertThat(result).isEqualTo("ok");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #8, Closes #9

## Issue #8: LangChain4jToolAdapter
- `toSpecification(AgentTool)`: builds ToolSpecification with single 'input' string param using LC4j 1.11.0 JsonObjectSchema API
- `execute(AgentTool, json)`: parses JSON args, extracts 'input', calls AgentTool; handles failures, exceptions, null
- `specificationsFrom(Object)`: delegates to LC4j's ToolSpecifications for @Tool-annotated objects
- `executeAnnotatedTool(Object, method, json)`: reflection-based execution for @Tool methods

## Issue #9: AgentPromptBuilder
- System prompt: role, optional background, goal, standard instructions, optional responseFormat
- User prompt: optional context section (rendered before task), task description, expected output

## Tests: 19 new tests (108 total)