### PR TITLE
feat: add .input() builder method for template variable inputs

### DIFF
--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -2,7 +2,9 @@ package net.agentensemble;
 
 import dev.langchain4j.model.chat.ChatModel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -122,26 +124,60 @@ public class Ensemble {
     private final List<EnsembleListener> listeners;
 
     /**
-     * Execute the ensemble's tasks with no input variables.
+     * Template variable inputs for task description and expected output substitution.
+     *
+     * Use {@code .input("key", "value")} on the builder to supply individual entries, or
+     * {@code .inputs(map)} to supply a batch. These values are applied on every {@link #run()}
+     * call. When the same key is also present in a {@link #run(Map)} invocation, the run-time
+     * value takes precedence over the builder value.
+     *
+     * Example:
+     * <pre>
+     * Ensemble.builder()
+     *     .agent(researcher)
+     *     .task(researchTask)
+     *     .input("topic", "AI agents")
+     *     .build()
+     *     .run();
+     * </pre>
+     */
+    @Singular("input")
+    private final Map<String, String> inputs;
+
+    /**
+     * Execute the ensemble's tasks using the inputs configured on the builder.
      *
      * @return EnsembleOutput containing all results
      * @throws ValidationException if the ensemble configuration is invalid
      */
     public EnsembleOutput run() {
-        return run(Map.of());
+        return runWithInputs(inputs);
     }
 
     /**
-     * Execute the ensemble's tasks with template variable substitution.
+     * Execute the ensemble's tasks, merging the supplied run-time inputs with any inputs
+     * configured on the builder. When the same key appears in both, the run-time value
+     * takes precedence.
      *
-     * Variables like {topic} in task descriptions and expected outputs are
-     * replaced with values from the inputs map before execution.
+     * Use this overload when the same {@code Ensemble} instance is executed multiple times
+     * with different variable values (for example, iterating over a list of topics or weeks).
+     * For the common single-run case, prefer setting inputs on the builder via
+     * {@code .input("key", "value")} and calling the no-arg {@link #run()}.
      *
-     * @param inputs map of variable names to replacement values
+     * @param runtimeInputs additional or overriding variable values
      * @return EnsembleOutput containing all results
      * @throws ValidationException if the ensemble configuration is invalid
      */
-    public EnsembleOutput run(Map<String, String> inputs) {
+    public EnsembleOutput run(Map<String, String> runtimeInputs) {
+        if (runtimeInputs == null || runtimeInputs.isEmpty()) {
+            return runWithInputs(inputs);
+        }
+        Map<String, String> merged = new LinkedHashMap<>(inputs);
+        merged.putAll(runtimeInputs);
+        return runWithInputs(Collections.unmodifiableMap(merged));
+    }
+
+    private EnsembleOutput runWithInputs(Map<String, String> resolvedInputs) {
         String ensembleId = UUID.randomUUID().toString();
         MDC.put("ensemble.id", ensembleId);
 
@@ -151,13 +187,13 @@ public class Ensemble {
                     workflow,
                     tasks.size(),
                     agents.size());
-            log.debug("Input variables: {}", inputs);
+            log.debug("Input variables: {}", resolvedInputs);
 
             // Step 1: Validate configuration
             new EnsembleValidator(this).validate();
 
             // Step 2: Resolve template variables in task descriptions and expected outputs
-            List<Task> resolvedTasks = resolveTasks(inputs);
+            List<Task> resolvedTasks = resolveTasks(resolvedInputs);
 
             // Step 3: Create memory context for this run (no-op when memory is not configured)
             MemoryContext memoryContext = memory != null ? MemoryContext.from(memory) : MemoryContext.disabled();

--- a/agentensemble-core/src/test/java/net/agentensemble/EnsembleTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/EnsembleTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.util.Map;
 import net.agentensemble.callback.EnsembleListener;
 import net.agentensemble.workflow.Workflow;
 import org.junit.jupiter.api.Test;
@@ -105,6 +106,49 @@ class EnsembleTest {
                 .onTaskStart(e -> {})
                 .build();
         assertThat(ensemble.getListeners()).hasSize(3);
+    }
+
+    // ========================
+    // Inputs builder
+    // ========================
+
+    @Test
+    void testDefaultInputs_isEmpty() {
+        var researcher = agent("Researcher");
+        var ensemble = Ensemble.builder().agent(researcher).build();
+        assertThat(ensemble.getInputs()).isEmpty();
+    }
+
+    @Test
+    void testInput_addsSingleEntry() {
+        var researcher = agent("Researcher");
+        var ensemble =
+                Ensemble.builder().agent(researcher).input("topic", "AI agents").build();
+        assertThat(ensemble.getInputs()).containsExactly(Map.entry("topic", "AI agents"));
+    }
+
+    @Test
+    void testMultipleInput_allAccumulate() {
+        var researcher = agent("Researcher");
+        var ensemble = Ensemble.builder()
+                .agent(researcher)
+                .input("company", "Acme")
+                .input("industry", "software")
+                .build();
+        assertThat(ensemble.getInputs())
+                .hasSize(2)
+                .containsEntry("company", "Acme")
+                .containsEntry("industry", "software");
+    }
+
+    @Test
+    void testInputs_bulkAddsAllEntries() {
+        var researcher = agent("Researcher");
+        var ensemble = Ensemble.builder()
+                .agent(researcher)
+                .inputs(Map.of("company", "Acme", "industry", "software"))
+                .build();
+        assertThat(ensemble.getInputs()).containsEntry("company", "Acme").containsEntry("industry", "software");
     }
 
     // ========================

--- a/agentensemble-core/src/test/java/net/agentensemble/integration/SequentialEnsembleIntegrationTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/integration/SequentialEnsembleIntegrationTest.java
@@ -191,6 +191,65 @@ class SequentialEnsembleIntegrationTest {
         assertThat(output.getTaskOutputs().get(0).getTaskDescription()).isEqualTo("Research AI Agents developments");
     }
 
+    @Test
+    void testBuilderInput_resolvedAtRunTime() {
+        var agent = agentWithResponse("Researcher", "Research about AI Agents");
+        var task = Task.builder()
+                .description("Research {topic} developments")
+                .expectedOutput("A report on {topic}")
+                .agent(agent)
+                .build();
+
+        var output = Ensemble.builder()
+                .agent(agent)
+                .task(task)
+                .input("topic", "AI Agents")
+                .build()
+                .run();
+
+        assertThat(output.getTaskOutputs().get(0).getTaskDescription()).isEqualTo("Research AI Agents developments");
+    }
+
+    @Test
+    void testRunTimeInput_overridesBuilderInput_whenKeyConflicts() {
+        var agent = agentWithResponse("Researcher", "Research about Machine Learning");
+        var task = Task.builder()
+                .description("Research {topic} developments")
+                .expectedOutput("A report on {topic}")
+                .agent(agent)
+                .build();
+
+        var output = Ensemble.builder()
+                .agent(agent)
+                .task(task)
+                .input("topic", "AI Agents") // builder default
+                .build()
+                .run(Map.of("topic", "Machine Learning")); // run-time wins
+
+        assertThat(output.getTaskOutputs().get(0).getTaskDescription())
+                .isEqualTo("Research Machine Learning developments");
+    }
+
+    @Test
+    void testRunTimeInput_mergesWithBuilderInputs_whenKeysDiffer() {
+        var agent = agentWithResponse("Researcher", "Research about AI Agents in 2026");
+        var task = Task.builder()
+                .description("Research {topic} developments in {year}")
+                .expectedOutput("A report")
+                .agent(agent)
+                .build();
+
+        var output = Ensemble.builder()
+                .agent(agent)
+                .task(task)
+                .input("year", "2026") // builder provides year
+                .build()
+                .run(Map.of("topic", "AI Agents")); // run-time provides topic
+
+        assertThat(output.getTaskOutputs().get(0).getTaskDescription())
+                .isEqualTo("Research AI Agents developments in 2026");
+    }
+
     // ========================
     // Error handling
     // ========================

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/CallbackExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/CallbackExample.java
@@ -4,7 +4,6 @@ import dev.langchain4j.model.openai.OpenAiChatModel;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.agentensemble.Agent;
 import net.agentensemble.Ensemble;
@@ -183,6 +182,7 @@ public class CallbackExample {
                 .task(researchTask)
                 .task(writeTask)
                 .workflow(Workflow.SEQUENTIAL)
+                .input("topic", topic)
                 // Full interface listener: collects all metrics
                 .listener(metrics)
                 // Lambda convenience: simple progress indicator
@@ -199,7 +199,7 @@ public class CallbackExample {
 
         System.out.println("\nRunning ensemble with callbacks registered...\n");
 
-        EnsembleOutput output = ensemble.run(Map.of("topic", topic));
+        EnsembleOutput output = ensemble.run();
 
         // ========================
         // Display results

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/HierarchicalTeamExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/HierarchicalTeamExample.java
@@ -1,7 +1,6 @@
 package net.agentensemble.examples;
 
 import dev.langchain4j.model.openai.OpenAiChatModel;
-import java.util.Map;
 import net.agentensemble.Agent;
 import net.agentensemble.Ensemble;
 import net.agentensemble.Task;
@@ -121,8 +120,9 @@ public class HierarchicalTeamExample {
                 .workflow(Workflow.HIERARCHICAL)
                 .managerLlm(powerfulModel)
                 .managerMaxIterations(15)
+                .input("company", company)
                 .build()
-                .run(Map.of("company", company));
+                .run();
 
         // ========================
         // Display results

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/ParallelCompetitiveIntelligenceExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/ParallelCompetitiveIntelligenceExample.java
@@ -2,7 +2,6 @@ package net.agentensemble.examples;
 
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import java.util.List;
-import java.util.Map;
 import net.agentensemble.Agent;
 import net.agentensemble.Ensemble;
 import net.agentensemble.Task;
@@ -138,8 +137,10 @@ public class ParallelCompetitiveIntelligenceExample {
                 .task(swotTask)
                 .task(summaryTask)
                 .workflow(Workflow.PARALLEL)
+                .input("company", company)
+                .input("industry", industry)
                 .build()
-                .run(Map.of("company", company, "industry", industry));
+                .run();
 
         // ========================
         // Display results

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/ResearchWriterExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/ResearchWriterExample.java
@@ -1,7 +1,6 @@
 package net.agentensemble.examples;
 
 import dev.langchain4j.model.openai.OpenAiChatModel;
-import java.util.Map;
 import net.agentensemble.Agent;
 import net.agentensemble.Ensemble;
 import net.agentensemble.Task;
@@ -121,14 +120,14 @@ public class ResearchWriterExample {
                 .task(writeTask)
                 .workflow(Workflow.SEQUENTIAL)
                 .verbose(false)
+                .input("topic", topic)
                 .build();
 
         log.info("Running ensemble with 2 agents and 2 tasks...");
         log.info("Topic: {}", topic);
         System.out.println("\n" + "=".repeat(60));
 
-        // Run with template variable substitution
-        EnsembleOutput output = ensemble.run(Map.of("topic", topic));
+        EnsembleOutput output = ensemble.run();
 
         // ========================
         // Display results

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/StructuredOutputExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/StructuredOutputExample.java
@@ -2,7 +2,6 @@ package net.agentensemble.examples;
 
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import java.util.List;
-import java.util.Map;
 import net.agentensemble.Agent;
 import net.agentensemble.Ensemble;
 import net.agentensemble.Task;
@@ -134,8 +133,9 @@ public class StructuredOutputExample {
                 .task(plainResearchTask)
                 .task(writeTask)
                 .workflow(Workflow.SEQUENTIAL)
+                .input("topic", topic)
                 .build()
-                .run(Map.of("topic", topic));
+                .run();
 
         System.out.println(markdownOutput.getRaw());
 

--- a/docs/guides/template-variables.md
+++ b/docs/guides/template-variables.md
@@ -1,12 +1,12 @@
 # Template Variables
 
-Task descriptions and expected outputs support `{variable}` placeholder substitution. Variables are resolved at run time by calling `ensemble.run(Map<String, String> inputs)`.
+Task descriptions and expected outputs support `{variable}` placeholder substitution. Variables are resolved at run time from inputs configured on the builder or passed to `ensemble.run(Map<String, String>)`.
 
 ---
 
 ## Basic Usage
 
-Use curly braces to define a placeholder:
+Use curly braces to define a placeholder in any task description or expected output:
 
 ```java
 Task task = Task.builder()
@@ -16,18 +16,49 @@ Task task = Task.builder()
     .build();
 ```
 
-Pass values at run time:
+Supply values on the builder with `.input("key", "value")`:
 
 ```java
-EnsembleOutput output = ensemble.run(Map.of(
-    "topic", "quantum computing",
-    "audience", "software engineers"
-));
+EnsembleOutput output = Ensemble.builder()
+    .agent(researcher)
+    .task(task)
+    .input("topic", "quantum computing")
+    .input("audience", "software engineers")
+    .build()
+    .run();
 ```
 
 The resolved description becomes:
 ```
 Research the latest developments in quantum computing for the software engineers audience
+```
+
+---
+
+## Multiple Inputs
+
+Chain `.input()` calls -- they accumulate and are all applied at run time:
+
+```java
+Ensemble.builder()
+    .agent(analyst)
+    .task(financialTask)
+    .input("company", "Acme Corp")
+    .input("quarter", "Q4")
+    .input("year", "2025")
+    .build()
+    .run();
+```
+
+To supply a whole map at once, use `.inputs(Map<String, String>)`:
+
+```java
+Ensemble.builder()
+    .agent(analyst)
+    .task(financialTask)
+    .inputs(Map.of("company", "Acme Corp", "quarter", "Q4", "year", "2025"))
+    .build()
+    .run();
 ```
 
 ---
@@ -48,21 +79,56 @@ Task task = Task.builder()
 
 ## No-Variable Runs
 
-When no variables are needed, call `run()` without arguments:
+When no variables are needed, call `run()` without any inputs configured:
 
 ```java
 EnsembleOutput output = ensemble.run();
-// equivalent to ensemble.run(Map.of())
+```
+
+---
+
+## Dynamic Runs: Overriding Inputs at Invocation Time
+
+When you need to run the same ensemble multiple times with different variable values, keep the ensemble instance and pass values to `run(Map<String, String>)`. Run-time values are merged with any builder inputs; **run-time values win** on key conflicts:
+
+```java
+// Create tasks and ensemble once
+Ensemble ensemble = Ensemble.builder()
+    .agent(analyst).agent(advisor)
+    .task(analysisTask).task(recommendationTask)
+    .build();
+
+// Invoke multiple times with different inputs
+ensemble.run(Map.of("week", "2026-01-06"));
+ensemble.run(Map.of("week", "2026-01-13"));
+ensemble.run(Map.of("week", "2026-01-20"));
+```
+
+Merge example -- builder provides a default, run-time call overrides it:
+
+```java
+Ensemble ensemble = Ensemble.builder()
+    .agent(researcher)
+    .task(task)
+    .input("audience", "developers")  // default
+    .build();
+
+// audience = "developers" (builder default)
+ensemble.run(Map.of("topic", "AI agents"));
+
+// audience = "executives" (run-time overrides builder)
+ensemble.run(Map.of("topic", "AI agents", "audience", "executives"));
 ```
 
 ---
 
 ## Missing Variables
 
-If a task description contains a placeholder that is not in the inputs map, a `PromptTemplateException` is thrown before any LLM calls:
+If a task description contains a placeholder that is not supplied by either the builder inputs or the run-time inputs, a `PromptTemplateException` is thrown before any LLM calls:
 
 ```java
 // Task has {topic} and {year} placeholders
+// Builder has no inputs configured
 try {
     ensemble.run(Map.of("topic", "AI"));  // missing "year"
 } catch (PromptTemplateException e) {
@@ -85,7 +151,7 @@ Task task = Task.builder()
     .build();
 ```
 
-With `inputs = Map.of("varName", "userId")`, the resolved description is:
+With `input("varName", "userId")`, the resolved description is:
 ```
 Write a Java method that parses {variable} from a string. Variable name: userId
 ```
@@ -94,7 +160,7 @@ Write a Java method that parses {variable} from a string. Variable name: userId
 
 ## Sharing Variables Across Tasks
 
-All tasks in the ensemble are resolved with the same inputs map. Any variable defined in inputs is available in all task descriptions and expected outputs:
+All tasks in the ensemble are resolved with the same inputs. Any variable defined on the builder is available in all task descriptions and expected outputs:
 
 ```java
 var researchTask = Task.builder()
@@ -110,40 +176,13 @@ var writeTask = Task.builder()
     .context(List.of(researchTask))
     .build();
 
-// Both tasks receive the same variables
-ensemble.run(Map.of("topic", "AI agents"));
-```
-
----
-
-## Dynamic Task Creation
-
-Because template resolution happens at run time, you can create task templates once and reuse them across multiple runs:
-
-```java
-// Create tasks once
-var researchTask = Task.builder()
-    .description("Research {topic}")
-    .expectedOutput("A summary of {topic}")
-    .agent(researcher)
-    .build();
-
-var writeTask = Task.builder()
-    .description("Write about {topic}")
-    .expectedOutput("A blog post about {topic}")
-    .agent(writer)
-    .context(List.of(researchTask))
-    .build();
-
-Ensemble ensemble = Ensemble.builder()
+// Both tasks receive the same variable
+Ensemble.builder()
     .agent(researcher).agent(writer)
     .task(researchTask).task(writeTask)
-    .build();
-
-// Run multiple times with different inputs
-ensemble.run(Map.of("topic", "AI agents"));
-ensemble.run(Map.of("topic", "quantum computing"));
-ensemble.run(Map.of("topic", "blockchain"));
+    .input("topic", "AI agents")
+    .build()
+    .run();
 ```
 
 ---
@@ -168,5 +207,10 @@ Variable names are case-sensitive and can contain letters, digits, and underscor
 Values are always strings. Passing `null` as a value is not permitted by `Map.of()`. Empty strings are allowed but will produce empty substitutions:
 
 ```java
-ensemble.run(Map.of("topic", ""));   // substitutes empty string
+Ensemble.builder()
+    .agent(researcher)
+    .task(task)
+    .input("topic", "")  // substitutes empty string
+    .build()
+    .run();
 ```

--- a/docs/reference/ensemble-configuration.md
+++ b/docs/reference/ensemble-configuration.md
@@ -6,6 +6,7 @@ All fields available on `Ensemble.builder()`.
 |---|---|---|---|---|
 | `agents` | `List<Agent>` | Yes | -- | All agents participating in this ensemble. Add with `.agent(a)` (singular) or `.agents(list)`. |
 | `tasks` | `List<Task>` | Yes | -- | All tasks to execute. Add with `.task(t)` (singular) or `.tasks(list)`. |
+| `inputs` | `Map<String, String>` | No | `{}` | Template variable values applied to all task descriptions and expected outputs at run time. Add individual entries with `.input("key", "value")` or a batch with `.inputs(map)`. Run-time values passed to `run(Map)` are merged on top; run-time values win on conflicts. See [Template Variables guide](../guides/template-variables.md). |
 | `workflow` | `Workflow` | No | `SEQUENTIAL` | Execution strategy. `SEQUENTIAL`, `HIERARCHICAL`, or `PARALLEL`. |
 | `managerLlm` | `ChatModel` | No | First agent's LLM | LLM for the auto-created Manager agent (hierarchical workflow only). |
 | `managerMaxIterations` | `int` | No | `20` | Maximum tool-call iterations for the Manager agent. Must be greater than zero (hierarchical only). |
@@ -64,15 +65,17 @@ EnsembleOutput output = Ensemble.builder()
     .task(writeTask)
     .task(editTask)
     .workflow(Workflow.SEQUENTIAL)
+    .input("topic", "AI agents")
+    .input("audience", "developers")
     .verbose(false)
     .memory(EnsembleMemory.builder().shortTerm(true).build())
     .maxDelegationDepth(2)
     .build()
-    .run(Map.of("topic", "AI agents", "audience", "developers"));
+    .run();
 ```
 
 ---
 
 ## Template Variables
 
-Call `ensemble.run(Map<String, String> inputs)` to resolve `{variable}` placeholders in all task descriptions and expected outputs. See [Template Variables guide](../guides/template-variables.md).
+Use `.input("key", "value")` on the builder to supply `{variable}` placeholder values for all task descriptions and expected outputs. For dynamic multi-run scenarios, pass values to `run(Map<String, String>)` instead; those values are merged on top of any builder inputs. See [Template Variables guide](../guides/template-variables.md).


### PR DESCRIPTION
## Summary

Adds `.input("key", "value")` as a first-class builder method on `Ensemble` so template variable inputs are declared alongside all other configuration, rather than being passed as an anonymous `Map` to `run()`.

### Before

```java
EnsembleOutput output = Ensemble.builder()
    .agent(marketResearcher)
    .task(marketTask)
    .workflow(Workflow.HIERARCHICAL)
    .managerLlm(powerfulModel)
    .build()
    .run(Map.of("company", company));
```

### After

```java
EnsembleOutput output = Ensemble.builder()
    .agent(marketResearcher)
    .task(marketTask)
    .workflow(Workflow.HIERARCHICAL)
    .managerLlm(powerfulModel)
    .input("company", company)
    .build()
    .run();
```

Multiple inputs scale naturally by chaining:

```java
.input("company", company)
.input("industry", industry)
.build()
.run();
```

## Design

- `@Singular("input") Map<String, String> inputs` added to `Ensemble` -- Lombok generates `.input(k, v)` (singular) and `.inputs(Map)` (bulk)
- `run()` uses builder inputs directly
- `run(Map)` merges builder inputs + run-time inputs (run-time wins on key conflicts) -- backward compatible, and supports the multi-run pattern in `MemoryAcrossRunsExample`

## Changes

- `Ensemble.java`: new field + refactored `run()` / `run(Map)` / `runWithInputs()`
- `EnsembleTest`: 4 new builder tests (default empty, single, multiple, bulk)
- `SequentialEnsembleIntegrationTest`: 3 new integration tests (builder resolves templates, run-time override on conflict, cross-source merge)
- All 5 examples updated to use `.input()` on the builder
- `docs/guides/template-variables.md` and `docs/reference/ensemble-configuration.md` updated