### PR TITLE
feat: hierarchical workflow -- manager agent delegates to workers (Issue #15)

### DIFF
--- a/agentensemble-core/src/main/java/io/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/Ensemble.java
@@ -1,11 +1,13 @@
 package io.agentensemble;
 
+import dev.langchain4j.model.chat.ChatModel;
 import io.agentensemble.config.TemplateResolver;
 import io.agentensemble.ensemble.EnsembleOutput;
 import io.agentensemble.exception.ValidationException;
+import io.agentensemble.workflow.HierarchicalWorkflowExecutor;
+import io.agentensemble.workflow.SequentialWorkflowExecutor;
 import io.agentensemble.workflow.Workflow;
 import io.agentensemble.workflow.WorkflowExecutor;
-import io.agentensemble.workflow.SequentialWorkflowExecutor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
@@ -56,6 +58,19 @@ public class Ensemble {
     /** How tasks are executed. Default: SEQUENTIAL. */
     @Builder.Default
     private final Workflow workflow = Workflow.SEQUENTIAL;
+
+    /**
+     * Optional LLM for the Manager agent in hierarchical workflow.
+     * If not set, defaults to the first registered agent's LLM.
+     */
+    private final ChatModel managerLlm;
+
+    /**
+     * Maximum number of tool call iterations for the Manager agent in hierarchical workflow.
+     * Default: 20. Must be greater than zero.
+     */
+    @Builder.Default
+    private final int managerMaxIterations = 20;
 
     /** When true, elevates execution logging to INFO level. */
     @Builder.Default
@@ -125,9 +140,13 @@ public class Ensemble {
     private WorkflowExecutor selectExecutor() {
         return switch (workflow) {
             case SEQUENTIAL -> new SequentialWorkflowExecutor();
-            case HIERARCHICAL -> throw new UnsupportedOperationException(
-                    "Hierarchical workflow is not yet implemented. It is planned for Phase 2.");
+            case HIERARCHICAL -> new HierarchicalWorkflowExecutor(
+                    resolveManagerLlm(), agents, managerMaxIterations);
         };
+    }
+
+    private ChatModel resolveManagerLlm() {
+        return managerLlm != null ? managerLlm : agents.get(0).getLlm();
     }
 
     // ========================
@@ -212,6 +231,12 @@ public class Ensemble {
     }
 
     private void validateContextOrdering() {
+        // Hierarchical workflow: the Manager agent decides execution order at runtime.
+        // Context ordering is not validated -- the manager handles task sequencing.
+        if (workflow == Workflow.HIERARCHICAL) {
+            return;
+        }
+
         // For sequential workflow: each context task must appear earlier in the tasks list
         List<Task> executedSoFar = new ArrayList<>();
         for (Task task : tasks) {

--- a/agentensemble-core/src/main/java/io/agentensemble/workflow/DelegateTaskTool.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/workflow/DelegateTaskTool.java
@@ -1,0 +1,114 @@
+package io.agentensemble.workflow;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+import io.agentensemble.agent.AgentExecutor;
+import io.agentensemble.task.TaskOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A tool that allows the Manager agent to delegate tasks to worker agents.
+ *
+ * When invoked, the tool locates the target agent by role, creates an ephemeral
+ * Task, executes it via AgentExecutor, and returns the worker's output. All
+ * delegated task outputs are accumulated and accessible after execution for
+ * inclusion in the EnsembleOutput.
+ *
+ * This class is stateful -- a new instance must be created for each ensemble run.
+ */
+public class DelegateTaskTool {
+
+    private static final Logger log = LoggerFactory.getLogger(DelegateTaskTool.class);
+
+    /** Default expected output text for delegated tasks. */
+    private static final String DEFAULT_EXPECTED_OUTPUT = "Complete the assigned task thoroughly";
+
+    private final List<Agent> agents;
+    private final AgentExecutor agentExecutor;
+    private final boolean verbose;
+    private final List<TaskOutput> delegatedOutputs = new ArrayList<>();
+
+    /**
+     * @param agents       the worker agents available for delegation
+     * @param agentExecutor the executor to use when running delegated tasks
+     * @param verbose      whether to enable verbose logging for delegated tasks
+     */
+    public DelegateTaskTool(List<Agent> agents, AgentExecutor agentExecutor, boolean verbose) {
+        this.agents = List.copyOf(agents);
+        this.agentExecutor = agentExecutor;
+        this.verbose = verbose;
+    }
+
+    /**
+     * Delegate a task to a specific worker agent.
+     *
+     * The tool locates the agent by role name (case-insensitive), creates a task
+     * with the provided description, executes it, and returns the output. If no
+     * agent is found for the given role, an error message listing available roles
+     * is returned instead.
+     *
+     * @param agentRole       the exact role of the worker agent to delegate to
+     * @param taskDescription a clear description of the task for the agent to complete
+     * @return the worker agent's output, or an error message if the role is not found
+     */
+    @Tool("Delegate a task to a worker agent. Provide the agent's role and a clear task description. "
+            + "Use this tool for each task that needs to be completed by a team member.")
+    public String delegateTask(
+            @P("The exact role of the worker agent to delegate to. "
+                    + "Must match one of the available agent roles.") String agentRole,
+            @P("A clear description of the task for the agent to complete.") String taskDescription) {
+
+        Agent agent = findAgentByRole(agentRole);
+        if (agent == null) {
+            List<String> availableRoles = agents.stream().map(Agent::getRole).toList();
+            String error = "No agent found with role '" + agentRole
+                    + "'. Available roles: " + availableRoles;
+            log.warn("Delegation failed: {}", error);
+            return error;
+        }
+
+        log.info("Delegating task to agent '{}': {}", agent.getRole(),
+                taskDescription.length() > 80 ? taskDescription.substring(0, 80) + "..." : taskDescription);
+
+        Task delegatedTask = Task.builder()
+                .description(taskDescription)
+                .expectedOutput(DEFAULT_EXPECTED_OUTPUT)
+                .agent(agent)
+                .build();
+
+        TaskOutput output = agentExecutor.execute(delegatedTask, List.of(), verbose);
+        delegatedOutputs.add(output);
+
+        log.info("Delegation to '{}' completed | Tool calls: {} | Duration: {}",
+                agent.getRole(), output.getToolCallCount(), output.getDuration());
+
+        return output.getRaw();
+    }
+
+    /**
+     * Returns an immutable snapshot of all task outputs produced by delegated tasks,
+     * in delegation order.
+     *
+     * @return immutable list of delegated TaskOutput instances
+     */
+    public List<TaskOutput> getDelegatedOutputs() {
+        return List.copyOf(delegatedOutputs);
+    }
+
+    private Agent findAgentByRole(String role) {
+        if (role == null) {
+            return null;
+        }
+        String normalizedRole = role.trim();
+        return agents.stream()
+                .filter(a -> a.getRole().equalsIgnoreCase(normalizedRole))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/agentensemble-core/src/main/java/io/agentensemble/workflow/HierarchicalWorkflowExecutor.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/workflow/HierarchicalWorkflowExecutor.java
@@ -1,0 +1,123 @@
+package io.agentensemble.workflow;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+import io.agentensemble.agent.AgentExecutor;
+import io.agentensemble.ensemble.EnsembleOutput;
+import io.agentensemble.task.TaskOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Executes tasks via a Manager agent that delegates to worker agents.
+ *
+ * The Manager is a virtual agent created at runtime with:
+ * <ul>
+ *   <li>A system prompt listing all available worker agents (via ManagerPromptBuilder)</li>
+ *   <li>A user prompt listing all tasks to complete (via ManagerPromptBuilder)</li>
+ *   <li>The delegateTask tool that dispatches tasks to workers</li>
+ * </ul>
+ *
+ * The Manager uses the delegateTask tool to assign tasks, receives each worker's
+ * output as the tool result, and synthesizes a final response. All worker outputs
+ * and the manager's final output are included in the EnsembleOutput.
+ *
+ * Stateless -- all mutable state is held in per-execution local variables.
+ */
+public class HierarchicalWorkflowExecutor implements WorkflowExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(HierarchicalWorkflowExecutor.class);
+
+    /** MDC key for the current agent role. */
+    private static final String MDC_AGENT_ROLE = "agent.role";
+
+    /** The role assigned to the automatically created manager agent. */
+    static final String MANAGER_ROLE = "Manager";
+
+    /** The goal assigned to the automatically created manager agent. */
+    private static final String MANAGER_GOAL =
+            "Coordinate worker agents to complete all tasks and synthesize a comprehensive final result";
+
+    /** The expected output for the manager's meta-task. */
+    private static final String MANAGER_EXPECTED_OUTPUT =
+            "A comprehensive final response synthesizing the outputs of all delegated tasks";
+
+    private final ChatModel managerLlm;
+    private final List<Agent> workerAgents;
+    private final int managerMaxIterations;
+    private final AgentExecutor agentExecutor;
+
+    /**
+     * @param managerLlm           LLM for the manager agent
+     * @param workerAgents         the worker agents available for delegation
+     * @param managerMaxIterations maximum number of tool call iterations for the manager
+     */
+    public HierarchicalWorkflowExecutor(ChatModel managerLlm, List<Agent> workerAgents,
+            int managerMaxIterations) {
+        this.managerLlm = managerLlm;
+        this.workerAgents = List.copyOf(workerAgents);
+        this.managerMaxIterations = managerMaxIterations;
+        this.agentExecutor = new AgentExecutor();
+    }
+
+    @Override
+    public EnsembleOutput execute(List<Task> resolvedTasks, boolean verbose) {
+        Instant startTime = Instant.now();
+        MDC.put(MDC_AGENT_ROLE, MANAGER_ROLE);
+
+        try {
+            log.info("Hierarchical workflow starting | Tasks: {} | Worker agents: {}",
+                    resolvedTasks.size(), workerAgents.size());
+
+            // 1. Create the stateful DelegateTaskTool (accumulates worker outputs)
+            DelegateTaskTool delegateTool = new DelegateTaskTool(workerAgents, agentExecutor, verbose);
+
+            // 2. Build the virtual Manager agent
+            Agent manager = Agent.builder()
+                    .role(MANAGER_ROLE)
+                    .goal(MANAGER_GOAL)
+                    .background(ManagerPromptBuilder.buildBackground(workerAgents))
+                    .llm(managerLlm)
+                    .maxIterations(managerMaxIterations)
+                    .tools(List.of(delegateTool))
+                    .build();
+
+            // 3. Build the meta-task that drives the manager
+            Task managerTask = Task.builder()
+                    .description(ManagerPromptBuilder.buildTaskDescription(resolvedTasks))
+                    .expectedOutput(MANAGER_EXPECTED_OUTPUT)
+                    .agent(manager)
+                    .build();
+
+            // 4. Execute the manager (ReAct loop: it calls delegateTask for each worker task)
+            log.info("Manager agent starting | Max iterations: {}", managerMaxIterations);
+            TaskOutput managerOutput = agentExecutor.execute(managerTask, List.of(), verbose);
+            log.info("Manager agent completed | Delegations: {} | Duration: {}",
+                    delegateTool.getDelegatedOutputs().size(), managerOutput.getDuration());
+
+            // 5. Assemble output: worker outputs first, manager final output last
+            List<TaskOutput> allOutputs = new ArrayList<>(delegateTool.getDelegatedOutputs());
+            allOutputs.add(managerOutput);
+
+            Duration totalDuration = Duration.between(startTime, Instant.now());
+            int totalToolCalls = allOutputs.stream().mapToInt(TaskOutput::getToolCallCount).sum();
+
+            return EnsembleOutput.builder()
+                    .raw(managerOutput.getRaw())
+                    .taskOutputs(List.copyOf(allOutputs))
+                    .totalDuration(totalDuration)
+                    .totalToolCalls(totalToolCalls)
+                    .build();
+
+        } finally {
+            MDC.remove(MDC_AGENT_ROLE);
+        }
+    }
+}

--- a/agentensemble-core/src/main/java/io/agentensemble/workflow/ManagerPromptBuilder.java
+++ b/agentensemble-core/src/main/java/io/agentensemble/workflow/ManagerPromptBuilder.java
@@ -1,0 +1,84 @@
+package io.agentensemble.workflow;
+
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+
+import java.util.List;
+
+/**
+ * Builds the meta-prompts used by the Manager agent in a hierarchical workflow.
+ *
+ * The manager agent receives a structured description of available worker agents
+ * (as its background, included in the system prompt) and the tasks to complete
+ * (as its task description, presented in the user prompt).
+ */
+public final class ManagerPromptBuilder {
+
+    private ManagerPromptBuilder() {
+        // Utility class -- not instantiable
+    }
+
+    /**
+     * Build the background text listing all available worker agents.
+     *
+     * This becomes the manager agent's background field, which is included
+     * in the system prompt by AgentPromptBuilder. The background describes each
+     * worker agent's role, goal, and optional background, followed by instructions
+     * to use the delegateTask tool.
+     *
+     * @param workers the worker agents available for delegation
+     * @return formatted string listing agents with roles, goals, and backgrounds
+     */
+    public static String buildBackground(List<Agent> workers) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("You have access to the following worker agents:\n\n");
+
+        for (int i = 0; i < workers.size(); i++) {
+            Agent agent = workers.get(i);
+            sb.append(i + 1).append(". ").append(agent.getRole()).append("\n");
+            sb.append("   Goal: ").append(agent.getGoal()).append("\n");
+            if (agent.getBackground() != null && !agent.getBackground().isBlank()) {
+                sb.append("   Background: ").append(agent.getBackground()).append("\n");
+            }
+            if (i < workers.size() - 1) {
+                sb.append("\n");
+            }
+        }
+
+        sb.append("\n");
+        sb.append("Use the delegateTask tool to assign work to your team members. ");
+        sb.append("Review their outputs and synthesize a comprehensive final result.");
+
+        return sb.toString();
+    }
+
+    /**
+     * Build the task description text listing all tasks to complete.
+     *
+     * This becomes the manager's task description, presented as the user prompt.
+     * It lists each task with its description and expected output, and instructs
+     * the manager to delegate and synthesize.
+     *
+     * @param tasks the tasks to be delegated and completed
+     * @return formatted string listing tasks with descriptions and expected outputs
+     */
+    public static String buildTaskDescription(List<Task> tasks) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("You must coordinate your team to complete the following tasks:\n\n");
+
+        for (int i = 0; i < tasks.size(); i++) {
+            Task task = tasks.get(i);
+            sb.append("Task ").append(i + 1).append(": ").append(task.getDescription()).append("\n");
+            sb.append("Expected output: ").append(task.getExpectedOutput()).append("\n");
+            if (i < tasks.size() - 1) {
+                sb.append("\n");
+            }
+        }
+
+        sb.append("\n");
+        sb.append("Delegate each task to the most appropriate team member using the delegateTask tool. ");
+        sb.append("Once all tasks are complete, synthesize the results into a comprehensive final response.");
+
+        return sb.toString();
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/integration/HierarchicalEnsembleIntegrationTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/integration/HierarchicalEnsembleIntegrationTest.java
@@ -1,0 +1,292 @@
+package io.agentensemble.integration;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.agentensemble.Agent;
+import io.agentensemble.Ensemble;
+import io.agentensemble.Task;
+import io.agentensemble.ensemble.EnsembleOutput;
+import io.agentensemble.exception.ValidationException;
+import io.agentensemble.workflow.Workflow;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end integration tests for hierarchical ensemble execution.
+ * Uses mocked LLMs to avoid real network calls.
+ */
+class HierarchicalEnsembleIntegrationTest {
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(text))
+                .build();
+    }
+
+    private ChatResponse delegateCallResponse(String agentRole, String taskDescription) {
+        ToolExecutionRequest req = ToolExecutionRequest.builder()
+                .id("d-1")
+                .name("delegateTask")
+                .arguments("{\"agentRole\": \"" + agentRole + "\", "
+                        + "\"taskDescription\": \"" + taskDescription + "\"}")
+                .build();
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(req))
+                .build();
+    }
+
+    // ========================
+    // Basic hierarchical flow
+    // ========================
+
+    @Test
+    void testHierarchicalWorkflow_singleTask_managerSynthesizes() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+
+        when(workerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Research complete"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI trends"))
+                .thenReturn(textResponse("Final synthesis based on research"));
+
+        Agent researcher = Agent.builder().role("Researcher").goal("Research topics")
+                .llm(workerModel).build();
+        Task task = Task.builder().description("Research AI trends")
+                .expectedOutput("AI trend summary").agent(researcher).build();
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Final synthesis based on research");
+        assertThat(output.getTaskOutputs()).hasSize(2); // worker + manager
+    }
+
+    @Test
+    void testHierarchicalWorkflow_multipleTasks_allDelegated() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+
+        when(workerModel.chat(any(ChatRequest.class)))
+                .thenReturn(textResponse("Research done"))
+                .thenReturn(textResponse("Writing done"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI trends"))
+                .thenReturn(delegateCallResponse("Writer", "Write about AI trends"))
+                .thenReturn(textResponse("Comprehensive final answer"));
+
+        Agent researcher = Agent.builder().role("Researcher").goal("Research").llm(workerModel).build();
+        Agent writer = Agent.builder().role("Writer").goal("Write").llm(workerModel).build();
+        Task researchTask = Task.builder().description("Research AI trends")
+                .expectedOutput("Research findings").agent(researcher).build();
+        Task writeTask = Task.builder().description("Write about AI trends")
+                .expectedOutput("Blog post").agent(writer).build();
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .agent(writer)
+                .task(researchTask)
+                .task(writeTask)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Comprehensive final answer");
+        assertThat(output.getTaskOutputs()).hasSize(3); // 2 workers + manager
+    }
+
+    // ========================
+    // managerLlm defaults
+    // ========================
+
+    @Test
+    void testHierarchicalWorkflow_noManagerLlm_usesFirstAgentLlm() {
+        ChatModel sharedModel = mock(ChatModel.class);
+
+        // First call is for a worker delegation, second is the manager's final answer.
+        // With no managerLlm, the first agent's LLM (sharedModel) is used for both.
+        when(sharedModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI"))
+                .thenReturn(textResponse("Worker output"))   // worker (same model)
+                .thenReturn(textResponse("Final answer"));   // manager final
+
+        // Simulate: manager (sharedModel) calls delegate, worker (sharedModel) responds,
+        // manager (sharedModel) synthesizes. The model responds differently based on call order.
+        Agent researcher = Agent.builder().role("Researcher").goal("Research")
+                .llm(sharedModel).build();
+        Task task = Task.builder().description("Research something")
+                .expectedOutput("Result").agent(researcher).build();
+
+        // No managerLlm set -- should default to first agent's LLM
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .build()
+                .run();
+
+        // Verify it completed without error (LLM was auto-resolved)
+        assertThat(output).isNotNull();
+        assertThat(output.getRaw()).isNotNull();
+    }
+
+    @Test
+    void testHierarchicalWorkflow_withExplicitManagerLlm_usesManagerLlm() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+
+        when(workerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Worker result"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Worker", "Do the work"))
+                .thenReturn(textResponse("Manager synthesized"));
+
+        Agent worker = Agent.builder().role("Worker").goal("Do work").llm(workerModel).build();
+        Task task = Task.builder().description("Do the work")
+                .expectedOutput("Work done").agent(worker).build();
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(worker)
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Manager synthesized");
+    }
+
+    // ========================
+    // managerMaxIterations
+    // ========================
+
+    @Test
+    void testHierarchicalWorkflow_customManagerMaxIterations_isRespected() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Done"));
+
+        Agent worker = Agent.builder().role("Worker").goal("Work").llm(workerModel).build();
+        Task task = Task.builder().description("Task").expectedOutput("Result").agent(worker).build();
+
+        // Should build and run without error with custom maxIterations
+        EnsembleOutput output = Ensemble.builder()
+                .agent(worker)
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .managerMaxIterations(5)
+                .build()
+                .run();
+
+        assertThat(output).isNotNull();
+    }
+
+    // ========================
+    // Validation: context ordering not enforced
+    // ========================
+
+    @Test
+    void testHierarchicalWorkflow_contextOrderingNotRequired() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Answer"));
+
+        Agent worker = Agent.builder().role("Worker").goal("Work").llm(workerModel).build();
+        Task task1 = Task.builder().description("Task one").expectedOutput("Output one")
+                .agent(worker).build();
+        // task2 depends on task1 as context but comes BEFORE task1 in the list.
+        // Sequential validation would reject this; hierarchical should allow it.
+        Task task2 = Task.builder().description("Task two").expectedOutput("Output two")
+                .agent(worker).context(List.of(task1)).build();
+
+        assertThatCode(() ->
+                Ensemble.builder()
+                        .agent(worker)
+                        .task(task2)  // task2 first, but it depends on task1 (listed after)
+                        .task(task1)
+                        .workflow(Workflow.HIERARCHICAL)
+                        .managerLlm(managerModel)
+                        .build()
+                        .run()
+        ).doesNotThrowAnyException();
+    }
+
+    // ========================
+    // Validation still enforced
+    // ========================
+
+    @Test
+    void testHierarchicalWorkflow_emptyTasks_throwsValidation() {
+        ChatModel managerModel = mock(ChatModel.class);
+        Agent agent = Agent.builder().role("Worker").goal("Work").llm(managerModel).build();
+
+        assertThatThrownBy(() -> Ensemble.builder()
+                .agent(agent)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("task");
+    }
+
+    @Test
+    void testHierarchicalWorkflow_emptyAgents_throwsValidation() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+        Agent agent = Agent.builder().role("Worker").goal("Work").llm(workerModel).build();
+        Task task = Task.builder().description("Task").expectedOutput("Result").agent(agent).build();
+
+        assertThatThrownBy(() -> Ensemble.builder()
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run())
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("agent");
+    }
+
+    // ========================
+    // EnsembleOutput structure
+    // ========================
+
+    @Test
+    void testHierarchicalWorkflow_outputTaskOutputsIsImmutable() {
+        ChatModel managerModel = mock(ChatModel.class);
+        ChatModel workerModel = mock(ChatModel.class);
+
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Answer"));
+
+        Agent worker = Agent.builder().role("Worker").goal("Work").llm(workerModel).build();
+        Task task = Task.builder().description("Task").expectedOutput("Result").agent(worker).build();
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(worker)
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run();
+
+        assertThat(output.getTaskOutputs()).isUnmodifiable();
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/integration/SequentialEnsembleIntegrationTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/integration/SequentialEnsembleIntegrationTest.java
@@ -9,7 +9,6 @@ import io.agentensemble.Ensemble;
 import io.agentensemble.Task;
 import io.agentensemble.exception.TaskExecutionException;
 import io.agentensemble.exception.ValidationException;
-import io.agentensemble.workflow.Workflow;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -230,20 +229,4 @@ class SequentialEnsembleIntegrationTest {
         assertThat(output.getRaw()).isEqualTo("Research result");
     }
 
-    // ========================
-    // Workflow
-    // ========================
-
-    @Test
-    void testHierarchicalWorkflow_throwsUnsupported() {
-        var agent = agentWithResponse("Agent", "result");
-        var task = Task.builder().description("Task").expectedOutput("Out").agent(agent).build();
-
-        assertThatThrownBy(() -> Ensemble.builder()
-                .agent(agent).task(task)
-                .workflow(Workflow.HIERARCHICAL)
-                .build()
-                .run())
-                .isInstanceOf(UnsupportedOperationException.class);
-    }
 }

--- a/agentensemble-core/src/test/java/io/agentensemble/workflow/DelegateTaskToolTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/workflow/DelegateTaskToolTest.java
@@ -1,0 +1,195 @@
+package io.agentensemble.workflow;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.agentensemble.Agent;
+import io.agentensemble.agent.AgentExecutor;
+import io.agentensemble.task.TaskOutput;
+import io.agentensemble.tool.LangChain4jToolAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DelegateTaskToolTest {
+
+    private ChatModel researcherModel;
+    private ChatModel writerModel;
+    private Agent researcher;
+    private Agent writer;
+    private DelegateTaskTool tool;
+
+    @BeforeEach
+    void setUp() {
+        researcherModel = mock(ChatModel.class);
+        writerModel = mock(ChatModel.class);
+        researcher = Agent.builder().role("Researcher").goal("Research topics")
+                .llm(researcherModel).build();
+        writer = Agent.builder().role("Writer").goal("Write content")
+                .llm(writerModel).build();
+        tool = new DelegateTaskTool(List.of(researcher, writer), new AgentExecutor(), false);
+    }
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(text))
+                .build();
+    }
+
+    // ========================
+    // delegateTask direct method tests
+    // ========================
+
+    @Test
+    void testDelegateTask_withValidRole_returnsWorkerOutput() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("AI trends found"));
+
+        String result = tool.delegateTask("Researcher", "Research AI trends");
+
+        assertThat(result).isEqualTo("AI trends found");
+    }
+
+    @Test
+    void testDelegateTask_routesToCorrectAgent() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("research result"));
+        when(writerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("written content"));
+
+        String researchResult = tool.delegateTask("Researcher", "Research something");
+        String writeResult = tool.delegateTask("Writer", "Write something");
+
+        assertThat(researchResult).isEqualTo("research result");
+        assertThat(writeResult).isEqualTo("written content");
+    }
+
+    @Test
+    void testDelegateTask_roleMatchIsCaseInsensitive() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("result"));
+
+        String result = tool.delegateTask("researcher", "Research something");
+
+        assertThat(result).isEqualTo("result");
+    }
+
+    @Test
+    void testDelegateTask_roleMatchTrimsWhitespace() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("result"));
+
+        String result = tool.delegateTask("  Researcher  ", "Research something");
+
+        assertThat(result).isEqualTo("result");
+    }
+
+    @Test
+    void testDelegateTask_withUnknownRole_returnsErrorMessage() {
+        String result = tool.delegateTask("Unknown Agent", "some task");
+
+        assertThat(result).contains("No agent found with role 'Unknown Agent'");
+    }
+
+    @Test
+    void testDelegateTask_withUnknownRole_listsAvailableRoles() {
+        String result = tool.delegateTask("Nonexistent", "some task");
+
+        assertThat(result).contains("Researcher");
+        assertThat(result).contains("Writer");
+    }
+
+    // ========================
+    // getDelegatedOutputs tests
+    // ========================
+
+    @Test
+    void testGetDelegatedOutputs_beforeAnyDelegation_isEmpty() {
+        assertThat(tool.getDelegatedOutputs()).isEmpty();
+    }
+
+    @Test
+    void testGetDelegatedOutputs_afterOneDelegation_containsOneOutput() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("output text"));
+
+        tool.delegateTask("Researcher", "some task");
+
+        assertThat(tool.getDelegatedOutputs()).hasSize(1);
+        assertThat(tool.getDelegatedOutputs().get(0).getRaw()).isEqualTo("output text");
+    }
+
+    @Test
+    void testGetDelegatedOutputs_afterMultipleDelegations_returnsAll() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("research"));
+        when(writerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("writing"));
+
+        tool.delegateTask("Researcher", "research task");
+        tool.delegateTask("Writer", "writing task");
+
+        assertThat(tool.getDelegatedOutputs()).hasSize(2);
+    }
+
+    @Test
+    void testGetDelegatedOutputs_isImmutable() {
+        assertThatThrownBy(() -> tool.getDelegatedOutputs().add(null))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testGetDelegatedOutputs_withUnknownRole_doesNotAddOutput() {
+        tool.delegateTask("Nobody", "some task");
+
+        assertThat(tool.getDelegatedOutputs()).isEmpty();
+    }
+
+    @Test
+    void testGetDelegatedOutputs_outputHasCorrectAgentRole() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("result"));
+
+        tool.delegateTask("Researcher", "some task");
+
+        TaskOutput output = tool.getDelegatedOutputs().get(0);
+        assertThat(output.getAgentRole()).isEqualTo("Researcher");
+    }
+
+    @Test
+    void testGetDelegatedOutputs_outputHasCorrectTaskDescription() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("result"));
+
+        tool.delegateTask("Researcher", "Research AI trends carefully");
+
+        TaskOutput output = tool.getDelegatedOutputs().get(0);
+        assertThat(output.getTaskDescription()).isEqualTo("Research AI trends carefully");
+    }
+
+    // ========================
+    // @Tool annotation integration test
+    // ========================
+
+    @Test
+    void testDelegateTask_canBeInvokedViaToolAdapter() {
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("adapter result"));
+
+        // Verify it works via the JSON-based tool adapter (as called by AgentExecutor)
+        String result = LangChain4jToolAdapter.executeAnnotatedTool(
+                tool, "delegateTask",
+                "{\"agentRole\": \"Researcher\", \"taskDescription\": \"Research AI trends\"}");
+
+        assertThat(result).isEqualTo("adapter result");
+    }
+
+    @Test
+    void testDelegateTask_toolAnnotationIsPresent() throws NoSuchMethodException {
+        var method = DelegateTaskTool.class.getMethod("delegateTask", String.class, String.class);
+        assertThat(method.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class)).isTrue();
+    }
+
+    @Test
+    void testDelegateTask_hasCorrectNumberOfParameters() throws NoSuchMethodException {
+        var method = DelegateTaskTool.class.getMethod("delegateTask", String.class, String.class);
+        assertThat(method.getParameterCount()).isEqualTo(2);
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/workflow/HierarchicalWorkflowExecutorTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/workflow/HierarchicalWorkflowExecutorTest.java
@@ -1,0 +1,196 @@
+package io.agentensemble.workflow;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+import io.agentensemble.ensemble.EnsembleOutput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HierarchicalWorkflowExecutorTest {
+
+    private ChatModel managerModel;
+    private ChatModel workerModel;
+    private Agent worker;
+    private HierarchicalWorkflowExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        managerModel = mock(ChatModel.class);
+        workerModel = mock(ChatModel.class);
+        worker = Agent.builder().role("Researcher").goal("Research topics")
+                .llm(workerModel).build();
+        executor = new HierarchicalWorkflowExecutor(managerModel, List.of(worker), 20);
+    }
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(text))
+                .build();
+    }
+
+    private ChatResponse delegateCallResponse(String agentRole, String taskDescription) {
+        ToolExecutionRequest req = ToolExecutionRequest.builder()
+                .id("delegate-1")
+                .name("delegateTask")
+                .arguments("{\"agentRole\": \"" + agentRole + "\", "
+                        + "\"taskDescription\": \"" + taskDescription + "\"}")
+                .build();
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(req))
+                .build();
+    }
+
+    private Task researchTask() {
+        return Task.builder()
+                .description("Research AI trends")
+                .expectedOutput("Summary of AI trends")
+                .agent(worker)
+                .build();
+    }
+
+    // ========================
+    // Output structure tests
+    // ========================
+
+    @Test
+    void testExecute_noDelegation_rawIsManagerOutput() {
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Direct manager answer"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getRaw()).isEqualTo("Direct manager answer");
+    }
+
+    @Test
+    void testExecute_noDelegation_taskOutputsContainsOnlyManagerOutput() {
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Manager answer"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTaskOutputs()).hasSize(1);
+        assertThat(output.getTaskOutputs().get(0).getAgentRole()).isEqualTo("Manager");
+    }
+
+    @Test
+    void testExecute_withDelegation_taskOutputsContainsWorkerThenManager() {
+        when(workerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Worker result"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI trends"))
+                .thenReturn(textResponse("Final synthesis"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTaskOutputs()).hasSize(2);
+        assertThat(output.getTaskOutputs().get(0).getAgentRole()).isEqualTo("Researcher");
+        assertThat(output.getTaskOutputs().get(1).getAgentRole()).isEqualTo("Manager");
+    }
+
+    @Test
+    void testExecute_managerOutputIsLastInTaskOutputs() {
+        when(workerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Worker result"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI trends"))
+                .thenReturn(textResponse("Manager final"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTaskOutputs().getLast().getRaw()).isEqualTo("Manager final");
+    }
+
+    @Test
+    void testExecute_rawIsManagerFinalOutput() {
+        when(workerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Worker stuff"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI trends"))
+                .thenReturn(textResponse("Synthesized final answer"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getRaw()).isEqualTo("Synthesized final answer");
+    }
+
+    // ========================
+    // Tool call count tests
+    // ========================
+
+    @Test
+    void testExecute_withDelegation_totalToolCallsIsAtLeastOne() {
+        when(workerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Worker result"));
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegateCallResponse("Researcher", "Research AI trends"))
+                .thenReturn(textResponse("Final synthesis"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTotalToolCalls()).isGreaterThanOrEqualTo(1);
+    }
+
+    // ========================
+    // Duration tests
+    // ========================
+
+    @Test
+    void testExecute_totalDurationIsPositive() {
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Answer"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTotalDuration()).isPositive();
+    }
+
+    // ========================
+    // Multiple task tests
+    // ========================
+
+    @Test
+    void testExecute_multipleTasks_allPassedToManagerPrompt() {
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Multi-task answer"));
+
+        Agent writer = Agent.builder().role("Writer").goal("Write content")
+                .llm(workerModel).build();
+        executor = new HierarchicalWorkflowExecutor(managerModel, List.of(worker, writer), 20);
+
+        Task task1 = researchTask();
+        Task task2 = Task.builder().description("Write the report").expectedOutput("A report")
+                .agent(writer).build();
+
+        EnsembleOutput output = executor.execute(List.of(task1, task2), false);
+
+        assertThat(output.getRaw()).isEqualTo("Multi-task answer");
+    }
+
+    // ========================
+    // Manager agent config tests
+    // ========================
+
+    @Test
+    void testExecute_managerAgentHasManagerRole() {
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Answer"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTaskOutputs().getLast().getAgentRole())
+                .isEqualTo(HierarchicalWorkflowExecutor.MANAGER_ROLE);
+    }
+
+    @Test
+    void testExecute_taskOutputsIsImmutable() {
+        when(managerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Answer"));
+
+        EnsembleOutput output = executor.execute(List.of(researchTask()), false);
+
+        assertThat(output.getTaskOutputs()).isUnmodifiable();
+    }
+}

--- a/agentensemble-core/src/test/java/io/agentensemble/workflow/ManagerPromptBuilderTest.java
+++ b/agentensemble-core/src/test/java/io/agentensemble/workflow/ManagerPromptBuilderTest.java
@@ -1,0 +1,148 @@
+package io.agentensemble.workflow;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.agentensemble.Agent;
+import io.agentensemble.Task;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ManagerPromptBuilderTest {
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private Agent agentWithRole(String role, String goal) {
+        return Agent.builder().role(role).goal(goal).llm(mock(ChatModel.class)).build();
+    }
+
+    private Agent agentWithBackground(String role, String goal, String background) {
+        return Agent.builder().role(role).goal(goal).background(background)
+                .llm(mock(ChatModel.class)).build();
+    }
+
+    private Task taskFor(Agent agent, String description, String expectedOutput) {
+        return Task.builder().description(description).expectedOutput(expectedOutput)
+                .agent(agent).build();
+    }
+
+    // ========================
+    // buildBackground tests
+    // ========================
+
+    @Test
+    void testBuildBackground_withSingleAgent_containsRole() {
+        Agent agent = agentWithRole("Researcher", "Find information");
+        String result = ManagerPromptBuilder.buildBackground(List.of(agent));
+        assertThat(result).contains("Researcher");
+    }
+
+    @Test
+    void testBuildBackground_containsGoal() {
+        Agent agent = agentWithRole("Researcher", "Find information");
+        String result = ManagerPromptBuilder.buildBackground(List.of(agent));
+        assertThat(result).contains("Find information");
+    }
+
+    @Test
+    void testBuildBackground_withBackground_includesBackground() {
+        Agent agent = agentWithBackground("Researcher", "Find information", "Expert analyst");
+        String result = ManagerPromptBuilder.buildBackground(List.of(agent));
+        assertThat(result).contains("Expert analyst");
+    }
+
+    @Test
+    void testBuildBackground_withoutBackground_omitsBackgroundLine() {
+        Agent agent = agentWithRole("Researcher", "Find information");
+        String result = ManagerPromptBuilder.buildBackground(List.of(agent));
+        assertThat(result).doesNotContain("Background:");
+    }
+
+    @Test
+    void testBuildBackground_withMultipleAgents_listsAll() {
+        Agent a1 = agentWithRole("Researcher", "Research topics");
+        Agent a2 = agentWithRole("Writer", "Write content");
+        String result = ManagerPromptBuilder.buildBackground(List.of(a1, a2));
+        assertThat(result).contains("Researcher").contains("Writer");
+    }
+
+    @Test
+    void testBuildBackground_numbersAgentsSequentially() {
+        Agent a1 = agentWithRole("Researcher", "Research");
+        Agent a2 = agentWithRole("Writer", "Write");
+        String result = ManagerPromptBuilder.buildBackground(List.of(a1, a2));
+        assertThat(result).contains("1.").contains("2.");
+    }
+
+    @Test
+    void testBuildBackground_containsDelegateTip() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        String result = ManagerPromptBuilder.buildBackground(List.of(agent));
+        assertThat(result).containsIgnoringCase("delegate");
+    }
+
+    @Test
+    void testBuildBackground_containsSynthesisInstruction() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        String result = ManagerPromptBuilder.buildBackground(List.of(agent));
+        assertThat(result).containsIgnoringCase("synthesiz");
+    }
+
+    // ========================
+    // buildTaskDescription tests
+    // ========================
+
+    @Test
+    void testBuildTaskDescription_withSingleTask_containsDescription() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        Task task = taskFor(agent, "Research AI trends", "Summary of AI trends");
+        String result = ManagerPromptBuilder.buildTaskDescription(List.of(task));
+        assertThat(result).contains("Research AI trends");
+    }
+
+    @Test
+    void testBuildTaskDescription_containsExpectedOutput() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        Task task = taskFor(agent, "Research AI trends", "Summary of AI trends");
+        String result = ManagerPromptBuilder.buildTaskDescription(List.of(task));
+        assertThat(result).contains("Summary of AI trends");
+    }
+
+    @Test
+    void testBuildTaskDescription_withMultipleTasks_listsAll() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        Task t1 = taskFor(agent, "Task one description", "Expected one");
+        Task t2 = taskFor(agent, "Task two description", "Expected two");
+        String result = ManagerPromptBuilder.buildTaskDescription(List.of(t1, t2));
+        assertThat(result).contains("Task one description").contains("Task two description");
+    }
+
+    @Test
+    void testBuildTaskDescription_numbersTasksSequentially() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        Task t1 = taskFor(agent, "First task", "First output");
+        Task t2 = taskFor(agent, "Second task", "Second output");
+        String result = ManagerPromptBuilder.buildTaskDescription(List.of(t1, t2));
+        assertThat(result).contains("Task 1").contains("Task 2");
+    }
+
+    @Test
+    void testBuildTaskDescription_containsSynthesisInstructions() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        Task task = taskFor(agent, "Do something", "Expected result");
+        String result = ManagerPromptBuilder.buildTaskDescription(List.of(task));
+        assertThat(result).containsIgnoringCase("synthesiz");
+    }
+
+    @Test
+    void testBuildTaskDescription_containsDelegateTip() {
+        Agent agent = agentWithRole("Researcher", "Research");
+        Task task = taskFor(agent, "Do something", "Expected result");
+        String result = ManagerPromptBuilder.buildTaskDescription(List.of(task));
+        assertThat(result).containsIgnoringCase("delegate");
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,10 @@ subprojects {
         }
     }
 
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.add("-parameters")
+    }
+
     tasks.withType<Test> {
         useJUnitPlatform()
         testLogging {


### PR DESCRIPTION
## Summary

Implements the hierarchical workflow mode (`Workflow.HIERARCHICAL`) introduced as a stub in Phase 1. A virtual Manager agent is automatically created at runtime, uses a `delegateTask` tool to assign work to registered worker agents, and synthesizes a final result.

## Changes

### New production classes

| Class | Description |
|-------|-------------|
| `DelegateTaskTool` | `@Tool`-annotated tool the Manager calls to invoke a worker by role. Collects delegated `TaskOutput`s. |
| `ManagerPromptBuilder` | Builds the Manager's system prompt background (worker agent list) and user prompt (task list with expected outputs). |
| `HierarchicalWorkflowExecutor` | Implements `WorkflowExecutor`. Creates the Manager at runtime, runs it via `AgentExecutor`, and assembles `EnsembleOutput` with worker outputs first, manager final output last. |

### Modified

- `Ensemble`: add `managerLlm` (optional, defaults to first agent's LLM), `managerMaxIterations` (default 20), wire executor, skip context-ordering validation for hierarchical workflow
- `build.gradle.kts` (root): add `-parameters` compiler flag so `@Tool`-annotated multi-parameter methods work with LangChain4j's reflection-based tool executor

### Removed

- `SequentialEnsembleIntegrationTest.testHierarchicalWorkflow_throwsUnsupported()` -- feature is now implemented

## New API

```java
EnsembleOutput result = Ensemble.builder()
    .agent(researcher)
    .agent(writer)
    .task(researchTask)
    .task(writeTask)
    .workflow(Workflow.HIERARCHICAL)
    .managerLlm(gpt4Model)          // optional; defaults to first agent's LLM
    .managerMaxIterations(20)       // optional; default 20
    .build()
    .run();
// result.getTaskOutputs() = [workerOutput1, workerOutput2, managerOutput]
// result.getRaw() = manager's synthesized final answer
```

## Tests

- `DelegateTaskToolTest` -- 16 tests
- `ManagerPromptBuilderTest` -- 14 tests
- `HierarchicalWorkflowExecutorTest` -- 10 tests
- `HierarchicalEnsembleIntegrationTest` -- 9 tests

**174 tests total, 0 failures**

Closes #15