### PR TITLE
feat: agent delegation (Issue #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built natively in Java on top of [LangChain4j](https://github.com/langchain4j/la
 **Gradle (Kotlin DSL):**
 ```kotlin
 dependencies {
-    implementation("net.agentensemble:agentensemble-core:0.3.0")
+    implementation("net.agentensemble:agentensemble-core:0.4.0")
 
     // Add your preferred LangChain4j model provider:
     implementation("dev.langchain4j:langchain4j-open-ai:1.11.0")
@@ -254,6 +254,55 @@ EnsembleOutput output = Ensemble.builder()
 
 ---
 
+## Agent Delegation
+
+When an agent has `allowDelegation = true`, a `delegate` tool is automatically injected into its tool list at execution time. The agent can call this tool during its ReAct reasoning loop to hand off a subtask to any other registered agent.
+
+```java
+var leadResearcher = Agent.builder()
+    .role("Lead Researcher")
+    .goal("Coordinate research by delegating specialised subtasks to the right team member")
+    .llm(model)
+    .allowDelegation(true)    // enables the delegate tool
+    .build();
+
+var writer = Agent.builder()
+    .role("Content Writer")
+    .goal("Write clear, engaging content from research notes")
+    .llm(model)
+    .build();
+
+var task = Task.builder()
+    .description("Research AI trends and produce a polished blog post")
+    .expectedOutput("An 800-word blog post about AI trends")
+    .agent(leadResearcher)
+    .build();
+
+EnsembleOutput output = Ensemble.builder()
+    .agent(leadResearcher)
+    .agent(writer)
+    .task(task)
+    .maxDelegationDepth(3)    // prevent infinite recursion (default: 3)
+    .build()
+    .run();
+```
+
+During execution, the `leadResearcher` can call:
+```
+delegate("Content Writer", "Write an 800-word blog post about: [research findings]")
+```
+
+The framework executes the writer, returns the result as the tool output, and the researcher incorporates it into its final answer.
+
+**Guards enforced automatically:**
+- An agent cannot delegate to itself
+- Delegating to an unknown agent role returns an error to the caller
+- Delegation depth is capped at `maxDelegationDepth` (default 3) to prevent infinite chains
+
+See the [Delegation guide](docs/guides/delegation.md) for full details.
+
+---
+
 ## Agent Configuration
 
 | Option | Type | Default | Description |
@@ -263,6 +312,7 @@ EnsembleOutput output = Ensemble.builder()
 | `background` | `String` | `null` | Persona context for the system prompt |
 | `tools` | `List<Object>` | `[]` | Tools the agent can use |
 | `llm` | `ChatModel` | required | Any LangChain4j `ChatModel` |
+| `allowDelegation` | `boolean` | `false` | Auto-injects a `delegate` tool; agent can delegate subtasks to peers |
 | `verbose` | `boolean` | `false` | Log prompts and responses at INFO |
 | `maxIterations` | `int` | `25` | Max tool-call iterations before forcing final answer |
 | `responseFormat` | `String` | `""` | Extra formatting instructions in the system prompt |
@@ -290,6 +340,7 @@ EnsembleOutput output = Ensemble.builder()
 | `managerLlm` | `ChatModel` | first agent's LLM | LLM for the Manager agent (hierarchical workflow only) |
 | `managerMaxIterations` | `int` | `20` | Max tool-call iterations for the Manager agent (hierarchical workflow only) |
 | `memory` | `EnsembleMemory` | `null` | Memory configuration; see [Memory System](#memory-system) |
+| `maxDelegationDepth` | `int` | `3` | Maximum peer-delegation depth when agents have `allowDelegation = true` |
 | `verbose` | `boolean` | `false` | Elevates execution logging to INFO |
 
 ---
@@ -453,13 +504,27 @@ See [`docs/design/`](docs/design/) for full specifications:
 
 ---
 
+## Documentation
+
+Full user documentation is in [`docs/`](docs/):
+
+| Section | Description |
+|---|---|
+| [Getting Started](docs/getting-started/installation.md) | Installation, quickstart, core concepts |
+| [Guides](docs/guides/agents.md) | Agents, tasks, workflows, tools, memory, delegation, error handling, logging |
+| [Reference](docs/reference/ensemble-configuration.md) | Complete configuration field tables |
+| [Examples](docs/examples/research-writer.md) | Annotated example walkthroughs |
+| [Design Specs](docs/design/) | Internal architecture and design documentation |
+
+---
+
 ## What's Next (Roadmap)
 
 | Phase | Features |
 |---|---|
 | ~~v0.2.0~~ | ~~Hierarchical workflow (manager agent delegates)~~ |
 | ~~v0.3.0~~ | ~~Memory system (short-term, long-term, entity)~~ |
-| v0.4.0 | Agent delegation |
+| ~~v0.4.0~~ | ~~Agent delegation~~ |
 | v0.5.0 | Parallel workflow (virtual threads) |
 | v0.6.0 | Structured output (typed output parsing) |
 | v1.0.0 | Callbacks, streaming, guardrails, built-in tools |

--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -86,6 +86,15 @@ public class Ensemble {
     private final EnsembleMemory memory;
 
     /**
+     * Maximum delegation depth for agent-to-agent delegation.
+     * Prevents infinite recursion when agents have {@code allowDelegation = true}.
+     * Only relevant when at least one agent has {@code allowDelegation = true}.
+     * Default: 3. Must be greater than zero.
+     */
+    @Builder.Default
+    private final int maxDelegationDepth = 3;
+
+    /**
      * Execute the ensemble's tasks with no input variables.
      *
      * @return EnsembleOutput containing all results
@@ -160,9 +169,9 @@ public class Ensemble {
 
     private WorkflowExecutor selectExecutor() {
         return switch (workflow) {
-            case SEQUENTIAL -> new SequentialWorkflowExecutor();
+            case SEQUENTIAL -> new SequentialWorkflowExecutor(agents, maxDelegationDepth);
             case HIERARCHICAL -> new HierarchicalWorkflowExecutor(
-                    resolveManagerLlm(), agents, managerMaxIterations);
+                    resolveManagerLlm(), agents, managerMaxIterations, maxDelegationDepth);
         };
     }
 
@@ -177,6 +186,7 @@ public class Ensemble {
     private void validate() {
         validateTasksNotEmpty();
         validateAgentsNotEmpty();
+        validateMaxDelegationDepth();
         validateAgentMembership();
         validateNoCircularContextDependencies();
         validateContextOrdering();
@@ -192,6 +202,13 @@ public class Ensemble {
     private void validateAgentsNotEmpty() {
         if (agents == null || agents.isEmpty()) {
             throw new ValidationException("Ensemble must have at least one agent");
+        }
+    }
+
+    private void validateMaxDelegationDepth() {
+        if (maxDelegationDepth <= 0) {
+            throw new ValidationException(
+                    "Ensemble maxDelegationDepth must be > 0, got: " + maxDelegationDepth);
         }
     }
 

--- a/agentensemble-core/src/main/java/net/agentensemble/agent/AgentExecutor.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/agent/AgentExecutor.java
@@ -12,6 +12,8 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import net.agentensemble.Agent;
 import net.agentensemble.Task;
+import net.agentensemble.delegation.AgentDelegationTool;
+import net.agentensemble.delegation.DelegationContext;
 import net.agentensemble.exception.AgentExecutionException;
 import net.agentensemble.exception.MaxIterationsExceededException;
 import net.agentensemble.memory.MemoryContext;
@@ -83,11 +85,37 @@ public class AgentExecutor {
      */
     public TaskOutput execute(Task task, List<TaskOutput> contextOutputs, boolean verbose,
             MemoryContext memoryContext) {
+        return execute(task, contextOutputs, verbose, memoryContext, null);
+    }
+
+    /**
+     * Execute the given task using the agent specified in the task, with optional
+     * agent delegation support.
+     *
+     * When {@code delegationContext} is non-null and the agent has
+     * {@code allowDelegation = true}, an {@link AgentDelegationTool} is auto-injected
+     * into the agent's effective tool list for this execution. The tool allows the agent
+     * to delegate subtasks to peer agents during its ReAct loop.
+     *
+     * @param task              the task to execute
+     * @param contextOutputs    outputs from prior tasks to include as context
+     * @param verbose           when true, prompts and responses are logged at INFO level
+     * @param memoryContext     runtime memory state; use {@link MemoryContext#disabled()}
+     *                          when memory is not configured
+     * @param delegationContext delegation state for this run; pass {@code null} when
+     *                          delegation is not enabled for this ensemble
+     * @return the task output
+     * @throws AgentExecutionException        if the LLM throws an error
+     * @throws MaxIterationsExceededException if the agent exceeds its iteration limit
+     */
+    public TaskOutput execute(Task task, List<TaskOutput> contextOutputs, boolean verbose,
+            MemoryContext memoryContext, DelegationContext delegationContext) {
         Instant startTime = Instant.now();
         Agent agent = task.getAgent();
         boolean effectiveVerbose = verbose || agent.isVerbose();
 
-        log.info("Agent '{}' executing task | Tools: {}", agent.getRole(), agent.getTools().size());
+        log.info("Agent '{}' executing task | Tools: {} | AllowDelegation: {}",
+                agent.getRole(), agent.getTools().size(), agent.isAllowDelegation());
 
         // Build prompts -- memory context injects STM, LTM, and entity knowledge as applicable
         String systemPrompt = AgentPromptBuilder.buildSystemPrompt(agent);
@@ -101,8 +129,11 @@ public class AgentExecutor {
             log.debug("User prompt ({} chars):\n{}", userPrompt.length(), userPrompt);
         }
 
+        // Build effective tool list -- inject delegation tool when allowed
+        List<Object> effectiveTools = buildEffectiveTools(agent, delegationContext);
+
         // Resolve tools
-        ResolvedTools resolvedTools = resolveTools(agent.getTools());
+        ResolvedTools resolvedTools = resolveTools(effectiveTools);
         AtomicInteger toolCallCounter = new AtomicInteger(0);
 
         String finalResponse;
@@ -152,6 +183,28 @@ public class AgentExecutor {
         memoryContext.record(output);
 
         return output;
+    }
+
+    /**
+     * Build the effective tool list for this execution.
+     *
+     * When the agent has {@code allowDelegation = true} and a non-null
+     * {@code delegationContext} is provided, an {@link AgentDelegationTool} is prepended
+     * to the agent's configured tools.
+     */
+    private List<Object> buildEffectiveTools(Agent agent, DelegationContext delegationContext) {
+        if (agent.isAllowDelegation() && delegationContext != null) {
+            AgentDelegationTool delegationTool =
+                    new AgentDelegationTool(agent.getRole(), delegationContext);
+            List<Object> tools = new ArrayList<>();
+            tools.add(delegationTool);
+            tools.addAll(agent.getTools());
+            log.debug("Agent '{}' delegation tool injected (depth {}/{})",
+                    agent.getRole(), delegationContext.getCurrentDepth(),
+                    delegationContext.getMaxDepth());
+            return tools;
+        }
+        return agent.getTools();
     }
 
     // ========================

--- a/agentensemble-core/src/main/java/net/agentensemble/delegation/AgentDelegationTool.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/delegation/AgentDelegationTool.java
@@ -1,0 +1,171 @@
+package net.agentensemble.delegation;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import net.agentensemble.Agent;
+import net.agentensemble.Task;
+import net.agentensemble.task.TaskOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A tool that allows an agent to delegate a subtask to another agent within the same ensemble.
+ *
+ * When an agent has {@code allowDelegation = true}, the framework auto-injects an instance of
+ * this tool into its tool list at execution time. The agent can then call {@code delegate}
+ * during its ReAct loop to hand off work to a peer agent. The peer executes the subtask and
+ * returns its output as the tool result, which the calling agent can incorporate into its
+ * final answer.
+ *
+ * Guards enforced before executing a delegation:
+ * <ul>
+ *   <li>Self-delegation: an agent cannot delegate to itself</li>
+ *   <li>Depth limit: delegation depth is capped at {@link DelegationContext#getMaxDepth()}</li>
+ *   <li>Unknown agent: the target role must match an agent registered with the ensemble</li>
+ * </ul>
+ *
+ * All delegated outputs are accumulated and accessible via {@link #getDelegatedOutputs()}
+ * for metrics and audit purposes.
+ *
+ * This class is stateful (accumulates outputs). A new instance must be created per
+ * agent execution.
+ */
+public class AgentDelegationTool {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentDelegationTool.class);
+
+    /** MDC key for the delegation depth. */
+    static final String MDC_DELEGATION_DEPTH = "delegation.depth";
+
+    /** MDC key for the parent agent's role. */
+    static final String MDC_DELEGATION_PARENT = "delegation.parent";
+
+    /** Default expected output for delegated tasks. */
+    private static final String DEFAULT_EXPECTED_OUTPUT = "Complete the assigned subtask thoroughly";
+
+    private final String callerRole;
+    private final DelegationContext delegationContext;
+    private final List<TaskOutput> delegatedOutputs = new ArrayList<>();
+
+    /**
+     * @param callerRole        the role of the agent that owns this tool instance
+     * @param delegationContext the delegation state for the current run
+     */
+    public AgentDelegationTool(String callerRole, DelegationContext delegationContext) {
+        this.callerRole = callerRole;
+        this.delegationContext = delegationContext;
+    }
+
+    /**
+     * Delegate a subtask to another agent.
+     *
+     * The target agent is located by role name (case-insensitive). If found, the subtask
+     * is executed and the result returned. If any guard fails (depth limit, self-delegation,
+     * unknown role), a descriptive error message is returned to the calling agent instead.
+     *
+     * @param agentRole       the role of the target agent
+     * @param taskDescription a description of the subtask for the target agent to complete
+     * @return the target agent's output, or an error message if the delegation cannot proceed
+     */
+    @Tool("Delegate a subtask to another agent in the ensemble. "
+            + "Use this when you need specialised help from a team member. "
+            + "Provide the target agent's role and a clear description of the subtask.")
+    public String delegate(
+            @P("The role of the agent to delegate to. Must match one of the available agent roles.")
+            String agentRole,
+            @P("A clear description of the subtask for the target agent to complete.")
+            String taskDescription) {
+
+        // Guard: depth limit
+        if (delegationContext.isAtLimit()) {
+            String msg = "Delegation depth limit reached (max: " + delegationContext.getMaxDepth()
+                    + ", current: " + delegationContext.getCurrentDepth()
+                    + "). Complete this task yourself without further delegation.";
+            log.warn("Delegation blocked for agent '{}': {}", callerRole, msg);
+            return msg;
+        }
+
+        // Guard: self-delegation
+        Agent target = findAgentByRole(agentRole);
+        if (target != null && target.getRole().equalsIgnoreCase(callerRole)) {
+            String msg = "Cannot delegate to yourself (role: '" + callerRole
+                    + "'). Choose a different agent.";
+            log.warn("{}", msg);
+            return msg;
+        }
+
+        // Guard: unknown agent
+        if (target == null) {
+            List<String> availableRoles = delegationContext.getPeerAgents()
+                    .stream()
+                    .map(Agent::getRole)
+                    .toList();
+            String msg = "Agent not found with role '" + agentRole
+                    + "'. Available roles: " + availableRoles;
+            log.warn("Delegation from '{}' failed: {}", callerRole, msg);
+            return msg;
+        }
+
+        log.info("Agent '{}' delegating subtask to '{}' (depth {}/{}): {}",
+                callerRole, target.getRole(),
+                delegationContext.getCurrentDepth() + 1, delegationContext.getMaxDepth(),
+                taskDescription.length() > 80 ? taskDescription.substring(0, 80) + "..." : taskDescription);
+
+        MDC.put(MDC_DELEGATION_DEPTH, String.valueOf(delegationContext.getCurrentDepth() + 1));
+        MDC.put(MDC_DELEGATION_PARENT, callerRole);
+
+        try {
+            Task delegatedTask = Task.builder()
+                    .description(taskDescription)
+                    .expectedOutput(DEFAULT_EXPECTED_OUTPUT)
+                    .agent(target)
+                    .build();
+
+            // Descend: child runs at depth + 1
+            DelegationContext childCtx = delegationContext.descend();
+
+            TaskOutput output = delegationContext.getAgentExecutor().execute(
+                    delegatedTask,
+                    List.of(),
+                    delegationContext.isVerbose(),
+                    delegationContext.getMemoryContext(),
+                    childCtx);
+
+            delegatedOutputs.add(output);
+
+            log.info("Delegation to '{}' completed | Tool calls: {} | Duration: {}",
+                    target.getRole(), output.getToolCallCount(), output.getDuration());
+
+            return output.getRaw();
+
+        } finally {
+            MDC.remove(MDC_DELEGATION_DEPTH);
+            MDC.remove(MDC_DELEGATION_PARENT);
+        }
+    }
+
+    /**
+     * Returns an immutable snapshot of all task outputs produced through delegation,
+     * in delegation order.
+     *
+     * @return immutable list of delegated TaskOutput instances
+     */
+    public List<TaskOutput> getDelegatedOutputs() {
+        return List.copyOf(delegatedOutputs);
+    }
+
+    private Agent findAgentByRole(String role) {
+        if (role == null) {
+            return null;
+        }
+        String normalized = role.trim();
+        return delegationContext.getPeerAgents().stream()
+                .filter(a -> a.getRole().equalsIgnoreCase(normalized))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/delegation/DelegationContext.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/delegation/DelegationContext.java
@@ -1,0 +1,133 @@
+package net.agentensemble.delegation;
+
+import net.agentensemble.Agent;
+import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.memory.MemoryContext;
+
+import java.util.List;
+
+/**
+ * Immutable runtime state for an agent delegation chain.
+ *
+ * Tracks the current delegation depth, maximum allowed depth, the peer agents
+ * available for delegation, and the shared execution infrastructure. A new
+ * {@code DelegationContext} is created at the start of each ensemble run by the
+ * workflow executor and threaded through {@link AgentExecutor} calls. When an
+ * agent delegates to a peer, {@link #descend()} produces a child context with
+ * depth incremented by one, preserving all other fields.
+ *
+ * This class is immutable and therefore thread-safe.
+ *
+ * Example:
+ * <pre>
+ * DelegationContext ctx = DelegationContext.create(
+ *     ensemble.getAgents(), 3, memoryContext, agentExecutor, verbose);
+ *
+ * // In AgentDelegationTool:
+ * DelegationContext childCtx = ctx.descend();
+ * agentExecutor.execute(task, List.of(), verbose, memoryContext, childCtx);
+ * </pre>
+ */
+public final class DelegationContext {
+
+    private final List<Agent> peerAgents;
+    private final int maxDepth;
+    private final int currentDepth;
+    private final MemoryContext memoryContext;
+    private final AgentExecutor agentExecutor;
+    private final boolean verbose;
+
+    private DelegationContext(List<Agent> peerAgents, int maxDepth, int currentDepth,
+            MemoryContext memoryContext, AgentExecutor agentExecutor, boolean verbose) {
+        this.peerAgents = peerAgents;
+        this.maxDepth = maxDepth;
+        this.currentDepth = currentDepth;
+        this.memoryContext = memoryContext;
+        this.agentExecutor = agentExecutor;
+        this.verbose = verbose;
+    }
+
+    /**
+     * Create a root delegation context (depth = 0).
+     *
+     * @param peerAgents    agents available for delegation; must not be null
+     * @param maxDepth      maximum delegation depth allowed; must be greater than zero
+     * @param memoryContext runtime memory state for this run; must not be null
+     * @param agentExecutor executor used to run delegated tasks; must not be null
+     * @param verbose       whether to enable verbose logging for delegated tasks
+     * @return a new root-level delegation context
+     * @throws IllegalArgumentException if any required argument is null or maxDepth is not positive
+     */
+    public static DelegationContext create(List<Agent> peerAgents, int maxDepth,
+            MemoryContext memoryContext, AgentExecutor agentExecutor, boolean verbose) {
+        if (peerAgents == null) {
+            throw new IllegalArgumentException("peerAgents must not be null");
+        }
+        if (maxDepth <= 0) {
+            throw new IllegalArgumentException("maxDepth must be > 0, got: " + maxDepth);
+        }
+        if (memoryContext == null) {
+            throw new IllegalArgumentException("memoryContext must not be null");
+        }
+        if (agentExecutor == null) {
+            throw new IllegalArgumentException("agentExecutor must not be null");
+        }
+        return new DelegationContext(List.copyOf(peerAgents), maxDepth, 0,
+                memoryContext, agentExecutor, verbose);
+    }
+
+    /**
+     * Return a child context with {@code currentDepth + 1}, all other fields preserved.
+     *
+     * Call this before executing a delegated task so the child agent receives a context
+     * that correctly reflects its position in the delegation chain.
+     *
+     * @return a new {@code DelegationContext} with depth incremented by one
+     */
+    public DelegationContext descend() {
+        return new DelegationContext(peerAgents, maxDepth, currentDepth + 1,
+                memoryContext, agentExecutor, verbose);
+    }
+
+    /**
+     * Return true if the current depth has reached or exceeded the maximum allowed depth.
+     *
+     * When true, the {@link AgentDelegationTool} must not delegate further and should
+     * return an error message to the calling agent instead.
+     *
+     * @return true if delegation limit has been reached
+     */
+    public boolean isAtLimit() {
+        return currentDepth >= maxDepth;
+    }
+
+    /** @return the list of agents available for delegation */
+    public List<Agent> getPeerAgents() {
+        return peerAgents;
+    }
+
+    /** @return the maximum allowed delegation depth for this run */
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+
+    /** @return the current delegation depth (0 = root, 1 = first delegation, etc.) */
+    public int getCurrentDepth() {
+        return currentDepth;
+    }
+
+    /** @return the shared memory context for this run */
+    public MemoryContext getMemoryContext() {
+        return memoryContext;
+    }
+
+    /** @return the agent executor used to run delegated tasks */
+    public AgentExecutor getAgentExecutor() {
+        return agentExecutor;
+    }
+
+    /** @return true if verbose logging is enabled */
+    public boolean isVerbose() {
+        return verbose;
+    }
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/workflow/DelegateTaskTool.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/workflow/DelegateTaskTool.java
@@ -5,6 +5,7 @@ import dev.langchain4j.agent.tool.Tool;
 import net.agentensemble.Agent;
 import net.agentensemble.Task;
 import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.delegation.DelegationContext;
 import net.agentensemble.memory.MemoryContext;
 import net.agentensemble.task.TaskOutput;
 import org.slf4j.Logger;
@@ -38,21 +39,24 @@ public class DelegateTaskTool {
     private final AgentExecutor agentExecutor;
     private final boolean verbose;
     private final MemoryContext memoryContext;
+    private final DelegationContext delegationContext;
     private final List<TaskOutput> delegatedOutputs = new ArrayList<>();
 
     /**
-     * @param agents        the worker agents available for delegation
-     * @param agentExecutor the executor to use when running delegated tasks
-     * @param verbose       whether to enable verbose logging for delegated tasks
-     * @param memoryContext runtime memory state for this run; use
-     *                      {@link MemoryContext#disabled()} when memory is not configured
+     * @param agents             the worker agents available for delegation
+     * @param agentExecutor      the executor to use when running delegated tasks
+     * @param verbose            whether to enable verbose logging for delegated tasks
+     * @param memoryContext      runtime memory state for this run; use
+     *                           {@link MemoryContext#disabled()} when memory is not configured
+     * @param delegationContext  peer-delegation context so workers can further delegate if allowed
      */
     public DelegateTaskTool(List<Agent> agents, AgentExecutor agentExecutor, boolean verbose,
-            MemoryContext memoryContext) {
+            MemoryContext memoryContext, DelegationContext delegationContext) {
         this.agents = List.copyOf(agents);
         this.agentExecutor = agentExecutor;
         this.verbose = verbose;
         this.memoryContext = memoryContext;
+        this.delegationContext = delegationContext;
     }
 
     /**
@@ -92,7 +96,8 @@ public class DelegateTaskTool {
                 .agent(agent)
                 .build();
 
-        TaskOutput output = agentExecutor.execute(delegatedTask, List.of(), verbose, memoryContext);
+        TaskOutput output = agentExecutor.execute(delegatedTask, List.of(), verbose, memoryContext,
+                delegationContext);
         delegatedOutputs.add(output);
 
         log.info("Delegation to '{}' completed | Tool calls: {} | Duration: {}",

--- a/agentensemble-core/src/main/java/net/agentensemble/workflow/HierarchicalWorkflowExecutor.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/workflow/HierarchicalWorkflowExecutor.java
@@ -4,6 +4,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import net.agentensemble.Agent;
 import net.agentensemble.Task;
 import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.delegation.DelegationContext;
 import net.agentensemble.ensemble.EnsembleOutput;
 import net.agentensemble.memory.MemoryContext;
 import net.agentensemble.task.TaskOutput;
@@ -56,18 +57,21 @@ public class HierarchicalWorkflowExecutor implements WorkflowExecutor {
     private final ChatModel managerLlm;
     private final List<Agent> workerAgents;
     private final int managerMaxIterations;
+    private final int maxDelegationDepth;
     private final AgentExecutor agentExecutor;
 
     /**
      * @param managerLlm           LLM for the manager agent
      * @param workerAgents         the worker agents available for delegation
      * @param managerMaxIterations maximum number of tool call iterations for the manager
+     * @param maxDelegationDepth   maximum peer-delegation depth for worker agents
      */
     public HierarchicalWorkflowExecutor(ChatModel managerLlm, List<Agent> workerAgents,
-            int managerMaxIterations) {
+            int managerMaxIterations, int maxDelegationDepth) {
         this.managerLlm = managerLlm;
         this.workerAgents = List.copyOf(workerAgents);
         this.managerMaxIterations = managerMaxIterations;
+        this.maxDelegationDepth = maxDelegationDepth;
         this.agentExecutor = new AgentExecutor();
     }
 
@@ -81,11 +85,15 @@ public class HierarchicalWorkflowExecutor implements WorkflowExecutor {
             log.info("Hierarchical workflow starting | Tasks: {} | Worker agents: {}",
                     resolvedTasks.size(), workerAgents.size());
 
-            // 1. Create the stateful DelegateTaskTool (accumulates worker outputs, shares memory)
-            DelegateTaskTool delegateTool = new DelegateTaskTool(workerAgents, agentExecutor,
-                    verbose, memoryContext);
+            // 1. Create delegation context for peer delegation among worker agents
+            DelegationContext workerDelegationContext = DelegationContext.create(
+                    workerAgents, maxDelegationDepth, memoryContext, agentExecutor, verbose);
 
-            // 2. Build the virtual Manager agent
+            // 2. Create the stateful DelegateTaskTool (accumulates worker outputs, shares memory)
+            DelegateTaskTool delegateTool = new DelegateTaskTool(workerAgents, agentExecutor,
+                    verbose, memoryContext, workerDelegationContext);
+
+            // 3. Build the virtual Manager agent
             Agent manager = Agent.builder()
                     .role(MANAGER_ROLE)
                     .goal(MANAGER_GOAL)
@@ -95,14 +103,14 @@ public class HierarchicalWorkflowExecutor implements WorkflowExecutor {
                     .tools(List.of(delegateTool))
                     .build();
 
-            // 3. Build the meta-task that drives the manager
+            // 4. Build the meta-task that drives the manager
             Task managerTask = Task.builder()
                     .description(ManagerPromptBuilder.buildTaskDescription(resolvedTasks))
                     .expectedOutput(MANAGER_EXPECTED_OUTPUT)
                     .agent(manager)
                     .build();
 
-            // 4. Execute the manager (ReAct loop: it calls delegateTask for each worker task)
+            // 5. Execute the manager (ReAct loop: it calls delegateTask for each worker task)
             // The manager itself does not participate in shared memory (it is a meta-orchestrator)
             log.info("Manager agent starting | Max iterations: {}", managerMaxIterations);
             TaskOutput managerOutput = agentExecutor.execute(managerTask, List.of(), verbose,

--- a/agentensemble-core/src/main/java/net/agentensemble/workflow/SequentialWorkflowExecutor.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/workflow/SequentialWorkflowExecutor.java
@@ -1,7 +1,9 @@
 package net.agentensemble.workflow;
 
+import net.agentensemble.Agent;
 import net.agentensemble.Task;
 import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.delegation.DelegationContext;
 import net.agentensemble.ensemble.EnsembleOutput;
 import net.agentensemble.exception.AgentExecutionException;
 import net.agentensemble.exception.MaxIterationsExceededException;
@@ -44,9 +46,19 @@ public class SequentialWorkflowExecutor implements WorkflowExecutor {
     /** Truncation length for task description in MDC and logs. */
     private static final int MDC_DESCRIPTION_MAX_LENGTH = 80;
 
+    private final List<Agent> agents;
+    private final int maxDelegationDepth;
     private final AgentExecutor agentExecutor;
 
-    public SequentialWorkflowExecutor() {
+    /**
+     * Create a SequentialWorkflowExecutor with delegation support.
+     *
+     * @param agents             all agents registered with the ensemble (used to build DelegationContext)
+     * @param maxDelegationDepth maximum allowed delegation depth for agents with allowDelegation=true
+     */
+    public SequentialWorkflowExecutor(List<Agent> agents, int maxDelegationDepth) {
+        this.agents = List.copyOf(agents);
+        this.maxDelegationDepth = maxDelegationDepth;
         this.agentExecutor = new AgentExecutor();
     }
 
@@ -56,6 +68,10 @@ public class SequentialWorkflowExecutor implements WorkflowExecutor {
         Instant ensembleStartTime = Instant.now();
         int totalTasks = resolvedTasks.size();
         Map<Task, TaskOutput> completedOutputs = new LinkedHashMap<>();
+
+        // Create the delegation context once for the entire run; all agents share it
+        DelegationContext delegationContext = DelegationContext.create(
+                agents, maxDelegationDepth, memoryContext, agentExecutor, verbose);
 
         for (int i = 0; i < totalTasks; i++) {
             Task task = resolvedTasks.get(i);
@@ -76,9 +92,10 @@ public class SequentialWorkflowExecutor implements WorkflowExecutor {
                 log.debug("Task {}/{} context: {} prior outputs", taskIndex, totalTasks,
                         contextOutputs.size());
 
-                // Execute the task -- AgentExecutor injects memory and records the output
+                // Execute the task with delegation context -- delegation tool is injected
+                // automatically when the agent has allowDelegation=true
                 TaskOutput taskOutput = agentExecutor.execute(task, contextOutputs, verbose,
-                        memoryContext);
+                        memoryContext, delegationContext);
                 completedOutputs.put(task, taskOutput);
 
                 log.info("Task {}/{} completed | Duration: {} | Tool calls: {}",

--- a/agentensemble-core/src/test/java/net/agentensemble/delegation/AgentDelegationToolTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/delegation/AgentDelegationToolTest.java
@@ -1,0 +1,259 @@
+package net.agentensemble.delegation;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import net.agentensemble.Agent;
+import net.agentensemble.Task;
+import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.memory.MemoryContext;
+import net.agentensemble.task.TaskOutput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AgentDelegationToolTest {
+
+    private ChatModel model;
+    private Agent researcher;
+    private Agent writer;
+    private AgentExecutor executor;
+    private MemoryContext memoryContext;
+    private DelegationContext delegationContext;
+
+    @BeforeEach
+    void setUp() {
+        model = mock(ChatModel.class);
+
+        // Default: model returns a plain text response so AgentExecutor won't loop
+        ChatResponse response = mock(ChatResponse.class);
+        AiMessage aiMessage = mock(AiMessage.class);
+        when(response.aiMessage()).thenReturn(aiMessage);
+        when(aiMessage.text()).thenReturn("delegated result");
+        when(aiMessage.hasToolExecutionRequests()).thenReturn(false);
+        when(model.chat(any(ChatRequest.class))).thenReturn(response);
+
+        researcher = Agent.builder()
+                .role("Researcher")
+                .goal("Research things")
+                .llm(model)
+                .allowDelegation(true)
+                .build();
+
+        writer = Agent.builder()
+                .role("Writer")
+                .goal("Write things")
+                .llm(model)
+                .allowDelegation(true)
+                .build();
+
+        executor = mock(AgentExecutor.class);
+        memoryContext = MemoryContext.disabled();
+    }
+
+    private TaskOutput makeOutput(String raw) {
+        return TaskOutput.builder()
+                .raw(raw)
+                .taskDescription("delegated task")
+                .agentRole("Writer")
+                .completedAt(Instant.now())
+                .duration(Duration.ofMillis(100))
+                .toolCallCount(0)
+                .build();
+    }
+
+    // ========================
+    // Successful delegation
+    // ========================
+
+    @Test
+    void delegate_returnsWorkerOutput() {
+        when(executor.execute(any(Task.class), any(), any(Boolean.class), any(MemoryContext.class),
+                any(DelegationContext.class)))
+                .thenReturn(makeOutput("research complete"));
+
+        delegationContext = DelegationContext.create(List.of(researcher, writer), 3,
+                memoryContext, executor, false);
+
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", delegationContext);
+        String result = tool.delegate("Writer", "Write a blog post about AI");
+
+        assertThat(result).isEqualTo("research complete");
+    }
+
+    @Test
+    void delegate_caseInsensitiveRoleMatch() {
+        when(executor.execute(any(Task.class), any(), any(Boolean.class), any(MemoryContext.class),
+                any(DelegationContext.class)))
+                .thenReturn(makeOutput("output"));
+
+        delegationContext = DelegationContext.create(List.of(writer), 3, memoryContext, executor, false);
+
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", delegationContext);
+        String result = tool.delegate("writer", "Write something"); // lowercase
+
+        assertThat(result).isEqualTo("output");
+    }
+
+    @Test
+    void delegate_accumulates_delegatedOutputs() {
+        when(executor.execute(any(Task.class), any(), any(Boolean.class), any(MemoryContext.class),
+                any(DelegationContext.class)))
+                .thenReturn(makeOutput("output 1"))
+                .thenReturn(makeOutput("output 2"));
+
+        delegationContext = DelegationContext.create(List.of(researcher, writer), 3,
+                memoryContext, executor, false);
+
+        AgentDelegationTool tool = new AgentDelegationTool("Caller", delegationContext);
+        tool.delegate("Researcher", "Task 1");
+        tool.delegate("Writer", "Task 2");
+
+        assertThat(tool.getDelegatedOutputs()).hasSize(2);
+        assertThat(tool.getDelegatedOutputs().get(0).getRaw()).isEqualTo("output 1");
+        assertThat(tool.getDelegatedOutputs().get(1).getRaw()).isEqualTo("output 2");
+    }
+
+    @Test
+    void getDelegatedOutputs_returnsImmutableList() {
+        delegationContext = DelegationContext.create(List.of(writer), 3, memoryContext, executor, false);
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", delegationContext);
+
+        List<TaskOutput> outputs = tool.getDelegatedOutputs();
+        assertThat(outputs).isEmpty();
+        // UnsupportedOperationException or similar expected on mutation attempt
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> outputs.add(makeOutput("x")));
+    }
+
+    // ========================
+    // Agent not found
+    // ========================
+
+    @Test
+    void delegate_agentNotFound_returnsErrorMessage() {
+        delegationContext = DelegationContext.create(List.of(researcher), 3, memoryContext, executor, false);
+
+        AgentDelegationTool tool = new AgentDelegationTool("Caller", delegationContext);
+        String result = tool.delegate("NonExistentAgent", "Some task");
+
+        assertThat(result).contains("NonExistentAgent");
+        assertThat(result).containsIgnoringCase("not found");
+    }
+
+    @Test
+    void delegate_agentNotFound_includesAvailableRoles() {
+        delegationContext = DelegationContext.create(List.of(researcher, writer), 3,
+                memoryContext, executor, false);
+
+        AgentDelegationTool tool = new AgentDelegationTool("Caller", delegationContext);
+        String result = tool.delegate("Unknown", "task");
+
+        assertThat(result).contains("Researcher");
+        assertThat(result).contains("Writer");
+    }
+
+    @Test
+    void delegate_nullRole_returnsErrorMessage() {
+        delegationContext = DelegationContext.create(List.of(researcher), 3, memoryContext, executor, false);
+        AgentDelegationTool tool = new AgentDelegationTool("Caller", delegationContext);
+
+        String result = tool.delegate(null, "some task");
+        assertThat(result).containsIgnoringCase("not found");
+    }
+
+    // ========================
+    // Depth limit enforcement
+    // ========================
+
+    @Test
+    void delegate_atDepthLimit_returnsLimitErrorMessage() {
+        // Create a context already at the limit (depth = max)
+        DelegationContext limitedCtx = DelegationContext.create(List.of(writer), 1,
+                memoryContext, executor, false)
+                .descend(); // depth = 1 = max
+
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", limitedCtx);
+        String result = tool.delegate("Writer", "Write something");
+
+        assertThat(result).containsIgnoringCase("delegation depth limit");
+    }
+
+    @Test
+    void delegate_atDepthLimit_doesNotInvokeExecutor() {
+        DelegationContext limitedCtx = DelegationContext.create(List.of(writer), 1,
+                memoryContext, executor, false)
+                .descend();
+
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", limitedCtx);
+        tool.delegate("Writer", "Task");
+
+        // No interactions with the executor
+        org.mockito.Mockito.verifyNoInteractions(executor);
+    }
+
+    @Test
+    void delegate_atDepthLimit_doesNotAccumulateOutputs() {
+        DelegationContext limitedCtx = DelegationContext.create(List.of(writer), 1,
+                memoryContext, executor, false)
+                .descend();
+
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", limitedCtx);
+        tool.delegate("Writer", "Task");
+
+        assertThat(tool.getDelegatedOutputs()).isEmpty();
+    }
+
+    // ========================
+    // Self-delegation guard
+    // ========================
+
+    @Test
+    void delegate_toSelf_returnsErrorMessage() {
+        delegationContext = DelegationContext.create(List.of(researcher, writer), 3,
+                memoryContext, executor, false);
+
+        // The calling agent's role is "Researcher" -- delegates to itself
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", delegationContext);
+        String result = tool.delegate("Researcher", "Do my own task");
+
+        assertThat(result).containsIgnoringCase("cannot delegate to yourself");
+    }
+
+    // ========================
+    // Descend context passed through
+    // ========================
+
+    @Test
+    void delegate_passesDescendedContextToExecutor() {
+        TaskOutput output = makeOutput("output");
+        DelegationContext[] capturedContext = {null};
+
+        // Custom executor that captures the DelegationContext passed to it
+        AgentExecutor capturingExecutor = new AgentExecutor() {
+            @Override
+            public TaskOutput execute(Task task, List<TaskOutput> contextOutputs,
+                    boolean verbose, MemoryContext mc, DelegationContext dc) {
+                capturedContext[0] = dc;
+                return output;
+            }
+        };
+
+        DelegationContext rootCtx = DelegationContext.create(List.of(writer), 3,
+                memoryContext, capturingExecutor, false);
+
+        AgentDelegationTool tool = new AgentDelegationTool("Researcher", rootCtx);
+        tool.delegate("Writer", "Write something");
+
+        assertThat(capturedContext[0]).isNotNull();
+        assertThat(capturedContext[0].getCurrentDepth()).isEqualTo(1);
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/delegation/DelegationContextTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/delegation/DelegationContextTest.java
@@ -1,0 +1,161 @@
+package net.agentensemble.delegation;
+
+import dev.langchain4j.model.chat.ChatModel;
+import net.agentensemble.Agent;
+import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.memory.MemoryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class DelegationContextTest {
+
+    private ChatModel model;
+    private Agent agentA;
+    private Agent agentB;
+    private AgentExecutor executor;
+    private MemoryContext memoryContext;
+
+    @BeforeEach
+    void setUp() {
+        model = mock(ChatModel.class);
+        agentA = Agent.builder().role("Researcher").goal("Research things").llm(model).build();
+        agentB = Agent.builder().role("Writer").goal("Write things").llm(model).build();
+        executor = mock(AgentExecutor.class);
+        memoryContext = MemoryContext.disabled();
+    }
+
+    // ========================
+    // create()
+    // ========================
+
+    @Test
+    void create_setsAllFields() {
+        List<Agent> peers = List.of(agentA, agentB);
+        DelegationContext ctx = DelegationContext.create(peers, 3, memoryContext, executor, false);
+
+        assertThat(ctx.getPeerAgents()).containsExactly(agentA, agentB);
+        assertThat(ctx.getMaxDepth()).isEqualTo(3);
+        assertThat(ctx.getCurrentDepth()).isEqualTo(0);
+        assertThat(ctx.getMemoryContext()).isSameAs(memoryContext);
+        assertThat(ctx.getAgentExecutor()).isSameAs(executor);
+        assertThat(ctx.isVerbose()).isFalse();
+    }
+
+    @Test
+    void create_withVerboseTrue() {
+        DelegationContext ctx = DelegationContext.create(List.of(agentA), 2, memoryContext, executor, true);
+        assertThat(ctx.isVerbose()).isTrue();
+    }
+
+    @Test
+    void create_copysPeerList_immutably() {
+        List<Agent> peers = List.of(agentA);
+        DelegationContext ctx = DelegationContext.create(peers, 2, memoryContext, executor, false);
+        // The returned list must not be the same mutable reference
+        assertThat(ctx.getPeerAgents()).containsExactly(agentA);
+    }
+
+    @Test
+    void create_throwsWhenPeerListIsNull() {
+        assertThatThrownBy(() -> DelegationContext.create(null, 3, memoryContext, executor, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("peerAgents");
+    }
+
+    @Test
+    void create_throwsWhenExecutorIsNull() {
+        assertThatThrownBy(() ->
+                DelegationContext.create(List.of(agentA), 3, memoryContext, null, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("agentExecutor");
+    }
+
+    @Test
+    void create_throwsWhenMemoryContextIsNull() {
+        assertThatThrownBy(() ->
+                DelegationContext.create(List.of(agentA), 3, null, executor, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("memoryContext");
+    }
+
+    @Test
+    void create_throwsWhenMaxDepthIsZero() {
+        assertThatThrownBy(() ->
+                DelegationContext.create(List.of(agentA), 0, memoryContext, executor, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxDepth");
+    }
+
+    @Test
+    void create_throwsWhenMaxDepthIsNegative() {
+        assertThatThrownBy(() ->
+                DelegationContext.create(List.of(agentA), -1, memoryContext, executor, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxDepth");
+    }
+
+    // ========================
+    // isAtLimit()
+    // ========================
+
+    @Test
+    void isAtLimit_falseWhenDepthBelowMax() {
+        DelegationContext ctx = DelegationContext.create(List.of(agentA), 3, memoryContext, executor, false);
+        assertThat(ctx.isAtLimit()).isFalse();
+    }
+
+    @Test
+    void isAtLimit_trueWhenDepthEqualsMax() {
+        DelegationContext ctx = DelegationContext.create(List.of(agentA), 1, memoryContext, executor, false);
+        DelegationContext descended = ctx.descend();
+        assertThat(descended.isAtLimit()).isTrue();
+    }
+
+    @Test
+    void isAtLimit_trueWhenDepthExceedsMax() {
+        DelegationContext ctx = DelegationContext.create(List.of(agentA), 1, memoryContext, executor, false);
+        DelegationContext descended = ctx.descend();
+        // Another descend beyond limit still reports at limit (depth = 2, max = 1)
+        DelegationContext deeper = descended.descend();
+        assertThat(deeper.isAtLimit()).isTrue();
+    }
+
+    // ========================
+    // descend()
+    // ========================
+
+    @Test
+    void descend_incrementsDepthByOne() {
+        DelegationContext ctx = DelegationContext.create(List.of(agentA), 3, memoryContext, executor, false);
+        DelegationContext child = ctx.descend();
+
+        assertThat(child.getCurrentDepth()).isEqualTo(1);
+        assertThat(ctx.getCurrentDepth()).isEqualTo(0); // original unchanged
+    }
+
+    @Test
+    void descend_preservesAllOtherFields() {
+        List<Agent> peers = List.of(agentA, agentB);
+        DelegationContext ctx = DelegationContext.create(peers, 5, memoryContext, executor, true);
+        DelegationContext child = ctx.descend();
+
+        assertThat(child.getPeerAgents()).containsExactlyElementsOf(peers);
+        assertThat(child.getMaxDepth()).isEqualTo(5);
+        assertThat(child.getMemoryContext()).isSameAs(memoryContext);
+        assertThat(child.getAgentExecutor()).isSameAs(executor);
+        assertThat(child.isVerbose()).isTrue();
+    }
+
+    @Test
+    void descend_chainedThreeTimes_depthIsThree() {
+        DelegationContext ctx = DelegationContext.create(List.of(agentA), 5, memoryContext, executor, false);
+        DelegationContext three = ctx.descend().descend().descend();
+        assertThat(three.getCurrentDepth()).isEqualTo(3);
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/integration/DelegationEnsembleIntegrationTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/integration/DelegationEnsembleIntegrationTest.java
@@ -1,0 +1,393 @@
+package net.agentensemble.integration;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.memory.EnsembleMemory;
+import net.agentensemble.workflow.Workflow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for agent delegation in both sequential and hierarchical workflows.
+ *
+ * Exercises the full path: Ensemble -> WorkflowExecutor -> AgentExecutor ->
+ * AgentDelegationTool -> AgentExecutor (for delegated agent).
+ */
+class DelegationEnsembleIntegrationTest {
+
+    private ChatModel researcherModel;
+    private ChatModel writerModel;
+    private ChatModel analystModel;
+    private Agent researcher;
+    private Agent writer;
+    private Agent analyst;
+
+    @BeforeEach
+    void setUp() {
+        researcherModel = mock(ChatModel.class);
+        writerModel = mock(ChatModel.class);
+        analystModel = mock(ChatModel.class);
+
+        researcher = Agent.builder()
+                .role("Researcher")
+                .goal("Research topics thoroughly")
+                .llm(researcherModel)
+                .allowDelegation(true)
+                .build();
+
+        writer = Agent.builder()
+                .role("Writer")
+                .goal("Write engaging content")
+                .llm(writerModel)
+                .build();
+
+        analyst = Agent.builder()
+                .role("Data Analyst")
+                .goal("Analyse data and produce insights")
+                .llm(analystModel)
+                .build();
+    }
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(text))
+                .build();
+    }
+
+    private ChatResponse delegationCallResponse(String agentRole, String taskDescription) {
+        ToolExecutionRequest req = ToolExecutionRequest.builder()
+                .id("del-1")
+                .name("delegate")
+                .arguments("{\"agentRole\": \"" + agentRole + "\", "
+                        + "\"taskDescription\": \"" + taskDescription + "\"}")
+                .build();
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(req))
+                .build();
+    }
+
+    // ========================
+    // Sequential workflow -- agent with allowDelegation=false (no tool injected)
+    // ========================
+
+    @Test
+    void sequential_agentWithAllowDelegationFalse_noDelegationToolInjected() {
+        Agent nonDelegatingAgent = Agent.builder()
+                .role("Researcher")
+                .goal("Research only")
+                .llm(researcherModel)
+                .allowDelegation(false)
+                .build();
+
+        Task task = Task.builder()
+                .description("Research AI trends")
+                .expectedOutput("A summary")
+                .agent(nonDelegatingAgent)
+                .build();
+
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("research result"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(nonDelegatingAgent)
+                .task(task)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("research result");
+    }
+
+    // ========================
+    // Sequential workflow -- agent delegates to peer
+    // ========================
+
+    @Test
+    void sequential_agentDelegatesToPeer_peerOutputReturnedAsTool() {
+        Task researchTask = Task.builder()
+                .description("Research AI trends and delegate writing to the Writer")
+                .expectedOutput("A comprehensive blog post")
+                .agent(researcher)
+                .build();
+
+        // Researcher first calls the delegate tool, then returns final answer
+        when(researcherModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("Writer", "Write a blog post about AI trends"))
+                .thenReturn(textResponse("Blog post complete"));
+
+        // Writer produces the delegated output
+        when(writerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Excellent blog post about AI"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .agent(writer)
+                .task(researchTask)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Blog post complete");
+    }
+
+    // ========================
+    // Sequential workflow -- delegation depth limit
+    // ========================
+
+    @Test
+    void sequential_delegationDepthLimitOf1_preventsChainingDelegation() {
+        Agent delegatingWriter = Agent.builder()
+                .role("Writer")
+                .goal("Write content")
+                .llm(writerModel)
+                .allowDelegation(true)
+                .build();
+
+        Task researchTask = Task.builder()
+                .description("Research and produce a report by delegating")
+                .expectedOutput("A report")
+                .agent(researcher)
+                .build();
+
+        // With maxDelegationDepth=1, researcher can delegate (depth 0->1)
+        // but if the writer also tries to delegate, it is blocked (depth 1 = max)
+        when(researcherModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("Writer", "Write the report"))
+                .thenReturn(textResponse("Final output from researcher"));
+
+        // Writer tries to delegate to analyst but will be blocked
+        when(writerModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("Data Analyst", "Analyse the data"))
+                .thenReturn(textResponse("Writer final output"));
+
+        // Analyst model should not be called
+        when(analystModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Analyst output"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .agent(delegatingWriter)
+                .agent(analyst)
+                .task(researchTask)
+                .maxDelegationDepth(1)
+                .build()
+                .run();
+
+        // The ensemble completes; the important thing is depth limit was enforced
+        assertThat(output.getRaw()).isEqualTo("Final output from researcher");
+    }
+
+    // ========================
+    // Sequential workflow -- unknown agent delegation
+    // ========================
+
+    @Test
+    void sequential_delegationToUnknownAgent_returnsErrorToCallerAgentAsToolResult() {
+        Task task = Task.builder()
+                .description("Research topics with possible delegation")
+                .expectedOutput("A result")
+                .agent(researcher)
+                .build();
+
+        // Researcher tries to delegate to a non-existent agent, gets error back, then answers
+        when(researcherModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("NonExistentAgent", "Some task"))
+                .thenReturn(textResponse("Researcher handled it directly"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .agent(writer)
+                .task(task)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Researcher handled it directly");
+    }
+
+    // ========================
+    // Sequential workflow -- self-delegation guard
+    // ========================
+
+    @Test
+    void sequential_selfDelegation_returnsErrorToCallerAgent() {
+        Task task = Task.builder()
+                .description("Research and self-delegate")
+                .expectedOutput("A result")
+                .agent(researcher)
+                .build();
+
+        // Researcher tries to delegate to itself -- gets error, then provides direct answer
+        when(researcherModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("Researcher", "Do this myself"))
+                .thenReturn(textResponse("Researcher completed without delegation"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .agent(writer)
+                .task(task)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Researcher completed without delegation");
+    }
+
+    // ========================
+    // Sequential workflow -- delegation with memory
+    // ========================
+
+    @Test
+    void sequential_delegationWithShortTermMemory_memoryContextThreadedThrough() {
+        Task task = Task.builder()
+                .description("Research and delegate")
+                .expectedOutput("Result with memory")
+                .agent(researcher)
+                .build();
+
+        when(researcherModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("Writer", "Write with full context"))
+                .thenReturn(textResponse("Researcher final with memory"));
+
+        when(writerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Writer result"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(researcher)
+                .agent(writer)
+                .task(task)
+                .memory(EnsembleMemory.builder().shortTerm(true).build())
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Researcher final with memory");
+    }
+
+    // ========================
+    // Sequential workflow -- maxDelegationDepth validated
+    // ========================
+
+    @Test
+    void sequential_maxDelegationDepthDefault_isThree() {
+        Task task = Task.builder()
+                .description("Research topics")
+                .expectedOutput("Summary")
+                .agent(researcher)
+                .build();
+
+        when(researcherModel.chat(any(ChatRequest.class))).thenReturn(textResponse("result"));
+
+        Ensemble ensemble = Ensemble.builder()
+                .agent(researcher)
+                .task(task)
+                .build();
+
+        assertThat(ensemble.getMaxDelegationDepth()).isEqualTo(3);
+    }
+
+    @Test
+    void sequential_customMaxDelegationDepth_isRespected() {
+        Task task = Task.builder()
+                .description("Research topics")
+                .expectedOutput("Summary")
+                .agent(researcher)
+                .build();
+
+        Ensemble ensemble = Ensemble.builder()
+                .agent(researcher)
+                .task(task)
+                .maxDelegationDepth(5)
+                .build();
+
+        assertThat(ensemble.getMaxDelegationDepth()).isEqualTo(5);
+    }
+
+    // ========================
+    // Sequential workflow -- backward compatibility
+    // ========================
+
+    @Test
+    void sequential_agentWithoutDelegation_backwardCompatible() {
+        Agent plainAgent = Agent.builder()
+                .role("Analyst")
+                .goal("Analyse")
+                .llm(analystModel)
+                .build();
+
+        Task task = Task.builder()
+                .description("Analyse data")
+                .expectedOutput("Insights")
+                .agent(plainAgent)
+                .build();
+
+        when(analystModel.chat(any(ChatRequest.class))).thenReturn(textResponse("analysis result"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(plainAgent)
+                .task(task)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("analysis result");
+    }
+
+    // ========================
+    // Hierarchical workflow -- delegation within hierarchical
+    // ========================
+
+    @Test
+    void hierarchical_workerWithAllowDelegation_canDelegateToPeer() {
+        ChatModel managerModel = mock(ChatModel.class);
+
+        Agent delegatingWorker = Agent.builder()
+                .role("Lead Researcher")
+                .goal("Coordinate research by delegating")
+                .llm(researcherModel)
+                .allowDelegation(true)
+                .build();
+
+        Task task = Task.builder()
+                .description("Research and produce analysis")
+                .expectedOutput("Comprehensive result")
+                .agent(delegatingWorker)
+                .build();
+
+        // Manager calls delegateTask to worker
+        ToolExecutionRequest managerDelegation = ToolExecutionRequest.builder()
+                .id("mgr-1")
+                .name("delegateTask")
+                .arguments("{\"agentRole\": \"Lead Researcher\", "
+                        + "\"taskDescription\": \"Research AI trends\"}")
+                .build();
+        when(managerModel.chat(any(ChatRequest.class)))
+                .thenReturn(ChatResponse.builder()
+                        .aiMessage(AiMessage.from(managerDelegation))
+                        .build())
+                .thenReturn(textResponse("Manager synthesized result"));
+
+        // Lead Researcher in turn delegates to Writer
+        when(researcherModel.chat(any(ChatRequest.class)))
+                .thenReturn(delegationCallResponse("Writer", "Write the summary"))
+                .thenReturn(textResponse("Lead researcher final answer"));
+
+        when(writerModel.chat(any(ChatRequest.class))).thenReturn(textResponse("Writer contribution"));
+
+        EnsembleOutput output = Ensemble.builder()
+                .agent(delegatingWorker)
+                .agent(writer)
+                .task(task)
+                .workflow(Workflow.HIERARCHICAL)
+                .managerLlm(managerModel)
+                .build()
+                .run();
+
+        assertThat(output.getRaw()).isEqualTo("Manager synthesized result");
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/workflow/DelegateTaskToolTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/workflow/DelegateTaskToolTest.java
@@ -6,6 +6,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import net.agentensemble.Agent;
 import net.agentensemble.agent.AgentExecutor;
+import net.agentensemble.delegation.DelegationContext;
 import net.agentensemble.memory.MemoryContext;
 import net.agentensemble.task.TaskOutput;
 import net.agentensemble.tool.LangChain4jToolAdapter;
@@ -36,8 +37,12 @@ class DelegateTaskToolTest {
                 .llm(researcherModel).build();
         writer = Agent.builder().role("Writer").goal("Write content")
                 .llm(writerModel).build();
-        tool = new DelegateTaskTool(List.of(researcher, writer), new AgentExecutor(), false,
-                MemoryContext.disabled());
+
+        AgentExecutor executor = new AgentExecutor();
+        DelegationContext delegationContext = DelegationContext.create(
+                List.of(researcher, writer), 3, MemoryContext.disabled(), executor, false);
+        tool = new DelegateTaskTool(List.of(researcher, writer), executor, false,
+                MemoryContext.disabled(), delegationContext);
     }
 
     private ChatResponse textResponse(String text) {

--- a/agentensemble-core/src/test/java/net/agentensemble/workflow/HierarchicalWorkflowExecutorTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/workflow/HierarchicalWorkflowExecutorTest.java
@@ -32,7 +32,7 @@ class HierarchicalWorkflowExecutorTest {
         workerModel = mock(ChatModel.class);
         worker = Agent.builder().role("Researcher").goal("Research topics")
                 .llm(workerModel).build();
-        executor = new HierarchicalWorkflowExecutor(managerModel, List.of(worker), 20);
+        executor = new HierarchicalWorkflowExecutor(managerModel, List.of(worker), 20, 3);
     }
 
     private ChatResponse textResponse(String text) {
@@ -168,7 +168,7 @@ class HierarchicalWorkflowExecutorTest {
 
         Agent writer = Agent.builder().role("Writer").goal("Write content")
                 .llm(workerModel).build();
-        executor = new HierarchicalWorkflowExecutor(managerModel, List.of(worker, writer), 20);
+        executor = new HierarchicalWorkflowExecutor(managerModel, List.of(worker, writer), 20, 3);
 
         Task task1 = researchTask();
         Task task2 = Task.builder().description("Write the report").expectedOutput("A report")

--- a/docs/examples/hierarchical-team.md
+++ b/docs/examples/hierarchical-team.md
@@ -1,0 +1,159 @@
+# Example: Hierarchical Team
+
+A hierarchical workflow where a Manager agent coordinates a team of specialists. The manager receives the task list, decides which worker handles each task, and synthesizes a final result.
+
+---
+
+## What It Does
+
+A product analysis team where a Manager coordinates:
+- **Market Researcher** -- analyses market trends and competitive landscape
+- **Financial Analyst** -- reviews financial metrics and projections
+- **Report Writer** -- synthesises findings into an executive report
+
+The Manager decides task assignment and ordering at run time based on agent roles and goals.
+
+---
+
+## Full Code
+
+```java
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import net.agentensemble.*;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.task.TaskOutput;
+import net.agentensemble.workflow.Workflow;
+
+import java.util.Map;
+
+public class HierarchicalTeamExample {
+
+    public static void main(String[] args) {
+        String company = args.length > 0 ? args[0] : "Acme Corp";
+
+        var fastModel = OpenAiChatModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName("gpt-4o-mini")
+            .build();
+
+        var powerfulModel = OpenAiChatModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName("gpt-4o")  // stronger model for the manager
+            .build();
+
+        // Worker agents
+        var marketResearcher = Agent.builder()
+            .role("Market Research Analyst")
+            .goal("Analyse market trends, competitive dynamics, and growth opportunities")
+            .background("You specialise in technology sector market research. " +
+                        "You provide concise, evidence-based insights.")
+            .llm(fastModel)
+            .build();
+
+        var financialAnalyst = Agent.builder()
+            .role("Financial Analyst")
+            .goal("Analyse financial performance, metrics, and investment implications")
+            .background("You are a CFA charter holder with 10 years of equity research experience. " +
+                        "You focus on publicly available financial data.")
+            .llm(fastModel)
+            .build();
+
+        var reportWriter = Agent.builder()
+            .role("Executive Report Writer")
+            .goal("Transform complex analysis into clear, compelling executive reports")
+            .background("You write board-level reports. You use clear language, structured sections, " +
+                        "and evidence-based conclusions.")
+            .llm(fastModel)
+            .build();
+
+        // Tasks -- the manager will decide which agent handles each
+        var marketTask = Task.builder()
+            .description("Analyse {company}'s current market position and competitive landscape")
+            .expectedOutput("A market analysis covering: market share, top three competitors, " +
+                            "key differentiators, and two to three growth opportunities")
+            .agent(marketResearcher)
+            .build();
+
+        var financialTask = Task.builder()
+            .description("Review {company}'s financial health and key performance indicators")
+            .expectedOutput("A financial summary covering: revenue trend (last 3 years), " +
+                            "profitability metrics, balance sheet strength, and investment thesis")
+            .agent(financialAnalyst)
+            .build();
+
+        var reportTask = Task.builder()
+            .description("Write an executive investment brief for {company} based on market and financial analysis")
+            .expectedOutput("A 600-word executive brief with: company overview, market position, " +
+                            "financial highlights, risks, and investment recommendation")
+            .agent(reportWriter)
+            .build();
+
+        // Hierarchical ensemble -- manager coordinates the team
+        EnsembleOutput output = Ensemble.builder()
+            .agent(marketResearcher)
+            .agent(financialAnalyst)
+            .agent(reportWriter)
+            .task(marketTask)
+            .task(financialTask)
+            .task(reportTask)
+            .workflow(Workflow.HIERARCHICAL)
+            .managerLlm(powerfulModel)
+            .managerMaxIterations(15)
+            .build()
+            .run(Map.of("company", company));
+
+        // The manager's synthesised output
+        System.out.println("EXECUTIVE BRIEF: " + company);
+        System.out.println("=".repeat(60));
+        System.out.println(output.getRaw());
+        System.out.println();
+
+        // Individual worker outputs
+        System.out.println("WORKER OUTPUTS");
+        System.out.println("-".repeat(40));
+        for (int i = 0; i < output.getTaskOutputs().size() - 1; i++) {
+            TaskOutput task = output.getTaskOutputs().get(i);
+            System.out.printf("[%s]%n%s%n%n", task.getAgentRole(), task.getRaw());
+        }
+
+        System.out.printf("Total duration: %s%n", output.getTotalDuration());
+    }
+}
+```
+
+---
+
+## How the Manager Behaves
+
+The Manager receives a prompt describing each worker agent and their capabilities, plus the full task list. It then:
+
+1. Calls `delegateTask("Market Research Analyst", "Analyse Acme Corp's current market position...")`
+2. Receives the market analysis as the tool result
+3. Calls `delegateTask("Financial Analyst", "Review Acme Corp's financial health...")`
+4. Receives the financial analysis
+5. Calls `delegateTask("Executive Report Writer", "Write an executive brief based on: [market and financial analyses]")`
+6. Receives the executive brief
+7. Synthesises a final response incorporating all worker outputs
+
+---
+
+## Notes on Manager LLM Choice
+
+The manager makes routing and synthesis decisions. Using a more capable model (GPT-4o, Claude 3.5 Sonnet) for the manager and a faster model (GPT-4o-mini) for workers is often a cost-effective strategy.
+
+---
+
+## Checking the Output Structure
+
+In hierarchical workflow, `output.getTaskOutputs()` contains:
+1. Worker outputs in delegation order
+2. The manager's final synthesis (last element)
+
+```java
+List<TaskOutput> outputs = output.getTaskOutputs();
+TaskOutput managerOutput = outputs.getLast();
+System.out.println("Manager: " + managerOutput.getAgentRole()); // "Manager"
+
+List<TaskOutput> workerOutputs = outputs.subList(0, outputs.size() - 1);
+workerOutputs.forEach(w -> System.out.println("Worker: " + w.getAgentRole()));
+```

--- a/docs/examples/memory-across-runs.md
+++ b/docs/examples/memory-across-runs.md
@@ -1,0 +1,190 @@
+# Example: Memory Across Runs
+
+Demonstrates how long-term memory persists task outputs across ensemble runs, allowing agents to build on knowledge from previous executions.
+
+---
+
+## What It Does
+
+A competitive intelligence system that runs weekly. Each run produces a market analysis. Long-term memory means that each week's agents can draw on all prior weeks' analyses when formulating their reports.
+
+---
+
+## Setup
+
+This example uses:
+- **Short-term memory** -- agents within a run share outputs automatically
+- **Long-term memory** -- past run outputs are retrieved by semantic similarity
+- **Entity memory** -- stable company facts are available to all agents in every run
+
+---
+
+## Full Code
+
+```java
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
+import net.agentensemble.*;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.memory.*;
+import net.agentensemble.workflow.Workflow;
+
+import java.util.Map;
+
+public class MemoryAcrossRunsExample {
+
+    public static void main(String[] args) throws InterruptedException {
+        var chatModel = OpenAiChatModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName("gpt-4o-mini")
+            .build();
+
+        var embeddingModel = OpenAiEmbeddingModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName("text-embedding-3-small")
+            .build();
+
+        // Use InMemoryEmbeddingStore for demonstration.
+        // In production, use a durable store (Chroma, Qdrant, etc.)
+        // that persists between JVM restarts.
+        EmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        LongTermMemory longTerm = new EmbeddingStoreLongTermMemory(store, embeddingModel);
+
+        // Entity memory: stable facts about the company we are analysing
+        EntityMemory entities = new InMemoryEntityMemory();
+        entities.put("TechCorp", "A publicly traded software company (ticker: TECH) " +
+                                  "specialising in cloud infrastructure tools. " +
+                                  "Founded 2012. Headquarters: Austin, TX.");
+        entities.put("TechCorp CEO", "Sarah Mitchell. Joined as CEO in 2019 from AWS.");
+
+        // Memory configuration shared across all runs
+        EnsembleMemory memory = EnsembleMemory.builder()
+            .shortTerm(true)
+            .longTerm(longTerm)
+            .entityMemory(entities)
+            .longTermMaxResults(3)
+            .build();
+
+        // Agent definitions (reused across runs)
+        var analyst = Agent.builder()
+            .role("Market Intelligence Analyst")
+            .goal("Track market developments, competitive movements, and industry trends for TechCorp")
+            .background("You produce weekly intelligence briefings. You draw on historical context " +
+                        "from prior analyses to identify trends and changes over time.")
+            .llm(chatModel)
+            .build();
+
+        var strategist = Agent.builder()
+            .role("Strategic Advisor")
+            .goal("Translate market intelligence into strategic recommendations for TechCorp")
+            .background("You provide actionable strategic recommendations grounded in both " +
+                        "current data and historical context.")
+            .llm(chatModel)
+            .build();
+
+        // Create the ensemble once and reuse it
+        var analysisTask = Task.builder()
+            .description("Analyse TechCorp's competitive environment for week of {week}. " +
+                         "Draw on any relevant historical context from long-term memory.")
+            .expectedOutput("A 300-word competitive intelligence briefing for the week of {week}")
+            .agent(analyst)
+            .build();
+
+        var recommendationTask = Task.builder()
+            .description("Provide strategic recommendations for TechCorp based on the week of {week} analysis")
+            .expectedOutput("Three specific, actionable strategic recommendations with supporting rationale")
+            .agent(strategist)
+            .build();
+
+        Ensemble ensemble = Ensemble.builder()
+            .agent(analyst)
+            .agent(strategist)
+            .task(analysisTask)
+            .task(recommendationTask)
+            .workflow(Workflow.SEQUENTIAL)
+            .memory(memory)
+            .build();
+
+        // Run 1: Week 1
+        System.out.println("=== RUN 1: WEEK 1 ===");
+        EnsembleOutput run1 = ensemble.run(Map.of("week", "2026-01-06"));
+        System.out.println(run1.getRaw());
+        System.out.printf("Duration: %s%n%n", run1.getTotalDuration());
+
+        // Run 2: Week 2 -- long-term memory now contains Week 1 outputs
+        System.out.println("=== RUN 2: WEEK 2 ===");
+        EnsembleOutput run2 = ensemble.run(Map.of("week", "2026-01-13"));
+        System.out.println(run2.getRaw());
+        System.out.printf("Duration: %s%n%n", run2.getTotalDuration());
+
+        // Run 3: Week 3 -- agents have access to both prior weeks
+        System.out.println("=== RUN 3: WEEK 3 ===");
+        EnsembleOutput run3 = ensemble.run(Map.of("week", "2026-01-20"));
+        System.out.println(run3.getRaw());
+        System.out.printf("Duration: %s%n", run3.getTotalDuration());
+    }
+}
+```
+
+---
+
+## How Memory Builds Over Time
+
+After Run 1:
+- Long-term memory contains the Week 1 analyst briefing and the Week 1 strategic recommendations
+
+In Run 2:
+- Before the analyst task runs, the framework queries the store with "Analyse TechCorp's competitive environment for week of 2026-01-13"
+- The Week 1 briefing is retrieved (high semantic similarity) and injected into the analyst's prompt
+- The analyst can reference prior context in its Week 2 analysis
+
+After Run 3:
+- The strategist has access to memories from both prior weeks
+- Trend detection, trajectory analysis, and context-aware recommendations become possible
+
+---
+
+## Using a Durable Store in Production
+
+For real persistence across JVM restarts, swap `InMemoryEmbeddingStore` for a durable implementation:
+
+```java
+// Chroma (local or cloud)
+EmbeddingStore<TextSegment> store = ChromaEmbeddingStore.builder()
+    .baseUrl("http://localhost:8000")
+    .collectionName("techcorp-intelligence")
+    .build();
+
+// Qdrant
+EmbeddingStore<TextSegment> store = QdrantEmbeddingStore.builder()
+    .host("localhost")
+    .port(6334)
+    .collectionName("techcorp-intelligence")
+    .build();
+
+// PostgreSQL pgvector
+EmbeddingStore<TextSegment> store = PgVectorEmbeddingStore.builder()
+    .datasource(dataSource)
+    .table("agentensemble_memories")
+    .dimension(1536)  // for text-embedding-3-small
+    .build();
+```
+
+The `LongTermMemory` and `EnsembleMemory` configuration stays the same.
+
+---
+
+## Updating Entity Facts
+
+Entity facts can be updated between runs as new information becomes available:
+
+```java
+entities.put("TechCorp CEO", "Alex Johnson. Appointed CEO in January 2026 following Sarah Mitchell's departure.");
+
+// Next run will use the updated fact in all agent prompts
+ensemble.run(Map.of("week", "2026-01-27"));
+```

--- a/docs/examples/research-writer.md
+++ b/docs/examples/research-writer.md
@@ -1,0 +1,165 @@
+# Example: Research and Writer Pipeline
+
+A classic two-agent sequential workflow where a researcher gathers information and a writer turns it into a blog post. This is the same pattern used by the included `ResearchWriterExample` application.
+
+---
+
+## What It Does
+
+1. **Researcher** receives a topic and produces a structured research summary
+2. **Writer** receives the topic and the researcher's summary, and produces a polished blog post
+
+---
+
+## Full Code
+
+```java
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import net.agentensemble.*;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.task.TaskOutput;
+import net.agentensemble.workflow.Workflow;
+
+import java.util.List;
+import java.util.Map;
+
+public class ResearchWriterExample {
+
+    public static void main(String[] args) {
+        String topic = args.length > 0 ? String.join(" ", args) : "AI agents in enterprise software";
+
+        var model = OpenAiChatModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName("gpt-4o-mini")
+            .build();
+
+        // 1. Define agents
+        var researcher = Agent.builder()
+            .role("Senior Research Analyst")
+            .goal("Find accurate, well-structured information on any given topic")
+            .background("You are a veteran researcher with expertise in technology and business. " +
+                        "You write concise, factual summaries backed by evidence.")
+            .llm(model)
+            .build();
+
+        var writer = Agent.builder()
+            .role("Content Writer")
+            .goal("Write engaging, well-structured blog posts from research material")
+            .background("You are an experienced technology writer. You translate complex research " +
+                        "into clear, engaging prose for a professional audience.")
+            .llm(model)
+            .responseFormat("Use markdown with clear headings (##) and bullet points where appropriate.")
+            .build();
+
+        // 2. Define tasks
+        var researchTask = Task.builder()
+            .description("Research the latest developments in {topic}. " +
+                         "Cover current state, key players, recent breakthroughs, and near-term outlook.")
+            .expectedOutput("A 400-500 word structured summary with clear sections: " +
+                            "Current State, Key Players, Recent Developments, and Outlook.")
+            .agent(researcher)
+            .build();
+
+        var writeTask = Task.builder()
+            .description("Write a professional blog post about {topic} based on the provided research.")
+            .expectedOutput("A 600-800 word blog post in markdown format. Include: an engaging title, " +
+                            "an introduction, three main sections with subheadings, and a conclusion.")
+            .agent(writer)
+            .context(List.of(researchTask))  // writer receives the researcher's output
+            .build();
+
+        // 3. Build and run the ensemble
+        EnsembleOutput output = Ensemble.builder()
+            .agent(researcher)
+            .agent(writer)
+            .task(researchTask)
+            .task(writeTask)
+            .workflow(Workflow.SEQUENTIAL)
+            .build()
+            .run(Map.of("topic", topic));
+
+        // 4. Display results
+        System.out.println("=".repeat(60));
+        System.out.println("FINAL BLOG POST");
+        System.out.println("=".repeat(60));
+        System.out.println(output.getRaw());
+        System.out.println();
+        System.out.printf("Completed in %s | Total tool calls: %d%n",
+            output.getTotalDuration(), output.getTotalToolCalls());
+    }
+}
+```
+
+---
+
+## Running the Included Example
+
+```bash
+git clone https://github.com/AgentEnsemble/agentensemble.git
+cd agentensemble
+export OPENAI_API_KEY=your-api-key
+
+# Default topic (AI agents in enterprise software)
+./gradlew :agentensemble-examples:run
+
+# Custom topic
+./gradlew :agentensemble-examples:run --args="quantum computing applications in finance"
+```
+
+---
+
+## Variations
+
+### Adding Web Search
+
+Give the researcher a web search tool to find current information:
+
+```java
+var researcher = Agent.builder()
+    .role("Senior Research Analyst")
+    .goal("Find accurate, current information using web search")
+    .llm(model)
+    .tools(List.of(new WebSearchTool(searchClient)))
+    .maxIterations(10)
+    .build();
+```
+
+### Using Memory
+
+Add short-term memory so the writer automatically receives the researcher's output without explicit `context`:
+
+```java
+EnsembleOutput output = Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .task(researchTask)
+    .task(writeTask)  // no context() needed when using shortTerm memory
+    .memory(EnsembleMemory.builder().shortTerm(true).build())
+    .build()
+    .run(Map.of("topic", topic));
+```
+
+### Adding an Editor
+
+Add a third agent to review and polish the blog post:
+
+```java
+var editor = Agent.builder()
+    .role("Senior Editor")
+    .goal("Polish writing for clarity, flow, and accuracy")
+    .llm(model)
+    .build();
+
+var editTask = Task.builder()
+    .description("Review and polish the blog post about {topic}")
+    .expectedOutput("The polished blog post with any corrections and improvements applied")
+    .agent(editor)
+    .context(List.of(writeTask))
+    .build();
+
+Ensemble.builder()
+    .agent(researcher).agent(writer).agent(editor)
+    .task(researchTask).task(writeTask).task(editTask)
+    .build()
+    .run(Map.of("topic", topic));
+```

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,0 +1,100 @@
+# Core Concepts
+
+Understanding these six concepts is sufficient to build any ensemble.
+
+---
+
+## Agent
+
+An **Agent** is an AI entity with a defined role, goal, and optionally a set of tools. When assigned a task, an agent uses its configured LLM to reason and produce an output. Agents can be given tools (such as web search or a calculator) to help them complete their work.
+
+Key properties:
+- **role**: The agent's title, used in prompts and logs. Example: `"Senior Research Analyst"`.
+- **goal**: The agent's primary objective, included in the system prompt. Example: `"Uncover accurate, well-sourced information"`.
+- **background**: Optional persona context. Example: `"You have 10 years experience in technology journalism"`.
+- **tools**: Optional list of tool objects the agent can call during execution.
+- **allowDelegation**: When `true`, the agent can delegate subtasks to other agents in the ensemble.
+
+See the [Agent Configuration reference](../reference/agent-configuration.md) for all fields.
+
+---
+
+## Task
+
+A **Task** is a unit of work assigned to one agent. It has a description of what to do and an expected output describing what the result should look like. Task descriptions support `{variable}` placeholders that are resolved at run time.
+
+Key properties:
+- **description**: What the agent should do. May contain `{variable}` templates.
+- **expectedOutput**: What the output should look like (quality guidance for the agent).
+- **agent**: The agent assigned to execute this task.
+- **context**: Other tasks whose outputs should be fed into this task as prior context.
+
+See the [Task Configuration reference](../reference/task-configuration.md).
+
+---
+
+## Ensemble
+
+An **Ensemble** is the top-level orchestrator. It groups agents and tasks, manages execution, handles template variable resolution, creates memory contexts, and returns the combined output. You call `ensemble.run()` or `ensemble.run(Map<String, String> inputs)` to execute.
+
+Key responsibilities:
+- Validates that all tasks reference registered agents
+- Resolves `{variable}` placeholders in task descriptions and expected outputs
+- Creates a `MemoryContext` for the run when memory is configured
+- Selects and runs the correct `WorkflowExecutor`
+- Returns an `EnsembleOutput` with all task results
+
+See the [Ensemble Configuration reference](../reference/ensemble-configuration.md).
+
+---
+
+## Workflow
+
+A **Workflow** is the execution strategy used by the ensemble. There are two strategies:
+
+### SEQUENTIAL (default)
+
+Tasks run one after another in list order. Each task can declare `context` dependencies on prior tasks; those outputs are injected into the dependent agent's prompt.
+
+```
+Task 1 -> Task 2 -> Task 3 (uses output of Task 1 and Task 2)
+```
+
+### HIERARCHICAL
+
+A virtual Manager agent is automatically created. The manager receives the full task list and the capabilities of all worker agents. It uses a `delegateTask` tool to assign tasks to workers and then synthesizes a final result from their outputs.
+
+```
+Manager -> delegates -> Worker A
+        -> delegates -> Worker B
+        -> synthesizes final output
+```
+
+See the [Workflows guide](../guides/workflows.md).
+
+---
+
+## Memory
+
+**Memory** lets agents share and persist context across tasks and ensemble runs. Three types are available:
+
+- **Short-term memory**: Within a single `run()` call, all task outputs are accumulated and injected into subsequent agents' prompts. This removes the need to declare explicit `context` dependencies.
+- **Long-term memory**: Task outputs are stored in a vector store after each run. Before each task, relevant past memories are retrieved by semantic similarity and injected into the agent's prompt.
+- **Entity memory**: A user-populated key-value store of known facts about named entities (people, companies, concepts, etc.). All stored facts are injected into every agent's prompt.
+
+Memory is optional and configured via `EnsembleMemory` on the ensemble builder.
+
+See the [Memory guide](../guides/memory.md).
+
+---
+
+## Delegation
+
+**Delegation** allows agents to hand off subtasks to other agents during execution. When an agent has `allowDelegation = true`, a `delegate` tool is automatically injected into its tool list. The agent can call this tool with a target agent role and a task description, and the framework pauses the caller, executes the subtask with the target agent, and returns the result.
+
+Guards prevent:
+- An agent from delegating to itself
+- Delegation to an unknown agent role
+- Infinite delegation chains (configurable `maxDelegationDepth`, default 3)
+
+See the [Delegation guide](../guides/delegation.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,128 @@
+# Installation
+
+## Requirements
+
+- Java 21 or later
+- Gradle or Maven build tool
+- A LangChain4j-supported LLM provider (OpenAI, Anthropic, Ollama, etc.)
+
+---
+
+## Add the Dependency
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/AgentEnsemble/agentensemble")
+        credentials {
+            username = System.getenv("GITHUB_ACTOR")
+            password = System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation("net.agentensemble:agentensemble-core:0.4.0")
+
+    // Add the LangChain4j integration for your LLM provider:
+    implementation("dev.langchain4j:langchain4j-open-ai:1.11.0")
+}
+```
+
+### Gradle (Groovy DSL)
+
+```groovy
+repositories {
+    maven {
+        url 'https://maven.pkg.github.com/AgentEnsemble/agentensemble'
+        credentials {
+            username System.getenv('GITHUB_ACTOR')
+            password System.getenv('GITHUB_TOKEN')
+        }
+    }
+}
+
+dependencies {
+    implementation 'net.agentensemble:agentensemble-core:0.4.0'
+    implementation 'dev.langchain4j:langchain4j-open-ai:1.11.0'
+}
+```
+
+### Maven
+
+```xml
+<repositories>
+    <repository>
+        <id>agentensemble-github</id>
+        <url>https://maven.pkg.github.com/AgentEnsemble/agentensemble</url>
+    </repository>
+</repositories>
+
+<dependencies>
+    <dependency>
+        <groupId>net.agentensemble</groupId>
+        <artifactId>agentensemble-core</artifactId>
+        <version>0.4.0</version>
+    </dependency>
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-open-ai</artifactId>
+        <version>1.11.0</version>
+    </dependency>
+</dependencies>
+```
+
+---
+
+## GitHub Packages Authentication
+
+AgentEnsemble is published to GitHub Packages. Authentication is required to download packages from GitHub Packages, even for public repositories.
+
+**Set environment variables:**
+
+```bash
+export GITHUB_ACTOR=your-github-username
+export GITHUB_TOKEN=your-personal-access-token
+```
+
+Your personal access token needs the `read:packages` scope. Create one at: **GitHub Settings > Developer Settings > Personal Access Tokens**.
+
+---
+
+## Supported LLM Providers
+
+AgentEnsemble uses the LangChain4j `ChatModel` interface and works with any provider that implements it:
+
+| Provider | LangChain4j Artifact |
+|---|---|
+| OpenAI (GPT-4o, GPT-4o-mini, etc.) | `langchain4j-open-ai` |
+| Anthropic (Claude 3.5, Claude 3 Haiku, etc.) | `langchain4j-anthropic` |
+| Ollama (local models) | `langchain4j-ollama` |
+| Azure OpenAI | `langchain4j-azure-open-ai` |
+| Amazon Bedrock | `langchain4j-bedrock` |
+| Google Vertex AI | `langchain4j-vertex-ai-gemini` |
+| Mistral AI | `langchain4j-mistral-ai` |
+
+For a full list, see the [LangChain4j documentation](https://docs.langchain4j.dev).
+
+---
+
+## Logging
+
+AgentEnsemble uses SLF4J for logging. Add your preferred implementation:
+
+```kotlin
+// Logback (recommended)
+implementation("ch.qos.logback:logback-classic:1.5.12")
+```
+
+See the [Logging guide](../guides/logging.md) for configuration details.
+
+---
+
+## Next Steps
+
+- [Quickstart](quickstart.md) -- Build your first ensemble
+- [Core Concepts](concepts.md) -- Understand the key abstractions

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,205 @@
+# Quickstart
+
+Build your first multi-agent ensemble in five minutes.
+
+---
+
+## 1. Set Up Your Project
+
+Add the dependencies (see [Installation](installation.md)):
+
+```kotlin
+dependencies {
+    implementation("net.agentensemble:agentensemble-core:0.4.0")
+    implementation("dev.langchain4j:langchain4j-open-ai:1.11.0")
+    implementation("ch.qos.logback:logback-classic:1.5.12")
+}
+```
+
+---
+
+## 2. Create a Model
+
+```java
+import dev.langchain4j.model.openai.OpenAiChatModel;
+
+var model = OpenAiChatModel.builder()
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .modelName("gpt-4o-mini")
+    .build();
+```
+
+---
+
+## 3. Define Your Agents
+
+Each agent has a role, a goal, and an LLM:
+
+```java
+import net.agentensemble.Agent;
+
+var researcher = Agent.builder()
+    .role("Senior Research Analyst")
+    .goal("Find accurate, well-structured information on any given topic")
+    .background("You are a veteran researcher with expertise in technology.")
+    .llm(model)
+    .build();
+
+var writer = Agent.builder()
+    .role("Content Writer")
+    .goal("Write engaging, well-structured blog posts")
+    .llm(model)
+    .responseFormat("Use markdown with clear headings and sections.")
+    .build();
+```
+
+---
+
+## 4. Define Your Tasks
+
+Each task describes work for one agent:
+
+```java
+import net.agentensemble.Task;
+
+var researchTask = Task.builder()
+    .description("Research the latest developments in {topic}")
+    .expectedOutput("A 400-word summary covering current state, key players, and future outlook")
+    .agent(researcher)
+    .build();
+
+var writeTask = Task.builder()
+    .description("Write a blog post about {topic} based on the provided research")
+    .expectedOutput("A 600-800 word blog post in markdown format, ready to publish")
+    .agent(writer)
+    .context(List.of(researchTask))  // the writer receives the researcher's output
+    .build();
+```
+
+---
+
+## 5. Run the Ensemble
+
+```java
+import net.agentensemble.Ensemble;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.workflow.Workflow;
+
+EnsembleOutput output = Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .task(researchTask)
+    .task(writeTask)
+    .workflow(Workflow.SEQUENTIAL)
+    .build()
+    .run(Map.of("topic", "AI agents in 2026"));
+
+System.out.println(output.getRaw());
+```
+
+---
+
+## 6. Explore the Results
+
+```java
+// Final output from the last task
+System.out.println(output.getRaw());
+
+// All task outputs in order
+for (TaskOutput taskOutput : output.getTaskOutputs()) {
+    System.out.printf("[%s] %s%n",
+        taskOutput.getAgentRole(),
+        taskOutput.getRaw().substring(0, Math.min(200, taskOutput.getRaw().length())));
+}
+
+// Execution summary
+System.out.printf("Total duration: %s%n", output.getTotalDuration());
+System.out.printf("Total tool calls: %d%n", output.getTotalToolCalls());
+```
+
+---
+
+## Complete Example
+
+```java
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import net.agentensemble.*;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.task.TaskOutput;
+import net.agentensemble.workflow.Workflow;
+
+import java.util.List;
+import java.util.Map;
+
+public class QuickstartExample {
+
+    public static void main(String[] args) {
+        var model = OpenAiChatModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName("gpt-4o-mini")
+            .build();
+
+        var researcher = Agent.builder()
+            .role("Senior Research Analyst")
+            .goal("Find accurate, well-structured information on any given topic")
+            .llm(model)
+            .build();
+
+        var writer = Agent.builder()
+            .role("Content Writer")
+            .goal("Write engaging, well-structured blog posts")
+            .llm(model)
+            .build();
+
+        var researchTask = Task.builder()
+            .description("Research the latest developments in {topic}")
+            .expectedOutput("A 400-word summary")
+            .agent(researcher)
+            .build();
+
+        var writeTask = Task.builder()
+            .description("Write a blog post about {topic} based on the research")
+            .expectedOutput("A 600-800 word blog post in markdown")
+            .agent(writer)
+            .context(List.of(researchTask))
+            .build();
+
+        EnsembleOutput output = Ensemble.builder()
+            .agent(researcher)
+            .agent(writer)
+            .task(researchTask)
+            .task(writeTask)
+            .workflow(Workflow.SEQUENTIAL)
+            .build()
+            .run(Map.of("topic", "AI agents in 2026"));
+
+        System.out.println(output.getRaw());
+    }
+}
+```
+
+---
+
+## Run the Included Example
+
+The repository includes a complete working example:
+
+```bash
+git clone https://github.com/AgentEnsemble/agentensemble.git
+cd agentensemble
+export OPENAI_API_KEY=your-api-key
+./gradlew :agentensemble-examples:run
+
+# Custom topic:
+./gradlew :agentensemble-examples:run --args="quantum computing"
+```
+
+---
+
+## Next Steps
+
+- [Core Concepts](concepts.md) -- Understand the abstractions
+- [Agents Guide](../guides/agents.md) -- More agent configuration options
+- [Tools Guide](../guides/tools.md) -- Give agents tools to use
+- [Memory Guide](../guides/memory.md) -- Persist context across tasks and runs
+- [Delegation Guide](../guides/delegation.md) -- Let agents delegate to peers

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -1,0 +1,202 @@
+# Agents
+
+An agent is an AI entity with a defined role and goal. Each agent uses a LangChain4j `ChatModel` to reason and produce outputs. Agents are immutable value objects built via a fluent builder.
+
+---
+
+## Creating an Agent
+
+```java
+Agent researcher = Agent.builder()
+    .role("Senior Research Analyst")
+    .goal("Find accurate, well-structured information on any given topic")
+    .background("You are a veteran researcher with 15 years of industry experience.")
+    .llm(model)
+    .build();
+```
+
+The `role`, `goal`, and `llm` fields are required. All other fields are optional.
+
+---
+
+## Role and Goal
+
+The `role` and `goal` fields are the most important parts of the agent identity. They are combined into the system prompt that the agent receives before each task.
+
+- **role**: The agent's title. Keep it concise and descriptive. Example: `"Data Scientist"`, `"Legal Reviewer"`, `"Code Reviewer"`.
+- **goal**: The agent's primary objective. Write this as a directive. Example: `"Analyse data and identify statistical patterns"`.
+
+---
+
+## Background
+
+The `background` field adds persona context to the system prompt. Use it to give the agent domain expertise, a specific point of view, or constraints:
+
+```java
+Agent analyst = Agent.builder()
+    .role("Financial Analyst")
+    .goal("Evaluate investment opportunities and risks")
+    .background("You specialise in technology sector equities. Your analysis is always " +
+                "grounded in publicly available data. You never speculate beyond the evidence.")
+    .llm(model)
+    .build();
+```
+
+When `background` is omitted, only role and goal are included in the system prompt.
+
+---
+
+## Tools
+
+Agents can be equipped with tools that they call during their ReAct-style reasoning loop. There are two ways to provide tools:
+
+### Option 1: Implement `AgentTool`
+
+```java
+public class WebSearchTool implements AgentTool {
+    public String name() { return "web_search"; }
+    public String description() { return "Search the web for current information. Input: a search query."; }
+    public ToolResult execute(String input) {
+        String results = performSearch(input);
+        return ToolResult.success(results);
+    }
+}
+
+Agent agent = Agent.builder()
+    .role("Researcher")
+    .goal("Find current information")
+    .tools(List.of(new WebSearchTool()))
+    .llm(model)
+    .build();
+```
+
+### Option 2: LangChain4j `@Tool` Annotation
+
+```java
+public class MathTools {
+    @Tool("Calculate a mathematical expression. Input: an expression like '2 + 3 * 4'.")
+    public double calculate(String expression) {
+        return evaluateExpression(expression);
+    }
+
+    @Tool("Convert a temperature from Celsius to Fahrenheit. Input: temperature in Celsius as a number.")
+    public double celsiusToFahrenheit(double celsius) {
+        return celsius * 9.0 / 5.0 + 32;
+    }
+}
+
+Agent agent = Agent.builder()
+    .role("Analyst")
+    .goal("Perform calculations and data conversions")
+    .tools(List.of(new MathTools()))
+    .llm(model)
+    .build();
+```
+
+Both tool types can be combined in the same list:
+
+```java
+Agent agent = Agent.builder()
+    .role("Research Analyst")
+    .goal("Research and calculate")
+    .tools(List.of(new WebSearchTool(), new MathTools()))
+    .llm(model)
+    .build();
+```
+
+See the [Tools guide](tools.md) for more detail.
+
+---
+
+## Verbose Mode
+
+When `verbose = true`, the agent's system prompt, user prompt, and LLM response are logged at INFO level. This is useful for debugging:
+
+```java
+Agent agent = Agent.builder()
+    .role("Researcher")
+    .goal("Research topics")
+    .llm(model)
+    .verbose(true)
+    .build();
+```
+
+Verbose can also be set at the ensemble level, which applies to all agents:
+
+```java
+Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .tasks(...)
+    .verbose(true)
+    .build();
+```
+
+---
+
+## Max Iterations
+
+The `maxIterations` field limits how many tool calls an agent can make before being forced to produce a final answer. The default is 25.
+
+```java
+Agent agent = Agent.builder()
+    .role("Data Analyst")
+    .goal("Analyse datasets")
+    .llm(model)
+    .maxIterations(10)  // stop after 10 tool calls
+    .build();
+```
+
+When the limit is exceeded, the agent receives a stop message asking it to produce a final answer with the information gathered so far. After three stop messages, a `MaxIterationsExceededException` is thrown.
+
+---
+
+## Response Format
+
+Use `responseFormat` to add formatting instructions to the system prompt:
+
+```java
+Agent agent = Agent.builder()
+    .role("Report Writer")
+    .goal("Write structured reports")
+    .llm(model)
+    .responseFormat("Always respond in JSON. Use the schema: {\"title\": string, \"summary\": string, \"recommendations\": [string]}.")
+    .build();
+```
+
+---
+
+## Delegation
+
+When `allowDelegation = true`, the agent has access to a `delegate` tool that it can call to hand off subtasks to other agents in the ensemble:
+
+```java
+Agent leadResearcher = Agent.builder()
+    .role("Lead Researcher")
+    .goal("Coordinate research by delegating specialised subtasks")
+    .llm(model)
+    .allowDelegation(true)
+    .build();
+```
+
+The agent can then call `delegate("Writer", "Write an executive summary based on: ...")` during its reasoning loop.
+
+See the [Delegation guide](delegation.md) for full details.
+
+---
+
+## Agent as a Value Object
+
+Agents are immutable. If you need to create a variant, use `toBuilder()`:
+
+```java
+Agent verboseResearcher = researcher.toBuilder()
+    .verbose(true)
+    .build();
+```
+
+---
+
+## Reference
+
+See the [Agent Configuration reference](../reference/agent-configuration.md) for the complete field table with types and defaults.

--- a/docs/guides/delegation.md
+++ b/docs/guides/delegation.md
@@ -1,0 +1,170 @@
+# Delegation
+
+Agent delegation allows agents to hand off subtasks to other agents in the ensemble during their own task execution. This enables peer-to-peer collaboration without requiring a hierarchical manager.
+
+---
+
+## Overview
+
+When an agent has `allowDelegation = true`, the framework automatically injects a `delegate` tool into its tool list at execution time. The agent can call this tool during its ReAct reasoning loop:
+
+```
+Agent A calls delegate("Agent B", "Write a summary of the research below: ...")
+  -> Framework executes Agent B with the subtask
+  -> Agent B's output is returned to Agent A as the tool result
+Agent A incorporates the result and produces its final answer
+```
+
+---
+
+## Enabling Delegation
+
+Set `allowDelegation = true` on any agent that should be able to delegate:
+
+```java
+Agent leadResearcher = Agent.builder()
+    .role("Lead Researcher")
+    .goal("Coordinate research by identifying and delegating specialised subtasks")
+    .llm(model)
+    .allowDelegation(true)
+    .build();
+
+Agent writer = Agent.builder()
+    .role("Content Writer")
+    .goal("Write clear, engaging content from research notes")
+    .llm(model)
+    .build();  // allowDelegation defaults to false
+```
+
+---
+
+## Basic Example
+
+```java
+var coordinateTask = Task.builder()
+    .description("Research the latest AI developments and produce a well-written summary")
+    .expectedOutput("A polished 800-word blog post covering AI trends")
+    .agent(leadResearcher)
+    .build();
+
+EnsembleOutput output = Ensemble.builder()
+    .agent(leadResearcher)
+    .agent(writer)
+    .task(coordinateTask)
+    .build()
+    .run();
+```
+
+During execution, the `leadResearcher` may decide to call:
+
+```
+delegate("Content Writer", "Write an 800-word blog post about these AI trends: [findings]")
+```
+
+The framework executes the writer, returns the blog post to the researcher, and the researcher incorporates it into its final answer.
+
+---
+
+## Delegation Guards
+
+Three guards are enforced automatically:
+
+### 1. Self-Delegation
+
+An agent cannot delegate to itself. If attempted, the tool returns:
+
+```
+Cannot delegate to yourself (role: 'Lead Researcher'). Choose a different agent.
+```
+
+The calling agent receives this as the tool result and must handle it.
+
+### 2. Unknown Agent
+
+If the specified role does not match any registered agent (case-insensitive), the tool returns:
+
+```
+Agent not found with role 'Data Scientist'. Available roles: [Lead Researcher, Content Writer]
+```
+
+### 3. Depth Limit
+
+Delegation chains are limited to prevent infinite recursion. When the limit is reached, the tool returns:
+
+```
+Delegation depth limit reached (max: 3, current: 3). Complete this task yourself without further delegation.
+```
+
+---
+
+## Delegation Depth
+
+The `maxDelegationDepth` field on the ensemble controls how many delegation levels are permitted. The default is 3.
+
+```java
+Ensemble.builder()
+    .agent(researchCoordinator)
+    .agent(researcher)
+    .agent(writer)
+    .task(task)
+    .maxDelegationDepth(2)   // A can delegate to B, B can delegate to C, but C cannot delegate further
+    .build();
+```
+
+Set `maxDelegationDepth(1)` to allow only one level of delegation (A delegates to B, but B cannot delegate).
+
+---
+
+## Delegation in Hierarchical Workflow
+
+In hierarchical workflow, the Manager agent delegates tasks to workers using the `delegateTask` tool. This is separate from peer delegation. Worker agents can also delegate to each other (if `allowDelegation = true`) in addition to the manager's own delegation.
+
+```java
+Ensemble.builder()
+    .agent(leadResearcher)     // allowDelegation = true
+    .agent(dataAnalyst)
+    .agent(writer)
+    .task(task1)
+    .task(task2)
+    .workflow(Workflow.HIERARCHICAL)
+    .managerLlm(managerModel)
+    .maxDelegationDepth(2)    // applies to worker-to-worker delegation
+    .build();
+```
+
+---
+
+## Delegation and Memory
+
+When memory is configured, the delegation tool passes the same `MemoryContext` to the delegated agent. This means:
+
+- The delegated agent can read from short-term memory (prior task outputs in the run)
+- The delegated agent's output is recorded into memory
+- Long-term and entity memory are available to all delegated agents
+
+---
+
+## MDC Logging
+
+When delegation occurs, two MDC keys are set for the duration of the delegated execution:
+
+| Key | Example Value |
+|---|---|
+| `delegation.depth` | `"1"` |
+| `delegation.parent` | `"Lead Researcher"` |
+
+This allows log aggregation tools to show the full parent-child delegation chain.
+
+---
+
+## Delegation vs. Hierarchical Workflow
+
+| | Peer Delegation | Hierarchical Workflow |
+|---|---|---|
+| Initiator | Any agent with `allowDelegation = true` | Automatic Manager agent |
+| Trigger | Agent decides during reasoning | Manager tool call |
+| Routing | Agent chooses who to delegate to | Manager decides |
+| Configuration | `agent.allowDelegation(true)` | `workflow(Workflow.HIERARCHICAL)` |
+| Depth limit | `ensemble.maxDelegationDepth(n)` | `managerMaxIterations` |
+
+Both can be used together: hierarchical workflow with worker agents that also support peer delegation.

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,0 +1,168 @@
+# Error Handling
+
+AgentEnsemble uses a hierarchy of unchecked exceptions. All exceptions extend `AgentEnsembleException`, making it easy to catch any framework exception with a single catch block or handle specific cases individually.
+
+---
+
+## Exception Hierarchy
+
+```
+AgentEnsembleException (base)
+  ValidationException          -- invalid configuration at build/run time
+  TaskExecutionException       -- a task failed during execution
+  AgentExecutionException      -- an LLM call failed
+  MaxIterationsExceededException  -- agent exceeded its tool-call limit
+  PromptTemplateException      -- unresolved template variables
+  ToolExecutionException       -- a tool call failed
+```
+
+---
+
+## `ValidationException`
+
+Thrown when the ensemble or its components are configured incorrectly. This exception is thrown before any LLM calls.
+
+Common causes:
+- Missing required fields (`role`, `goal`, `llm`, `description`, `expectedOutput`, `agent`)
+- A task references an agent not registered with the ensemble
+- Context tasks appear after the tasks that depend on them (sequential workflow)
+- Circular context dependencies
+- `maxIterations`, `managerMaxIterations`, or `maxDelegationDepth` set to zero or negative
+- `EnsembleMemory` built with no memory type enabled
+
+```java
+try {
+    EnsembleOutput output = ensemble.run();
+} catch (ValidationException e) {
+    System.err.println("Configuration error: " + e.getMessage());
+}
+```
+
+---
+
+## `TaskExecutionException`
+
+Thrown when a task fails during execution. Contains:
+- The description of the failed task
+- The role of the agent assigned to it
+- A list of `TaskOutput` objects for tasks that completed before the failure
+
+```java
+try {
+    EnsembleOutput output = ensemble.run();
+} catch (TaskExecutionException e) {
+    System.err.println("Task failed: " + e.getTaskDescription());
+    System.err.println("Agent: " + e.getAgentRole());
+    System.err.println("Cause: " + e.getCause().getMessage());
+
+    // Access results from tasks that completed before the failure
+    for (TaskOutput completed : e.getCompletedTaskOutputs()) {
+        System.out.println("Completed: " + completed.getTaskDescription());
+        System.out.println("Output: " + completed.getRaw());
+    }
+}
+```
+
+---
+
+## `AgentExecutionException`
+
+Thrown when the LLM call itself fails (network error, API error, timeout). Contains the agent role and task description.
+
+```java
+catch (AgentExecutionException e) {
+    System.err.println("Agent '" + e.getAgentRole() + "' failed on task '"
+        + e.getTaskDescription() + "': " + e.getMessage());
+}
+```
+
+---
+
+## `MaxIterationsExceededException`
+
+Thrown when an agent exceeds its `maxIterations` limit. Contains the configured limit and the actual count.
+
+```java
+catch (MaxIterationsExceededException e) {
+    System.err.println("Agent '" + e.getAgentRole() + "' exceeded its iteration limit.");
+    System.err.println("Configured limit: " + e.getMaxIterations());
+    System.err.println("Actual iterations: " + e.getActualIterations());
+}
+```
+
+To prevent this, either increase `maxIterations` on the agent or give the agent fewer, more focused tools.
+
+---
+
+## `PromptTemplateException`
+
+Thrown when a task description or expected output contains `{variable}` placeholders that were not resolved because the corresponding key was not in the inputs map.
+
+```java
+catch (PromptTemplateException e) {
+    System.err.println("Missing template variables: " + e.getMissingVariables());
+    // e.g., "Missing template variables: [topic, year]"
+}
+```
+
+---
+
+## `ToolExecutionException`
+
+Thrown when a tool fails to execute. This is typically wrapped inside an `AgentExecutionException`.
+
+---
+
+## Catching All Framework Exceptions
+
+```java
+try {
+    EnsembleOutput output = ensemble.run(inputs);
+} catch (AgentEnsembleException e) {
+    log.error("Ensemble failed: {}", e.getMessage(), e);
+}
+```
+
+---
+
+## Partial Results on Failure
+
+When a `TaskExecutionException` is thrown, the partial results from successfully completed tasks are available via `e.getCompletedTaskOutputs()`. This allows you to save or display intermediate work even when the ensemble fails partway through.
+
+```java
+try {
+    EnsembleOutput output = ensemble.run(inputs);
+    saveResults(output);
+} catch (TaskExecutionException e) {
+    // Save whatever was completed before the failure
+    for (TaskOutput partial : e.getCompletedTaskOutputs()) {
+        savePartialResult(partial);
+    }
+    // Alert on the failure
+    alertOnFailure(e.getTaskDescription(), e.getAgentRole());
+}
+```
+
+---
+
+## Retry Patterns
+
+AgentEnsemble does not have built-in retry logic. For transient failures (e.g., API rate limits), implement retry at the call site:
+
+```java
+int attempts = 0;
+EnsembleOutput output = null;
+
+while (attempts < 3) {
+    try {
+        output = ensemble.run(inputs);
+        break;
+    } catch (AgentExecutionException e) {
+        attempts++;
+        if (attempts == 3) throw e;
+        Thread.sleep(1000L * attempts);   // exponential back-off
+    }
+}
+```
+
+For production use, consider integrating a resilience library such as Resilience4j.

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,0 +1,145 @@
+# Logging
+
+AgentEnsemble uses SLF4J for all logging. Add any SLF4J-compatible implementation to your project (Logback, Log4j2, JUL, etc.).
+
+---
+
+## Adding a Logging Implementation
+
+**Logback (recommended):**
+```kotlin
+implementation("ch.qos.logback:logback-classic:1.5.12")
+```
+
+**Log4j2:**
+```kotlin
+implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.23.1")
+```
+
+---
+
+## Logger Name
+
+All AgentEnsemble classes log under the `net.agentensemble` namespace. Set the log level for this package in your configuration:
+
+```xml
+<logger name="net.agentensemble" level="INFO"/>
+```
+
+---
+
+## Log Levels
+
+| Level | What is logged |
+|---|---|
+| ERROR | Ensemble run failures, task failures |
+| WARN | Agent exceeded max iterations (stop messages sent), unused agents, delegation guards triggered |
+| INFO | Ensemble start/complete, task start/complete, tool calls, delegation events, memory state |
+| DEBUG | Prompt lengths, context counts, task output previews |
+| TRACE | Full agent responses |
+
+---
+
+## MDC Keys
+
+AgentEnsemble populates MDC (Mapped Diagnostic Context) values during execution. These can be included in your log format to add context to each log line.
+
+| Key | Value | When set |
+|---|---|---|
+| `ensemble.id` | UUID | For the duration of each `run()` call |
+| `task.index` | `"2/5"` (current/total) | During each task execution |
+| `agent.role` | Agent role string | During each task/agent execution |
+| `delegation.depth` | `"1"`, `"2"`, etc. | During delegated agent executions |
+| `delegation.parent` | Parent agent role | During delegated agent executions |
+
+---
+
+## Logback Configuration
+
+### Basic Pattern with MDC
+
+```xml
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} %-5level [%X{ensemble.id:-}] [%X{task.index:-}] [%X{agent.role:-}] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="net.agentensemble" level="INFO"/>
+    <root level="WARN"><appender-ref ref="CONSOLE"/></root>
+</configuration>
+```
+
+### Sample Output
+
+```
+14:32:01 INFO  [a3f4-...] [] [] net.agentensemble.Ensemble - Ensemble run started | Workflow: SEQUENTIAL | Tasks: 2 | Agents: 2
+14:32:01 INFO  [a3f4-...] [1/2] [Senior Research Analyst] net.agentensemble.agent.AgentExecutor - Agent 'Senior Research Analyst' executing task | Tools: 1 | AllowDelegation: false
+14:32:01 INFO  [a3f4-...] [1/2] [Senior Research Analyst] net.agentensemble.agent.AgentExecutor - Tool call: web_search(AI agents 2026) -> Found 5 results... [342ms]
+14:32:03 INFO  [a3f4-...] [1/2] [Senior Research Analyst] net.agentensemble.workflow.SequentialWorkflowExecutor - Task 1/2 completed | Duration: PT2.341S | Tool calls: 1
+14:32:03 INFO  [a3f4-...] [2/2] [Content Writer] net.agentensemble.agent.AgentExecutor - Agent 'Content Writer' executing task | Tools: 0 | AllowDelegation: false
+14:32:05 INFO  [a3f4-...] [] [] net.agentensemble.Ensemble - Ensemble run completed | Duration: PT4.102S | Tasks: 2 | Tool calls: 1
+```
+
+---
+
+## Verbose Mode
+
+Set `verbose = true` on an agent or ensemble to log the full system prompt, user prompt, and LLM response at INFO level. This is useful during development:
+
+```java
+// Agent-level verbose
+Agent researcher = Agent.builder()
+    .role("Researcher")
+    .goal("Research topics")
+    .llm(model)
+    .verbose(true)
+    .build();
+
+// Ensemble-level verbose (applies to all agents)
+Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .tasks(...)
+    .verbose(true)
+    .build();
+```
+
+When verbose, each agent logs:
+- Full system prompt
+- Full user prompt (including memory sections if enabled)
+- Full LLM response
+
+---
+
+## Delegation Logging
+
+When delegation occurs, the log context switches to show the delegation chain:
+
+```
+14:32:05 INFO  [a3f4-...] [1/1] [Lead Researcher] AgentExecutor - Agent 'Lead Researcher' delegating subtask to 'Content Writer' (depth 1/3)
+14:32:05 INFO  [a3f4-...] [1/1] [Content Writer] AgentExecutor - Agent 'Content Writer' executing task | Tools: 0 | AllowDelegation: false
+```
+
+The `delegation.depth` and `delegation.parent` MDC keys are available during delegated executions for structured log patterns that show the full delegation tree.
+
+---
+
+## Structured JSON Logging
+
+For production environments, consider structured JSON logging with Logback's `logstash-logback-encoder`:
+
+```kotlin
+implementation("net.logstash.logback:logstash-logback-encoder:8.0")
+```
+
+```xml
+<appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <includeMdc>true</includeMdc>
+    </encoder>
+</appender>
+```
+
+All MDC keys (`ensemble.id`, `task.index`, `agent.role`, `delegation.depth`, `delegation.parent`) are automatically included in the JSON output.

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -1,0 +1,173 @@
+# Memory
+
+AgentEnsemble supports three complementary memory types that can be used independently or together. Memory is configured via `EnsembleMemory` on the `Ensemble` builder.
+
+---
+
+## Memory Types
+
+### Short-Term Memory
+
+Accumulates all task outputs produced during a single `run()` call and injects them into each subsequent agent's prompt. When short-term memory is active, agents automatically receive the outputs of all prior tasks without requiring explicit `context` declarations.
+
+**Use when:** You want agents to be aware of everything that has been done in the current run, without manually wiring context dependencies.
+
+### Long-Term Memory
+
+Persists task outputs across ensemble runs using a LangChain4j `EmbeddingStore`. Before each task, the framework searches the store for past outputs relevant to the current task description and injects them into the agent's prompt.
+
+**Use when:** You run the same or similar ensembles repeatedly and want agents to benefit from previous runs. For example, a weekly report ensemble that learns from prior weeks.
+
+### Entity Memory
+
+A user-populated key-value store of known facts about named entities. All stored facts are injected into every agent's prompt for every task. Entity memory is seeded before running the ensemble.
+
+**Use when:** You have stable, well-known facts that should be consistently available to all agents. For example, facts about a company, a project, or key people.
+
+---
+
+## Configuring Memory
+
+### Short-Term Only
+
+```java
+EnsembleMemory memory = EnsembleMemory.builder()
+    .shortTerm(true)
+    .build();
+
+EnsembleOutput output = Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .task(researchTask)
+    .task(writeTask)
+    .memory(memory)
+    .build()
+    .run();
+```
+
+With short-term memory enabled, the `writeTask` does not need `context(List.of(researchTask))` -- the researcher's output is automatically injected.
+
+### Long-Term Memory
+
+Long-term memory requires a LangChain4j `EmbeddingStore` and `EmbeddingModel`:
+
+```java
+// For development/testing -- use a durable store in production
+EmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+
+EmbeddingModel embeddingModel = OpenAiEmbeddingModel.builder()
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .modelName("text-embedding-3-small")
+    .build();
+
+LongTermMemory longTerm = new EmbeddingStoreLongTermMemory(store, embeddingModel);
+
+EnsembleMemory memory = EnsembleMemory.builder()
+    .longTerm(longTerm)
+    .longTermMaxResults(5)   // retrieve up to 5 relevant memories per task (default: 5)
+    .build();
+```
+
+**Supported stores (via LangChain4j):** Chroma, Qdrant, Pinecone, Weaviate, Milvus, Redis, PostgreSQL (pgvector), and more.
+
+### Entity Memory
+
+```java
+EntityMemory entities = new InMemoryEntityMemory();
+entities.put("Acme Corp", "A mid-sized SaaS company founded in 2015, publicly traded as ACME. " +
+                          "Their primary product is a B2B CRM platform with 15,000 customers.");
+entities.put("Alice Chen", "Head of Product at Acme Corp. Background in ML research. " +
+                           "Joined in 2021 from Google.");
+
+EnsembleMemory memory = EnsembleMemory.builder()
+    .entityMemory(entities)
+    .build();
+```
+
+### All Three Together
+
+```java
+EmbeddingStore<TextSegment> store = loadDurableStore();  // e.g., Chroma
+EmbeddingModel embeddingModel = buildEmbeddingModel();
+
+EntityMemory entities = new InMemoryEntityMemory();
+entities.put("Project Phoenix", "Internal codename for the new mobile app, launching in Q3.");
+
+EnsembleMemory memory = EnsembleMemory.builder()
+    .shortTerm(true)
+    .longTerm(new EmbeddingStoreLongTermMemory(store, embeddingModel))
+    .entityMemory(entities)
+    .longTermMaxResults(3)
+    .build();
+
+EnsembleOutput output = Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .task(researchTask)
+    .task(writeTask)
+    .memory(memory)
+    .build()
+    .run(Map.of("topic", "Project Phoenix launch strategy"));
+```
+
+---
+
+## How Memory Appears in Prompts
+
+When memory is active, the agent's user prompt contains additional sections before the task description:
+
+```
+## Short-Term Memory (Current Run)
+[Prior task outputs from this run]
+
+## Long-Term Memory
+[Relevant outputs from previous runs, retrieved by semantic similarity]
+
+## Entity Knowledge
+[All entity facts from the entity memory store]
+
+## Your Task
+[Task description and expected output]
+```
+
+Short-term memory replaces the "Context from prior tasks" section when active.
+
+---
+
+## Memory Lifecycle
+
+| Memory type | Scope | Created | Cleared |
+|---|---|---|---|
+| Short-term | Per `run()` call | At start of `run()` | At end of `run()` |
+| Long-term | Persistent | Controlled by your `EmbeddingStore` | When you clear the store |
+| Entity | Controlled by you | Before `run()` | When you update the store |
+
+Long-term memory and entity memory are shared across runs. Their lifecycle is entirely under your control -- AgentEnsemble never clears or modifies them outside of storing new entries.
+
+---
+
+## Custom Long-Term Memory
+
+You can implement the `LongTermMemory` interface for custom storage backends or retrieval strategies:
+
+```java
+public class MyDatabaseMemory implements LongTermMemory {
+
+    @Override
+    public void store(MemoryEntry entry) {
+        // Persist to your database
+    }
+
+    @Override
+    public List<MemoryEntry> retrieve(String query, int maxResults) {
+        // Return relevant entries for the given query
+        return myDatabase.search(query, maxResults);
+    }
+}
+```
+
+---
+
+## Memory Configuration Reference
+
+See the [Memory Configuration reference](../reference/memory-configuration.md) for the complete field table.

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -1,0 +1,134 @@
+# Tasks
+
+A task is a unit of work assigned to one agent. It describes what the agent should do and what the output should look like.
+
+---
+
+## Creating a Task
+
+```java
+Task task = Task.builder()
+    .description("Research the latest developments in quantum computing")
+    .expectedOutput("A 400-word summary covering key breakthroughs, key players, and near-term outlook")
+    .agent(researcher)
+    .build();
+```
+
+The `description`, `expectedOutput`, and `agent` fields are required.
+
+---
+
+## Description
+
+The `description` field tells the agent what to do. Write it clearly and specifically. The description supports `{variable}` placeholders that are resolved with values from `ensemble.run(Map)`.
+
+```java
+Task task = Task.builder()
+    .description("Analyse the sales data for {region} in {year} and identify the top three growth drivers")
+    .expectedOutput("A structured analysis listing three growth drivers with supporting evidence")
+    .agent(analyst)
+    .build();
+```
+
+Resolved at run time:
+
+```java
+ensemble.run(Map.of("region", "EMEA", "year", "2025"));
+```
+
+See the [Template Variables guide](template-variables.md) for full syntax details.
+
+---
+
+## Expected Output
+
+The `expectedOutput` field is quality guidance for the agent. It describes what the result should look like, not a validation rule. Include:
+
+- Format (markdown, JSON, bullet points, prose)
+- Length (word count, number of items)
+- Structure (sections, headings)
+- Constraints (what to include, what to exclude)
+
+Good example:
+
+```java
+.expectedOutput(
+    "A 600-800 word blog post in markdown format with: " +
+    "an engaging headline, an introduction paragraph, three main sections each with a subheading, " +
+    "and a conclusion paragraph. Suitable for a technical audience.")
+```
+
+---
+
+## Agent Assignment
+
+Each task is assigned to exactly one agent:
+
+```java
+Task researchTask = Task.builder()
+    .description("Research AI trends")
+    .expectedOutput("A research summary")
+    .agent(researcher)      // researcher will execute this task
+    .build();
+```
+
+In hierarchical workflow, the Manager agent decides at run time which worker handles each task based on agent roles and goals. You still specify an agent per task for configuration purposes and validation, but the manager may re-assign at runtime.
+
+---
+
+## Context Dependencies
+
+In sequential workflow, a task can receive outputs from prior tasks using the `context` field. Context outputs are injected into the agent's user prompt before the task runs.
+
+```java
+var researchTask = Task.builder()
+    .description("Research the history of {topic}")
+    .expectedOutput("A factual historical summary")
+    .agent(researcher)
+    .build();
+
+var writeTask = Task.builder()
+    .description("Write a compelling blog post about {topic}")
+    .expectedOutput("A 700-word blog post")
+    .agent(writer)
+    .context(List.of(researchTask))   // writer sees researcher's output
+    .build();
+```
+
+Rules:
+- Context tasks must appear earlier in the ensemble's task list
+- Circular dependencies are detected at validation time and throw `ValidationException`
+- A task may declare context on multiple prior tasks
+
+When short-term memory is enabled, explicit `context` declarations are not required -- all prior task outputs within the run are automatically injected.
+
+---
+
+## Multiple Context Tasks
+
+```java
+var writeTask = Task.builder()
+    .description("Write a final report incorporating both the research and the financial analysis")
+    .expectedOutput("A 1000-word executive report")
+    .agent(writer)
+    .context(List.of(researchTask, analysisTask))  // receives both prior outputs
+    .build();
+```
+
+---
+
+## Tasks Are Immutable
+
+Tasks are immutable value objects. The builder produces a new instance on each call to `build()`. Use `toBuilder()` to create modified copies:
+
+```java
+Task verboseTask = task.toBuilder()
+    .description("Research {topic} with particular focus on regulatory changes")
+    .build();
+```
+
+---
+
+## Reference
+
+See the [Task Configuration reference](../reference/task-configuration.md) for the complete field table.

--- a/docs/guides/template-variables.md
+++ b/docs/guides/template-variables.md
@@ -1,0 +1,171 @@
+# Template Variables
+
+Task descriptions and expected outputs support `{variable}` placeholder substitution. Variables are resolved at run time by calling `ensemble.run(Map<String, String> inputs)`.
+
+---
+
+## Basic Usage
+
+Use curly braces to define a placeholder:
+
+```java
+Task task = Task.builder()
+    .description("Research the latest developments in {topic} for the {audience} audience")
+    .expectedOutput("A 400-word summary of {topic} suitable for {audience}")
+    .agent(researcher)
+    .build();
+```
+
+Pass values at run time:
+
+```java
+EnsembleOutput output = ensemble.run(Map.of(
+    "topic", "quantum computing",
+    "audience", "software engineers"
+));
+```
+
+The resolved description becomes:
+```
+Research the latest developments in quantum computing for the software engineers audience
+```
+
+---
+
+## Variables in Expected Output
+
+Template variables are resolved in both `description` and `expectedOutput`:
+
+```java
+Task task = Task.builder()
+    .description("Analyse {company} financial results for Q{quarter} {year}")
+    .expectedOutput("A financial analysis report for {company} Q{quarter} {year} with three key findings")
+    .agent(analyst)
+    .build();
+```
+
+---
+
+## No-Variable Runs
+
+When no variables are needed, call `run()` without arguments:
+
+```java
+EnsembleOutput output = ensemble.run();
+// equivalent to ensemble.run(Map.of())
+```
+
+---
+
+## Missing Variables
+
+If a task description contains a placeholder that is not in the inputs map, a `PromptTemplateException` is thrown before any LLM calls:
+
+```java
+// Task has {topic} and {year} placeholders
+try {
+    ensemble.run(Map.of("topic", "AI"));  // missing "year"
+} catch (PromptTemplateException e) {
+    System.err.println("Missing: " + e.getMissingVariables());
+    // Missing: [year]
+}
+```
+
+---
+
+## Escaping Braces
+
+To include a literal `{variable}` in the output without substitution, use double braces:
+
+```java
+Task task = Task.builder()
+    .description("Write a Java method that parses {{variable}} from a string. Variable name: {varName}")
+    .expectedOutput("A Java method with parameter name {varName}")
+    .agent(coder)
+    .build();
+```
+
+With `inputs = Map.of("varName", "userId")`, the resolved description is:
+```
+Write a Java method that parses {variable} from a string. Variable name: userId
+```
+
+---
+
+## Sharing Variables Across Tasks
+
+All tasks in the ensemble are resolved with the same inputs map. Any variable defined in inputs is available in all task descriptions and expected outputs:
+
+```java
+var researchTask = Task.builder()
+    .description("Research {topic} in depth")
+    .expectedOutput("A summary of {topic}")
+    .agent(researcher)
+    .build();
+
+var writeTask = Task.builder()
+    .description("Write a blog post about {topic}")
+    .expectedOutput("A 700-word blog post about {topic}")
+    .agent(writer)
+    .context(List.of(researchTask))
+    .build();
+
+// Both tasks receive the same variables
+ensemble.run(Map.of("topic", "AI agents"));
+```
+
+---
+
+## Dynamic Task Creation
+
+Because template resolution happens at run time, you can create task templates once and reuse them across multiple runs:
+
+```java
+// Create tasks once
+var researchTask = Task.builder()
+    .description("Research {topic}")
+    .expectedOutput("A summary of {topic}")
+    .agent(researcher)
+    .build();
+
+var writeTask = Task.builder()
+    .description("Write about {topic}")
+    .expectedOutput("A blog post about {topic}")
+    .agent(writer)
+    .context(List.of(researchTask))
+    .build();
+
+Ensemble ensemble = Ensemble.builder()
+    .agent(researcher).agent(writer)
+    .task(researchTask).task(writeTask)
+    .build();
+
+// Run multiple times with different inputs
+ensemble.run(Map.of("topic", "AI agents"));
+ensemble.run(Map.of("topic", "quantum computing"));
+ensemble.run(Map.of("topic", "blockchain"));
+```
+
+---
+
+## Variable Naming
+
+Variable names are case-sensitive and can contain letters, digits, underscores, and hyphens:
+
+```
+{topic}          -- valid
+{company_name}   -- valid
+{year2025}       -- valid
+{TOPIC}          -- valid, but different from {topic}
+{company name}   -- invalid (space not allowed)
+```
+
+---
+
+## Null and Empty Values
+
+Values are always strings. Passing `null` as a value is not permitted by `Map.of()`. Empty strings are allowed but will produce empty substitutions:
+
+```java
+ensemble.run(Map.of("topic", ""));   // substitutes empty string
+```

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -1,0 +1,204 @@
+# Tools
+
+Agents can be equipped with tools that they invoke during execution using a ReAct-style reasoning loop. There are two supported tool patterns.
+
+---
+
+## How Tools Work
+
+When an agent has tools, the execution loop works as follows:
+
+1. The agent receives a system prompt (role, goal, background) and user prompt (task description, context)
+2. The agent decides whether to call a tool or produce a final answer
+3. If a tool is called, the framework executes it and returns the result to the agent
+4. The agent incorporates the tool result and decides on the next step (another tool call or a final answer)
+5. This loop continues until the agent produces a final text answer or `maxIterations` is reached
+
+---
+
+## Option 1: Implement `AgentTool`
+
+The `AgentTool` interface provides a simple, string-in / string-out contract:
+
+```java
+public interface AgentTool {
+    String name();
+    String description();
+    ToolResult execute(String input);
+}
+```
+
+### Example: Web Search Tool
+
+```java
+public class WebSearchTool implements AgentTool {
+
+    private final SearchClient client;
+
+    public WebSearchTool(SearchClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String name() {
+        return "web_search";
+    }
+
+    @Override
+    public String description() {
+        return "Search the web for current information. " +
+               "Input: a search query string. " +
+               "Returns: search results as text.";
+    }
+
+    @Override
+    public ToolResult execute(String input) {
+        try {
+            String results = client.search(input);
+            return ToolResult.success(results);
+        } catch (Exception e) {
+            return ToolResult.failure("Search failed: " + e.getMessage());
+        }
+    }
+}
+```
+
+### `ToolResult`
+
+Use `ToolResult.success(content)` for successful results and `ToolResult.failure(reason)` for errors. The failure message is returned to the agent so it can decide how to proceed.
+
+```java
+ToolResult.success("Found 3 results: ...");
+ToolResult.failure("API rate limit exceeded. Try again later.");
+```
+
+### Registering an `AgentTool`
+
+```java
+Agent agent = Agent.builder()
+    .role("Researcher")
+    .goal("Find current information")
+    .tools(List.of(new WebSearchTool(searchClient)))
+    .llm(model)
+    .build();
+```
+
+---
+
+## Option 2: LangChain4j `@Tool` Annotation
+
+Objects with `@Tool`-annotated methods are supported directly. The method signature is used to generate the tool specification. Multi-parameter methods are supported (the `-parameters` compiler flag is required; the framework's `build.gradle.kts` already enables this).
+
+### Example: Math and Lookup Tools
+
+```java
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.P;
+
+public class DataTools {
+
+    @Tool("Calculate the percentage change between two values. " +
+          "Use this to compute growth rates.")
+    public double percentageChange(
+            @P("The original value") double original,
+            @P("The new value") double newValue) {
+        return ((newValue - original) / original) * 100.0;
+    }
+
+    @Tool("Look up the current stock price for a ticker symbol. " +
+          "Input: a stock ticker symbol like 'AAPL'.")
+    public String stockPrice(String ticker) {
+        return fetchStockPrice(ticker);
+    }
+}
+```
+
+### Registering `@Tool`-Annotated Objects
+
+```java
+Agent agent = Agent.builder()
+    .role("Financial Analyst")
+    .goal("Analyse financial data using available tools")
+    .tools(List.of(new DataTools()))
+    .llm(model)
+    .build();
+```
+
+---
+
+## Combining Both Tool Types
+
+Both types can be used together in a single agent:
+
+```java
+Agent agent = Agent.builder()
+    .role("Research Analyst")
+    .goal("Find and analyse data")
+    .tools(List.of(
+        new WebSearchTool(searchClient),   // AgentTool
+        new DataTools()                     // @Tool annotated
+    ))
+    .llm(model)
+    .build();
+```
+
+---
+
+## Writing Good Tool Descriptions
+
+The description is critical -- it is the only information the LLM uses to decide when and how to call the tool.
+
+**Best practices:**
+
+1. Start with a verb that describes what the tool does: `"Search..."`, `"Calculate..."`, `"Look up..."`, `"Convert..."`.
+2. Describe the input format clearly: `"Input: a search query string"`, `"Input: a company name"`.
+3. Describe the output: `"Returns: a JSON object with price and volume"`.
+4. List any constraints: `"Only use this for publicly traded companies"`.
+
+**Good description:**
+```
+"Search the web for recent news and articles. Input: a concise search query of 2-8 words. Returns: a summary of the top results including source names and publication dates."
+```
+
+**Poor description:**
+```
+"Web search tool"
+```
+
+---
+
+## Tool Parameter Annotations (`@P`)
+
+For `@Tool` annotated methods with multiple parameters, use `@P` to describe each parameter:
+
+```java
+@Tool("Calculate compound interest.")
+public double compoundInterest(
+        @P("Principal amount in dollars") double principal,
+        @P("Annual interest rate as a decimal, e.g. 0.05 for 5%") double rate,
+        @P("Number of years") int years) {
+    return principal * Math.pow(1 + rate, years);
+}
+```
+
+---
+
+## Max Iterations
+
+When an agent has tools, the `maxIterations` field limits the number of tool calls. The default is 25. Set it lower for tasks where you want the agent to be concise, or higher for complex analytical tasks:
+
+```java
+Agent agent = Agent.builder()
+    .role("Data Analyst")
+    .goal("Perform thorough data analysis")
+    .tools(List.of(new DataTools()))
+    .llm(model)
+    .maxIterations(50)
+    .build();
+```
+
+---
+
+## Delegation Tool
+
+When `allowDelegation = true`, an additional `delegate` tool is automatically injected at execution time. This is distinct from the tools you configure on the agent. See the [Delegation guide](delegation.md).

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,0 +1,136 @@
+# Workflows
+
+A workflow defines how tasks are executed. AgentEnsemble supports two strategies: `SEQUENTIAL` and `HIERARCHICAL`.
+
+---
+
+## SEQUENTIAL (Default)
+
+Tasks execute one after another in the order they are declared. Each task that declares `context` dependencies receives those prior outputs injected into its agent's prompt.
+
+```java
+Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .task(researchTask)
+    .task(writeTask)           // writeTask has context(List.of(researchTask))
+    .workflow(Workflow.SEQUENTIAL)
+    .build()
+    .run();
+```
+
+### Execution Order
+
+Tasks run in list order. The ensemble validates at build time that context tasks always appear before the tasks that reference them. If this ordering is violated, a `ValidationException` is thrown immediately -- not at run time.
+
+### Context Injection
+
+When a task has a non-empty `context` list, each referenced task's output is injected into the agent's user prompt as a "Context from prior tasks" section. The agent uses this to inform its response.
+
+### When to Use SEQUENTIAL
+
+- You have a defined, linear pipeline (research -> write -> review)
+- Task order is fixed and predictable
+- Each task depends on the output of the task immediately before it
+
+---
+
+## HIERARCHICAL
+
+A virtual Manager agent is automatically created at run time. The manager receives:
+- A system prompt describing all worker agents and their roles/goals
+- A user prompt listing all tasks to complete
+
+The manager uses a `delegateTask` tool to assign tasks to workers. Workers execute and return their outputs as tool results. The manager synthesizes a final response.
+
+```java
+Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .agent(editor)
+    .task(researchTask)
+    .task(writeTask)
+    .task(editTask)
+    .workflow(Workflow.HIERARCHICAL)
+    .managerLlm(gpt4Model)       // optional: dedicated LLM for the manager
+    .managerMaxIterations(20)    // optional: default is 20
+    .build()
+    .run();
+```
+
+### Manager Agent
+
+The manager is a virtual, automatically-configured agent with:
+- **role**: `"Manager"`
+- **goal**: `"Coordinate worker agents to complete all tasks and synthesize a comprehensive final result"`
+- **background**: A generated description of all worker agents and their capabilities
+- **tools**: The `delegateTask` tool
+
+The manager is not included in the `agents` list -- it is created internally.
+
+### Manager LLM
+
+If `managerLlm` is not set, the manager uses the first registered agent's LLM. For production use, it is recommended to provide a capable LLM (GPT-4o, Claude 3.5, etc.) as the manager:
+
+```java
+ChatModel powerfulModel = OpenAiChatModel.builder()
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .modelName("gpt-4o")
+    .build();
+
+Ensemble.builder()
+    .agents(...)
+    .tasks(...)
+    .workflow(Workflow.HIERARCHICAL)
+    .managerLlm(powerfulModel)
+    .build();
+```
+
+### Manager Max Iterations
+
+The `managerMaxIterations` field limits how many delegation tool calls the manager can make before being forced to synthesize. Default is 20.
+
+### Output Structure
+
+In hierarchical workflow, `EnsembleOutput.getTaskOutputs()` contains:
+1. All worker outputs in delegation order
+2. The manager's final synthesized output (last)
+
+`EnsembleOutput.getRaw()` is the manager's final synthesis.
+
+### When to Use HIERARCHICAL
+
+- You want the LLM to decide which agent handles each task
+- The task-to-agent mapping is not obvious from the task descriptions
+- You want the manager to re-order or combine tasks dynamically
+- You are building a system where task routing should be AI-driven
+
+---
+
+## Choosing a Workflow
+
+| Consideration | SEQUENTIAL | HIERARCHICAL |
+|---|---|---|
+| Task order | Fixed, user-defined | Dynamic, manager-decided |
+| Routing logic | Explicit (agent per task) | Implicit (manager decides) |
+| LLM calls | N calls (one per task) | N+1 calls (tasks + manager) |
+| Predictability | High | Lower |
+| Flexibility | Lower | Higher |
+
+---
+
+## Workflow and Memory
+
+Both workflows support all memory types. Memory context is shared across all agent executions within a single `run()` call.
+
+In hierarchical workflow, the Manager agent itself does not participate in memory -- only the worker agents do.
+
+See the [Memory guide](memory.md).
+
+---
+
+## Workflow and Delegation
+
+Both workflows support agent-to-agent delegation when agents have `allowDelegation = true`. In hierarchical workflow, worker agents can delegate to peer workers in addition to the manager's own delegation via `delegateTask`.
+
+See the [Delegation guide](delegation.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,82 @@
+# AgentEnsemble Documentation
+
+AgentEnsemble is an open-source Java 21 framework for orchestrating teams of AI agents that collaborate to accomplish complex tasks. Built on [LangChain4j](https://github.com/langchain4j/langchain4j), it is LLM-agnostic and integrates with OpenAI, Anthropic, Ollama, Azure OpenAI, Amazon Bedrock, Google Vertex AI, and any other provider LangChain4j supports.
+
+---
+
+## Getting Started
+
+| Page | Description |
+|---|---|
+| [Installation](getting-started/installation.md) | Add the dependency to your project |
+| [Quickstart](getting-started/quickstart.md) | Build your first ensemble in five minutes |
+| [Core Concepts](getting-started/concepts.md) | Agents, Tasks, Ensembles, Workflows, Memory, Delegation |
+
+---
+
+## Guides
+
+| Page | Description |
+|---|---|
+| [Agents](guides/agents.md) | Create and configure agents |
+| [Tasks](guides/tasks.md) | Define tasks, expected outputs, and context |
+| [Workflows](guides/workflows.md) | Sequential and hierarchical execution strategies |
+| [Tools](guides/tools.md) | Extend agents with custom tools |
+| [Memory](guides/memory.md) | Short-term, long-term, and entity memory |
+| [Delegation](guides/delegation.md) | Agent-to-agent delegation |
+| [Error Handling](guides/error-handling.md) | Exceptions, partial results, recovery patterns |
+| [Logging](guides/logging.md) | SLF4J logging, MDC keys, and configuration |
+| [Template Variables](guides/template-variables.md) | Dynamic task descriptions |
+
+---
+
+## Reference
+
+| Page | Description |
+|---|---|
+| [Agent Configuration](reference/agent-configuration.md) | All agent fields and defaults |
+| [Task Configuration](reference/task-configuration.md) | All task fields and defaults |
+| [Ensemble Configuration](reference/ensemble-configuration.md) | All ensemble fields and defaults |
+| [Memory Configuration](reference/memory-configuration.md) | EnsembleMemory and memory type reference |
+| [Exceptions](reference/exceptions.md) | Full exception hierarchy |
+
+---
+
+## Examples
+
+| Page | Description |
+|---|---|
+| [Research and Writer](examples/research-writer.md) | Sequential two-agent research and writing pipeline |
+| [Hierarchical Team](examples/hierarchical-team.md) | Manager-led team with automatic task delegation |
+| [Memory Across Runs](examples/memory-across-runs.md) | Long-term memory persisted across ensemble runs |
+
+---
+
+## Design Documentation
+
+The `docs/design/` directory contains internal architecture specifications for contributors:
+
+- [01 - Overview](design/01-overview.md)
+- [02 - Architecture](design/02-architecture.md)
+- [03 - Domain Model](design/03-domain-model.md)
+- [04 - Execution Engine](design/04-execution-engine.md)
+- [05 - Prompt Templates](design/05-prompt-templates.md)
+- [06 - Tool System](design/06-tool-system.md)
+- [07 - Template Resolver](design/07-template-resolver.md)
+- [08 - Error Handling](design/08-error-handling.md)
+- [09 - Logging](design/09-logging.md)
+- [10 - Concurrency](design/10-concurrency.md)
+- [11 - Configuration Reference](design/11-configuration.md)
+- [12 - Testing Strategy](design/12-testing-strategy.md)
+- [13 - Future Roadmap](design/13-future-roadmap.md)
+
+---
+
+## Releases
+
+| Version | Features |
+|---|---|
+| [v0.4.0](https://github.com/AgentEnsemble/agentensemble/releases/tag/v0.4.0) | Agent delegation |
+| [v0.3.0](https://github.com/AgentEnsemble/agentensemble/releases/tag/v0.3.0) | Memory system |
+| [v0.2.0](https://github.com/AgentEnsemble/agentensemble/releases/tag/v0.2.0) | Hierarchical workflow |
+| [v0.1.0](https://github.com/AgentEnsemble/agentensemble/releases/tag/v0.1.0) | Core framework |

--- a/docs/reference/agent-configuration.md
+++ b/docs/reference/agent-configuration.md
@@ -1,0 +1,55 @@
+# Agent Configuration Reference
+
+All fields available on `Agent.builder()`.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `role` | `String` | Yes | -- | The agent's role/title. Used in prompts and logging. |
+| `goal` | `String` | Yes | -- | The agent's primary objective. Included in the system prompt. |
+| `background` | `String` | No | `null` | Persona context for the system prompt. Omitted when null or blank. |
+| `tools` | `List<Object>` | No | `[]` | Tools available to this agent. Each entry must implement `AgentTool` or have `@Tool`-annotated methods. |
+| `llm` | `ChatModel` | Yes | -- | Any LangChain4j `ChatModel`. |
+| `allowDelegation` | `boolean` | No | `false` | When `true`, a `delegate` tool is auto-injected at execution time. |
+| `verbose` | `boolean` | No | `false` | When `true`, prompts and LLM responses are logged at INFO level. |
+| `maxIterations` | `int` | No | `25` | Maximum number of tool-call iterations before the agent is forced to produce a final answer. Must be greater than zero. |
+| `responseFormat` | `String` | No | `""` | Extra formatting instructions appended to the system prompt. |
+
+---
+
+## Validation
+
+The following validations are applied at `build()` time:
+
+- `role` must not be null or blank
+- `goal` must not be null or blank
+- `llm` must not be null
+- `maxIterations` must be greater than zero
+- Each tool must implement `AgentTool` or have at least one `@Tool`-annotated method
+
+---
+
+## Example
+
+```java
+Agent agent = Agent.builder()
+    .role("Senior Research Analyst")
+    .goal("Find accurate, well-structured information on any topic")
+    .background("You are a veteran researcher with 15 years of technology industry experience.")
+    .tools(List.of(new WebSearchTool()))
+    .llm(model)
+    .allowDelegation(true)
+    .verbose(false)
+    .maxIterations(25)
+    .responseFormat("Always structure your response with clear headings.")
+    .build();
+```
+
+---
+
+## Immutability
+
+`Agent` is an immutable value object. Use `toBuilder()` to create modified copies:
+
+```java
+Agent verboseAgent = agent.toBuilder().verbose(true).build();
+```

--- a/docs/reference/ensemble-configuration.md
+++ b/docs/reference/ensemble-configuration.md
@@ -1,0 +1,77 @@
+# Ensemble Configuration Reference
+
+All fields available on `Ensemble.builder()`.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `agents` | `List<Agent>` | Yes | -- | All agents participating in this ensemble. Add with `.agent(a)` (singular) or `.agents(list)`. |
+| `tasks` | `List<Task>` | Yes | -- | All tasks to execute. Add with `.task(t)` (singular) or `.tasks(list)`. |
+| `workflow` | `Workflow` | No | `SEQUENTIAL` | Execution strategy. `SEQUENTIAL` or `HIERARCHICAL`. |
+| `managerLlm` | `ChatModel` | No | First agent's LLM | LLM for the auto-created Manager agent (hierarchical workflow only). |
+| `managerMaxIterations` | `int` | No | `20` | Maximum tool-call iterations for the Manager agent. Must be greater than zero. |
+| `verbose` | `boolean` | No | `false` | When `true`, elevates all agent logging to INFO level. |
+| `memory` | `EnsembleMemory` | No | `null` | Memory configuration. See [Memory Configuration reference](memory-configuration.md). |
+| `maxDelegationDepth` | `int` | No | `3` | Maximum peer-delegation depth. Applies when agents have `allowDelegation = true`. Must be greater than zero. |
+
+---
+
+## Validation
+
+At `Ensemble.run()` time:
+
+- At least one agent must be registered
+- At least one task must be registered
+- Every task's `agent` must be in the ensemble's `agents` list
+- No circular context dependencies
+- Context task ordering is valid (sequential workflow only)
+- `maxDelegationDepth` must be greater than zero
+
+---
+
+## Output: `EnsembleOutput`
+
+`ensemble.run()` returns an `EnsembleOutput` with:
+
+| Method | Type | Description |
+|---|---|---|
+| `getRaw()` | `String` | Raw text of the final task output (or manager synthesis in hierarchical workflow) |
+| `getTaskOutputs()` | `List<TaskOutput>` | All task outputs in execution order |
+| `getTotalDuration()` | `Duration` | Wall-clock time for the entire run |
+| `getTotalToolCalls()` | `int` | Total number of tool calls across all agents |
+
+Each `TaskOutput` contains:
+
+| Method | Type | Description |
+|---|---|---|
+| `getRaw()` | `String` | Raw text output from the agent |
+| `getAgentRole()` | `String` | Role of the agent that produced this output |
+| `getTaskDescription()` | `String` | Description of the task (after template resolution) |
+| `getDuration()` | `Duration` | Time taken for this task |
+| `getToolCallCount()` | `int` | Number of tool calls made for this task |
+| `getCompletedAt()` | `Instant` | Timestamp when this task completed |
+
+---
+
+## Full Example
+
+```java
+EnsembleOutput output = Ensemble.builder()
+    .agent(researcher)
+    .agent(writer)
+    .agent(editor)
+    .task(researchTask)
+    .task(writeTask)
+    .task(editTask)
+    .workflow(Workflow.SEQUENTIAL)
+    .verbose(false)
+    .memory(EnsembleMemory.builder().shortTerm(true).build())
+    .maxDelegationDepth(2)
+    .build()
+    .run(Map.of("topic", "AI agents", "audience", "developers"));
+```
+
+---
+
+## Template Variables
+
+Call `ensemble.run(Map<String, String> inputs)` to resolve `{variable}` placeholders in all task descriptions and expected outputs. See [Template Variables guide](../guides/template-variables.md).

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -1,0 +1,122 @@
+# Exceptions Reference
+
+All AgentEnsemble exceptions extend `AgentEnsembleException`, which itself extends `RuntimeException`. All exceptions are unchecked.
+
+---
+
+## Hierarchy
+
+```
+java.lang.RuntimeException
+  net.agentensemble.exception.AgentEnsembleException
+    ValidationException
+    TaskExecutionException
+    AgentExecutionException
+    MaxIterationsExceededException
+    PromptTemplateException
+    ToolExecutionException
+```
+
+---
+
+## `AgentEnsembleException`
+
+**Package:** `net.agentensemble.exception`
+
+Base class for all framework exceptions. Catch this to handle any AgentEnsemble error with a single catch block.
+
+```java
+catch (AgentEnsembleException e) {
+    log.error("Ensemble error: {}", e.getMessage(), e);
+}
+```
+
+---
+
+## `ValidationException`
+
+**Thrown by:** `Agent.build()`, `Task.build()`, `EnsembleMemory.build()`, `Ensemble.run()`
+
+Indicates an invalid configuration. Always thrown before any LLM calls, so there is no partial state.
+
+**Common messages:**
+- `"Agent role must not be blank"`
+- `"Agent llm must not be null"`
+- `"Agent maxIterations must be > 0, got: 0"`
+- `"Ensemble must have at least one task"`
+- `"Task 'X' references agent 'Y' which is not in the ensemble's agent list"`
+- `"Ensemble maxDelegationDepth must be > 0, got: 0"`
+- `"Circular context dependency detected involving task: 'X'"`
+- `"EnsembleMemory must have at least one memory type enabled"`
+
+---
+
+## `TaskExecutionException`
+
+**Thrown by:** `SequentialWorkflowExecutor`
+
+A task failed during execution. Contains partial results from tasks that completed before the failure.
+
+**Methods:**
+| Method | Type | Description |
+|---|---|---|
+| `getTaskDescription()` | `String` | Description of the task that failed |
+| `getAgentRole()` | `String` | Role of the agent assigned to the failed task |
+| `getCompletedTaskOutputs()` | `List<TaskOutput>` | Outputs of tasks that completed successfully before the failure |
+
+---
+
+## `AgentExecutionException`
+
+**Thrown by:** `AgentExecutor`
+
+The LLM call failed (API error, network error, timeout, etc.).
+
+**Methods:**
+| Method | Type | Description |
+|---|---|---|
+| `getAgentRole()` | `String` | Role of the agent that failed |
+| `getTaskDescription()` | `String` | Description of the task being executed |
+
+---
+
+## `MaxIterationsExceededException`
+
+**Thrown by:** `AgentExecutor`
+
+The agent exceeded its `maxIterations` limit and did not produce a final answer after receiving stop messages.
+
+**Methods:**
+| Method | Type | Description |
+|---|---|---|
+| `getAgentRole()` | `String` | Role of the agent |
+| `getTaskDescription()` | `String` | Description of the task |
+| `getMaxIterations()` | `int` | The configured limit |
+| `getActualIterations()` | `int` | The actual number of iterations |
+
+---
+
+## `PromptTemplateException`
+
+**Thrown by:** `TemplateResolver` during `Ensemble.run()`
+
+One or more `{variable}` placeholders in task descriptions or expected outputs were not resolved because the corresponding key was not in the inputs map.
+
+**Methods:**
+| Method | Type | Description |
+|---|---|---|
+| `getMissingVariables()` | `List<String>` | Names of the unresolved variables |
+
+---
+
+## `ToolExecutionException`
+
+**Thrown by:** `LangChain4jToolAdapter`
+
+A `@Tool`-annotated method threw an exception during execution. The exception is typically wrapped in an `AgentExecutionException`.
+
+---
+
+## Error Handling Guide
+
+See the [Error Handling guide](../guides/error-handling.md) for patterns and examples.

--- a/docs/reference/memory-configuration.md
+++ b/docs/reference/memory-configuration.md
@@ -1,0 +1,161 @@
+# Memory Configuration Reference
+
+---
+
+## `EnsembleMemory`
+
+Configured via `EnsembleMemory.builder()`. At least one memory type must be enabled.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `shortTerm` | `boolean` | One of these must be set | `false` | Accumulate all task outputs within a run and inject into subsequent agents |
+| `longTerm` | `LongTermMemory` | One of these must be set | `null` | Cross-run vector-store persistence |
+| `entityMemory` | `EntityMemory` | One of these must be set | `null` | Named entity fact store |
+| `longTermMaxResults` | `int` | No | `5` | Maximum number of long-term memories retrieved per task. Must be greater than zero. |
+
+---
+
+## `LongTermMemory` Interface
+
+```java
+public interface LongTermMemory {
+    void store(MemoryEntry entry);
+    List<MemoryEntry> retrieve(String query, int maxResults);
+}
+```
+
+### `EmbeddingStoreLongTermMemory`
+
+The built-in implementation. Uses a LangChain4j `EmbeddingStore<TextSegment>` and `EmbeddingModel`.
+
+**Constructor:**
+```java
+new EmbeddingStoreLongTermMemory(
+    EmbeddingStore<TextSegment> embeddingStore,
+    EmbeddingModel embeddingModel
+)
+```
+
+Both arguments must be non-null.
+
+**LangChain4j Embedding Stores:** `InMemoryEmbeddingStore` (development), Chroma, Qdrant, Pinecone, Weaviate, Milvus, PostgreSQL pgvector, Redis, and more.
+
+**LangChain4j Embedding Models:** OpenAI `text-embedding-3-small` / `text-embedding-3-large`, Ollama embeddings, Azure OpenAI embeddings, and more.
+
+---
+
+## `EntityMemory` Interface
+
+```java
+public interface EntityMemory {
+    void put(String entityName, String fact);
+    Optional<String> get(String entityName);
+    Map<String, String> getAll();
+    boolean isEmpty();
+}
+```
+
+### `InMemoryEntityMemory`
+
+The built-in implementation backed by a `ConcurrentHashMap`.
+
+```java
+EntityMemory entities = new InMemoryEntityMemory();
+entities.put("Acme Corp", "A B2B SaaS company with 15,000 enterprise customers");
+entities.put("Alice Chen", "Head of Product, background in NLP research");
+```
+
+Entity names are trimmed when stored and looked up. `put()` replaces any existing fact for the same entity name.
+
+---
+
+## `MemoryEntry`
+
+Each recorded task output produces a `MemoryEntry` with:
+
+| Field | Type | Description |
+|---|---|---|
+| `content` | `String` | The raw output from the task |
+| `agentRole` | `String` | The role of the agent that produced it |
+| `taskDescription` | `String` | The task description |
+| `timestamp` | `Instant` | When the output was recorded |
+
+---
+
+## Custom Implementations
+
+### Custom Long-Term Memory
+
+```java
+public class PostgresLongTermMemory implements LongTermMemory {
+    @Override
+    public void store(MemoryEntry entry) {
+        db.insert("memories", entry.getContent(), entry.getAgentRole(),
+                  entry.getTaskDescription(), entry.getTimestamp());
+    }
+
+    @Override
+    public List<MemoryEntry> retrieve(String query, int maxResults) {
+        return db.vectorSearch(query, maxResults).stream()
+            .map(row -> MemoryEntry.builder()
+                .content(row.content())
+                .agentRole(row.agentRole())
+                .taskDescription(row.taskDescription())
+                .timestamp(row.timestamp())
+                .build())
+            .toList();
+    }
+}
+```
+
+### Custom Entity Memory
+
+```java
+public class ConfiguredEntityMemory implements EntityMemory {
+    private final Map<String, String> facts;
+
+    public ConfiguredEntityMemory(Map<String, String> facts) {
+        this.facts = new HashMap<>(facts);
+    }
+
+    @Override
+    public void put(String entityName, String fact) { facts.put(entityName.trim(), fact); }
+
+    @Override
+    public Optional<String> get(String entityName) {
+        return Optional.ofNullable(facts.get(entityName == null ? null : entityName.trim()));
+    }
+
+    @Override
+    public Map<String, String> getAll() { return Collections.unmodifiableMap(facts); }
+
+    @Override
+    public boolean isEmpty() { return facts.isEmpty(); }
+}
+```
+
+---
+
+## Example: All Memory Types
+
+```java
+EmbeddingStore<TextSegment> store = ChromaEmbeddingStore.builder()
+    .baseUrl("http://localhost:8000")
+    .collectionName("agentensemble-memories")
+    .build();
+
+EmbeddingModel embeddingModel = OpenAiEmbeddingModel.builder()
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .modelName("text-embedding-3-small")
+    .build();
+
+EntityMemory entities = new InMemoryEntityMemory();
+entities.put("Project Horizon", "Q4 initiative to expand into the APAC market");
+
+EnsembleMemory memory = EnsembleMemory.builder()
+    .shortTerm(true)
+    .longTerm(new EmbeddingStoreLongTermMemory(store, embeddingModel))
+    .entityMemory(entities)
+    .longTermMaxResults(3)
+    .build();
+```

--- a/docs/reference/task-configuration.md
+++ b/docs/reference/task-configuration.md
@@ -1,0 +1,75 @@
+# Task Configuration Reference
+
+All fields available on `Task.builder()`.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `description` | `String` | Yes | -- | What the agent should do. Supports `{variable}` template placeholders. |
+| `expectedOutput` | `String` | Yes | -- | What the output should look like. Quality guidance for the agent. Supports `{variable}` placeholders. |
+| `agent` | `Agent` | Yes | -- | The agent assigned to execute this task. |
+| `context` | `List<Task>` | No | `[]` | Prior tasks whose outputs are injected into this task's agent prompt. Sequential workflow only. |
+
+---
+
+## Validation
+
+The following validations are applied at `build()` time:
+
+- `description` must not be null or blank
+- `expectedOutput` must not be null or blank
+- `agent` must not be null
+
+At `Ensemble.run()` time:
+- All context tasks must appear earlier in the ensemble's task list (sequential workflow)
+- No circular context dependencies
+- The assigned agent must be registered with the ensemble
+
+---
+
+## Template Variables
+
+Both `description` and `expectedOutput` support `{variable}` substitution. Variables are resolved by calling `ensemble.run(Map<String, String> inputs)`.
+
+Use `{{variable}}` to include a literal `{variable}` in the text without substitution.
+
+See the [Template Variables guide](../guides/template-variables.md).
+
+---
+
+## Context Injection
+
+Context task outputs are injected into the agent's user prompt as a "Context from prior tasks" section. The agent sees the task description and the full raw output of each context task.
+
+When short-term memory is enabled, the `context` field is not required -- all prior outputs within the run are automatically injected.
+
+---
+
+## Example
+
+```java
+var researchTask = Task.builder()
+    .description("Research the competitive landscape for {company} in the {industry} sector")
+    .expectedOutput("A structured competitive analysis with three to five key competitors, " +
+                    "their strengths, weaknesses, and market position")
+    .agent(researcher)
+    .build();
+
+var strategyTask = Task.builder()
+    .description("Develop a market entry strategy for {company} based on the competitive research")
+    .expectedOutput("A 500-word strategic recommendation with three concrete action items")
+    .agent(strategist)
+    .context(List.of(researchTask))
+    .build();
+```
+
+---
+
+## Immutability
+
+`Task` is an immutable value object. Use `toBuilder()` to create modified copies:
+
+```java
+Task modifiedTask = task.toBuilder()
+    .description("Research {topic} with a focus on regulatory implications")
+    .build();
+```


### PR DESCRIPTION
## Summary

Implements Issue #17: Agent-to-agent peer delegation.

## Changes

### New classes
- `DelegationContext` -- immutable runtime state: peer agents, depth, max depth, memory context, executor
- `AgentDelegationTool` -- `@Tool`-annotated; auto-injected when `allowDelegation=true`; guards for depth limit, self-delegation, unknown role

### Modified classes
- `AgentExecutor` -- new 5-arg `execute()` with `DelegationContext`; `buildEffectiveTools()` injects delegation tool
- `Ensemble` -- `maxDelegationDepth` field (default 3, validated > 0)
- `SequentialWorkflowExecutor` -- 2-arg constructor; creates `DelegationContext` per run
- `HierarchicalWorkflowExecutor` -- 4-arg constructor; creates worker `DelegationContext`
- `DelegateTaskTool` -- 5-arg constructor; threads `DelegationContext` to worker executions

### Tests
- `DelegationContextTest` (16 tests)
- `AgentDelegationToolTest` (14 tests)
- `DelegationEnsembleIntegrationTest` (10 tests)
- Updated `DelegateTaskToolTest` and `HierarchicalWorkflowExecutorTest` for new constructors
- **287 tests passing** (was 251, +36 new)

### Documentation
- 21 new files in `docs/`: getting-started, guides, reference, and examples sections
- README updated: Agent Delegation section, updated config tables, docs index, v0.4.0 marked complete

## How It Works

```java
Agent coordinator = Agent.builder()
    .role("Lead Researcher")
    .goal("Coordinate research")
    .llm(model)
    .allowDelegation(true)
    .build();

Ensemble.builder()
    .agent(coordinator)
    .agent(writer)
    .task(task)
    .maxDelegationDepth(3)
    .build()
    .run();
```

Closes #17