### PR TITLE
feat: guardrails -- pre/post execution validation hooks (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,46 @@ Ensemble.builder()
 
 ---
 
+## Guardrails
+
+Add pluggable validation hooks to tasks to control what enters and exits agent execution:
+
+```java
+// Block before the LLM is called
+InputGuardrail noPiiGuardrail = input -> {
+    if (input.taskDescription().contains("SSN")) {
+        return GuardrailResult.failure("Task contains PII");
+    }
+    return GuardrailResult.success();
+};
+
+// Validate after the agent responds
+OutputGuardrail lengthGuardrail = output -> {
+    if (output.rawResponse().length() > 5000) {
+        return GuardrailResult.failure("Response exceeds 5000 characters");
+    }
+    return GuardrailResult.success();
+};
+
+var task = Task.builder()
+    .description("Summarize the article")
+    .expectedOutput("A concise summary")
+    .agent(writer)
+    .inputGuardrails(List.of(noPiiGuardrail))
+    .outputGuardrails(List.of(lengthGuardrail))
+    .build();
+```
+
+**Input guardrails** fire before the LLM call -- if any fails, `GuardrailViolationException` is thrown and no API call is made.
+
+**Output guardrails** fire after the agent response (and after structured output parsing when `outputType` is set).
+
+When a guardrail blocks a task, `GuardrailViolationException` propagates and is wrapped in `TaskExecutionException`, consistent with other task failures. The `TaskFailedEvent` callback fires before the exception propagates.
+
+**Full documentation:** [Guardrails Guide](https://docs.agentensemble.net/guides/guardrails/)
+
+---
+
 ## Task Configuration
 
 | Option | Type | Default | Description |
@@ -502,6 +542,8 @@ Ensemble.builder()
 | `context` | `List<Task>` | `[]` | Prior tasks whose outputs feed into this task (sequential workflow) |
 | `outputType` | `Class<?>` | `null` | Java class for structured output parsing. Records recommended. |
 | `maxOutputRetries` | `int` | `3` | Retry attempts when structured output parsing fails. `0` disables retries. |
+| `inputGuardrails` | `List<InputGuardrail>` | `[]` | Validation hooks that run before the LLM call. |
+| `outputGuardrails` | `List<OutputGuardrail>` | `[]` | Validation hooks that run after the agent produces a response. |
 
 **Full documentation:** [Task Configuration Reference](https://docs.agentensemble.net/reference/task-configuration/) | [Tasks Guide](https://docs.agentensemble.net/guides/tasks/)
 
@@ -744,7 +786,8 @@ Full documentation is available at **[docs.agentensemble.net](https://docs.agent
 | ~~v0.5.0~~ | ~~Parallel workflow (virtual threads)~~ |
 | ~~v0.6.0~~ | ~~Structured output (typed output parsing)~~ |
 | ~~v0.7.0~~ | ~~Callbacks and event listeners~~ |
-| v1.0.0 | Streaming, guardrails, built-in tools |
+| ~~v0.8.0~~ | ~~Guardrails: pre/post execution validation~~ |
+| v1.0.0 | Streaming, built-in tools |
 
 ---
 

--- a/agentensemble-core/src/main/java/net/agentensemble/Task.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Task.java
@@ -4,6 +4,8 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 import net.agentensemble.exception.ValidationException;
+import net.agentensemble.guardrail.InputGuardrail;
+import net.agentensemble.guardrail.OutputGuardrail;
 
 /**
  * A unit of work assigned to an agent.
@@ -101,6 +103,37 @@ public class Task {
     int maxOutputRetries;
 
     /**
+     * Guardrails evaluated before this task is executed.
+     *
+     * Each guardrail receives a {@link net.agentensemble.guardrail.GuardrailInput}
+     * containing the task description, expected output, context outputs, and agent role.
+     * If any guardrail returns a failure result, a
+     * {@link net.agentensemble.guardrail.GuardrailViolationException} is thrown before
+     * any LLM call is made.
+     *
+     * Guardrails are evaluated in order; the first failure stops evaluation.
+     *
+     * Default: empty list (no input validation).
+     */
+    List<InputGuardrail> inputGuardrails;
+
+    /**
+     * Guardrails evaluated after this task's agent produces a response.
+     *
+     * Each guardrail receives a {@link net.agentensemble.guardrail.GuardrailOutput}
+     * containing the raw response text, the parsed output (if any), the task
+     * description, and the agent role. If any guardrail returns a failure result,
+     * a {@link net.agentensemble.guardrail.GuardrailViolationException} is thrown.
+     * When {@link #outputType} is set, output guardrails run after structured output
+     * parsing completes.
+     *
+     * Guardrails are evaluated in order; the first failure stops evaluation.
+     *
+     * Default: empty list (no output validation).
+     */
+    List<OutputGuardrail> outputGuardrails;
+
+    /**
      * Custom builder that sets defaults and validates the Task configuration.
      */
     public static class TaskBuilder {
@@ -109,6 +142,8 @@ public class Task {
         private List<Task> context = List.of();
         private Class<?> outputType = null;
         private int maxOutputRetries = 3;
+        private List<InputGuardrail> inputGuardrails = List.of();
+        private List<OutputGuardrail> outputGuardrails = List.of();
 
         public Task build() {
             validateDescription();
@@ -119,7 +154,19 @@ public class Task {
             validateOutputType();
             validateMaxOutputRetries();
             context = List.copyOf(effectiveContext);
-            return new Task(description, expectedOutput, agent, context, outputType, maxOutputRetries);
+            List<InputGuardrail> effectiveInputGuardrails = inputGuardrails != null ? inputGuardrails : List.of();
+            List<OutputGuardrail> effectiveOutputGuardrails = outputGuardrails != null ? outputGuardrails : List.of();
+            inputGuardrails = List.copyOf(effectiveInputGuardrails);
+            outputGuardrails = List.copyOf(effectiveOutputGuardrails);
+            return new Task(
+                    description,
+                    expectedOutput,
+                    agent,
+                    context,
+                    outputType,
+                    maxOutputRetries,
+                    inputGuardrails,
+                    outputGuardrails);
         }
 
         private void validateDescription() {

--- a/agentensemble-core/src/main/java/net/agentensemble/agent/AgentExecutor.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/agent/AgentExecutor.java
@@ -21,6 +21,13 @@ import net.agentensemble.delegation.DelegationContext;
 import net.agentensemble.exception.AgentExecutionException;
 import net.agentensemble.exception.MaxIterationsExceededException;
 import net.agentensemble.execution.ExecutionContext;
+import net.agentensemble.guardrail.GuardrailInput;
+import net.agentensemble.guardrail.GuardrailOutput;
+import net.agentensemble.guardrail.GuardrailResult;
+import net.agentensemble.guardrail.GuardrailViolationException;
+import net.agentensemble.guardrail.GuardrailViolationException.GuardrailType;
+import net.agentensemble.guardrail.InputGuardrail;
+import net.agentensemble.guardrail.OutputGuardrail;
 import net.agentensemble.task.TaskOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +107,9 @@ public class AgentExecutor {
         Agent agent = task.getAgent();
         boolean effectiveVerbose = verbose || agent.isVerbose();
 
+        // Run input guardrails before any LLM call -- throws GuardrailViolationException on failure
+        runInputGuardrails(task, contextOutputs);
+
         // Build prompts -- memory context injects STM, LTM, and entity knowledge as applicable
         String systemPrompt = AgentPromptBuilder.buildSystemPrompt(agent);
         String userPrompt = AgentPromptBuilder.buildUserPrompt(task, contextOutputs, executionContext.memoryContext());
@@ -164,6 +174,9 @@ public class AgentExecutor {
         if (task.getOutputType() != null) {
             parsedOutput = StructuredOutputHandler.parse(agent, task, finalResponse, systemPrompt);
         }
+
+        // Run output guardrails after response (and after structured output parsing)
+        runOutputGuardrails(task, finalResponse, parsedOutput);
 
         Duration duration = Duration.between(startTime, Instant.now());
         int toolCalls = toolCallCounter.get();
@@ -306,6 +319,76 @@ public class AgentExecutor {
             } else {
                 // LLM produced a text response -- we're done
                 return aiMessage.text();
+            }
+        }
+    }
+
+    // ========================
+    // Guardrail invocation
+    // ========================
+
+    /**
+     * Evaluate all input guardrails on the task before the LLM call.
+     *
+     * Guardrails are evaluated in order. The first failure stops evaluation and throws
+     * {@link GuardrailViolationException} with type INPUT.
+     *
+     * @param task           the task being executed
+     * @param contextOutputs outputs from prior tasks passed as context
+     * @throws GuardrailViolationException if any input guardrail fails
+     */
+    private void runInputGuardrails(Task task, List<TaskOutput> contextOutputs) {
+        List<InputGuardrail> guardrails = task.getInputGuardrails();
+        if (guardrails.isEmpty()) {
+            return;
+        }
+        Agent agent = task.getAgent();
+        GuardrailInput input =
+                new GuardrailInput(task.getDescription(), task.getExpectedOutput(), contextOutputs, agent.getRole());
+
+        for (InputGuardrail guardrail : guardrails) {
+            GuardrailResult result = guardrail.validate(input);
+            if (!result.isSuccess()) {
+                log.warn(
+                        "Input guardrail blocked agent '{}' task '{}': {}",
+                        agent.getRole(),
+                        truncate(task.getDescription(), 80),
+                        result.getMessage());
+                throw new GuardrailViolationException(
+                        GuardrailType.INPUT, result.getMessage(), task.getDescription(), agent.getRole());
+            }
+        }
+    }
+
+    /**
+     * Evaluate all output guardrails on the agent response after the LLM call.
+     *
+     * Guardrails are evaluated in order. The first failure stops evaluation and throws
+     * {@link GuardrailViolationException} with type OUTPUT.
+     *
+     * @param task         the task that was executed
+     * @param rawResponse  the raw text response from the agent
+     * @param parsedOutput the parsed structured output, or {@code null} if not applicable
+     * @throws GuardrailViolationException if any output guardrail fails
+     */
+    private void runOutputGuardrails(Task task, String rawResponse, Object parsedOutput) {
+        List<OutputGuardrail> guardrails = task.getOutputGuardrails();
+        if (guardrails.isEmpty()) {
+            return;
+        }
+        Agent agent = task.getAgent();
+        GuardrailOutput output = new GuardrailOutput(rawResponse, parsedOutput, task.getDescription(), agent.getRole());
+
+        for (OutputGuardrail guardrail : guardrails) {
+            GuardrailResult result = guardrail.validate(output);
+            if (!result.isSuccess()) {
+                log.warn(
+                        "Output guardrail blocked agent '{}' task '{}': {}",
+                        agent.getRole(),
+                        truncate(task.getDescription(), 80),
+                        result.getMessage());
+                throw new GuardrailViolationException(
+                        GuardrailType.OUTPUT, result.getMessage(), task.getDescription(), agent.getRole());
             }
         }
     }

--- a/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailInput.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailInput.java
@@ -1,0 +1,28 @@
+package net.agentensemble.guardrail;
+
+import java.util.List;
+import net.agentensemble.task.TaskOutput;
+
+/**
+ * The context object passed to an {@link InputGuardrail} before agent execution begins.
+ *
+ * Carries everything the guardrail needs to decide whether the task should proceed:
+ * the task description, expected output, outputs from prior context tasks, and the
+ * agent role that will execute the task.
+ *
+ * @param taskDescription the description of the task about to be executed
+ * @param expectedOutput  the expected output as configured on the task
+ * @param contextOutputs  outputs from prior tasks declared as context for this task
+ *                        (immutable; may be empty)
+ * @param agentRole       the role of the agent assigned to execute this task
+ */
+public record GuardrailInput(
+        String taskDescription, String expectedOutput, List<TaskOutput> contextOutputs, String agentRole) {
+
+    /**
+     * Defensive copy constructor: ensures contextOutputs is always immutable.
+     */
+    public GuardrailInput {
+        contextOutputs = List.copyOf(contextOutputs);
+    }
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailOutput.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailOutput.java
@@ -1,0 +1,17 @@
+package net.agentensemble.guardrail;
+
+/**
+ * The context object passed to an {@link OutputGuardrail} after agent execution completes.
+ *
+ * Carries everything the guardrail needs to decide whether the response should be
+ * accepted: the raw LLM text, the typed parsed output (if the task had an
+ * {@code outputType}), the task description, and the agent role that produced the output.
+ *
+ * @param rawResponse     the full text response produced by the agent
+ * @param parsedOutput    the parsed Java object when the task declared an
+ *                        {@code outputType}; {@code null} when no structured output
+ *                        was requested
+ * @param taskDescription the description of the task that was executed
+ * @param agentRole       the role of the agent that produced the output
+ */
+public record GuardrailOutput(String rawResponse, Object parsedOutput, String taskDescription, String agentRole) {}

--- a/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailResult.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailResult.java
@@ -1,0 +1,66 @@
+package net.agentensemble.guardrail;
+
+import java.util.Objects;
+
+/**
+ * The result of a guardrail validation check.
+ *
+ * Instances are created via the factory methods {@link #success()} and
+ * {@link #failure(String)}.
+ *
+ * A successful result carries an empty message. A failure result carries a
+ * non-null reason string that is included in the
+ * {@link GuardrailViolationException} message when the guardrail blocks execution.
+ */
+public final class GuardrailResult {
+
+    private static final GuardrailResult SUCCESS = new GuardrailResult(true, "");
+
+    private final boolean success;
+    private final String message;
+
+    private GuardrailResult(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    /**
+     * Returns a result indicating the guardrail passed.
+     *
+     * @return a successful guardrail result
+     */
+    public static GuardrailResult success() {
+        return SUCCESS;
+    }
+
+    /**
+     * Returns a result indicating the guardrail blocked execution.
+     *
+     * @param reason a human-readable explanation of why the guardrail failed;
+     *               must not be null
+     * @return a failure guardrail result carrying the given reason
+     * @throws NullPointerException if reason is null
+     */
+    public static GuardrailResult failure(String reason) {
+        Objects.requireNonNull(reason, "reason must not be null");
+        return new GuardrailResult(false, reason);
+    }
+
+    /**
+     * Returns {@code true} if the guardrail passed.
+     *
+     * @return true when the check succeeded, false when it failed
+     */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /**
+     * Returns the failure reason, or an empty string when the result is a success.
+     *
+     * @return the failure message, never null
+     */
+    public String getMessage() {
+        return message;
+    }
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailViolationException.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/guardrail/GuardrailViolationException.java
@@ -1,0 +1,97 @@
+package net.agentensemble.guardrail;
+
+import net.agentensemble.exception.AgentEnsembleException;
+
+/**
+ * Thrown when a guardrail validation check fails, blocking task execution.
+ *
+ * Carries the guardrail type (INPUT or OUTPUT), the violation message returned
+ * by the guardrail, the task description, and the agent role -- providing full
+ * diagnostic context at the call site.
+ *
+ * Input guardrail violations are thrown before any LLM call is made.
+ * Output guardrail violations are thrown after the agent response (and any
+ * structured output parsing) has completed.
+ */
+public class GuardrailViolationException extends AgentEnsembleException {
+
+    /**
+     * Identifies whether the violation was detected on input (before execution) or
+     * output (after execution).
+     */
+    public enum GuardrailType {
+        /** The guardrail ran before the LLM call and blocked execution. */
+        INPUT,
+        /** The guardrail ran after the LLM response and blocked the result. */
+        OUTPUT
+    }
+
+    private final GuardrailType guardrailType;
+    private final String violationMessage;
+    private final String taskDescription;
+    private final String agentRole;
+
+    /**
+     * Constructs a new {@code GuardrailViolationException}.
+     *
+     * @param guardrailType    whether the violation was on INPUT or OUTPUT
+     * @param violationMessage the reason returned by the failing guardrail
+     * @param taskDescription  the description of the task that was blocked
+     * @param agentRole        the role of the agent assigned to the task
+     */
+    public GuardrailViolationException(
+            GuardrailType guardrailType, String violationMessage, String taskDescription, String agentRole) {
+        super(buildMessage(guardrailType, violationMessage, taskDescription, agentRole));
+        this.guardrailType = guardrailType;
+        this.violationMessage = violationMessage;
+        this.taskDescription = taskDescription;
+        this.agentRole = agentRole;
+    }
+
+    private static String buildMessage(
+            GuardrailType guardrailType, String violationMessage, String taskDescription, String agentRole) {
+        return guardrailType
+                + " guardrail violation on agent '"
+                + agentRole
+                + "' task '"
+                + taskDescription
+                + "': "
+                + violationMessage;
+    }
+
+    /**
+     * Returns whether this violation was detected on the task input or output.
+     *
+     * @return the guardrail type
+     */
+    public GuardrailType getGuardrailType() {
+        return guardrailType;
+    }
+
+    /**
+     * Returns the failure reason supplied by the failing guardrail.
+     *
+     * @return the violation message, never null
+     */
+    public String getViolationMessage() {
+        return violationMessage;
+    }
+
+    /**
+     * Returns the description of the task that was blocked.
+     *
+     * @return the task description, never null
+     */
+    public String getTaskDescription() {
+        return taskDescription;
+    }
+
+    /**
+     * Returns the role of the agent assigned to the blocked task.
+     *
+     * @return the agent role, never null
+     */
+    public String getAgentRole() {
+        return agentRole;
+    }
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/guardrail/InputGuardrail.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/guardrail/InputGuardrail.java
@@ -1,0 +1,37 @@
+package net.agentensemble.guardrail;
+
+/**
+ * A pluggable validation hook that runs before an agent executes a task.
+ *
+ * Implement this functional interface to inspect the task input (description,
+ * expected output, prior context outputs, and agent role) and decide whether
+ * execution should proceed.
+ *
+ * When the guardrail returns a {@linkplain GuardrailResult#failure(String) failure}
+ * result, {@link GuardrailViolationException} is thrown immediately -- before any
+ * LLM call is made.
+ *
+ * When multiple input guardrails are configured on a task, they are evaluated in
+ * order. The first failure stops evaluation and throws the exception.
+ *
+ * Example:
+ * <pre>
+ * InputGuardrail noPiiGuardrail = input -> {
+ *     if (containsPersonalInfo(input.taskDescription())) {
+ *         return GuardrailResult.failure("Task description contains personal information");
+ *     }
+ *     return GuardrailResult.success();
+ * };
+ * </pre>
+ */
+@FunctionalInterface
+public interface InputGuardrail {
+
+    /**
+     * Validate the task input before execution begins.
+     *
+     * @param input the guardrail input context
+     * @return a {@link GuardrailResult} indicating pass or fail
+     */
+    GuardrailResult validate(GuardrailInput input);
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/guardrail/OutputGuardrail.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/guardrail/OutputGuardrail.java
@@ -1,0 +1,39 @@
+package net.agentensemble.guardrail;
+
+/**
+ * A pluggable validation hook that runs after an agent produces a response.
+ *
+ * Implement this functional interface to inspect the raw response text and (when
+ * applicable) the parsed structured output, then decide whether the response should
+ * be accepted.
+ *
+ * When the guardrail returns a {@linkplain GuardrailResult#failure(String) failure}
+ * result, {@link GuardrailViolationException} is thrown. When structured output
+ * parsing was requested ({@code task.outputType} is set), output guardrails run after
+ * parsing completes -- the parsed object is available via
+ * {@link GuardrailOutput#parsedOutput()}.
+ *
+ * When multiple output guardrails are configured on a task, they are evaluated in
+ * order. The first failure stops evaluation and throws the exception.
+ *
+ * Example:
+ * <pre>
+ * OutputGuardrail lengthGuardrail = output -> {
+ *     if (output.rawResponse().length() > 5000) {
+ *         return GuardrailResult.failure("Response exceeds maximum length of 5000 characters");
+ *     }
+ *     return GuardrailResult.success();
+ * };
+ * </pre>
+ */
+@FunctionalInterface
+public interface OutputGuardrail {
+
+    /**
+     * Validate the agent output after execution completes.
+     *
+     * @param output the guardrail output context
+     * @return a {@link GuardrailResult} indicating pass or fail
+     */
+    GuardrailResult validate(GuardrailOutput output);
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/workflow/SequentialWorkflowExecutor.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/workflow/SequentialWorkflowExecutor.java
@@ -18,6 +18,7 @@ import net.agentensemble.exception.AgentExecutionException;
 import net.agentensemble.exception.MaxIterationsExceededException;
 import net.agentensemble.exception.TaskExecutionException;
 import net.agentensemble.execution.ExecutionContext;
+import net.agentensemble.guardrail.GuardrailViolationException;
 import net.agentensemble.task.TaskOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +134,7 @@ public class SequentialWorkflowExecutor implements WorkflowExecutor {
                         taskIndex,
                         totalTasks));
 
-            } catch (AgentExecutionException | MaxIterationsExceededException e) {
+            } catch (AgentExecutionException | MaxIterationsExceededException | GuardrailViolationException e) {
                 Duration taskDuration = Duration.between(taskStart, Instant.now());
                 log.error("Task {}/{} failed: {}", taskIndex, totalTasks, e.getMessage());
 

--- a/agentensemble-core/src/test/java/net/agentensemble/TaskTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/TaskTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.model.chat.ChatModel;
 import java.util.List;
+import net.agentensemble.guardrail.GuardrailResult;
+import net.agentensemble.guardrail.InputGuardrail;
+import net.agentensemble.guardrail.OutputGuardrail;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -260,5 +263,94 @@ class TaskTest {
                 .build();
 
         assertThat(task.getMaxOutputRetries()).isEqualTo(5);
+    }
+
+    // ========================
+    // inputGuardrails happy paths
+    // ========================
+
+    @Test
+    void testBuild_defaultInputGuardrails_isEmpty() {
+        var task = Task.builder()
+                .description("Task")
+                .expectedOutput("Output")
+                .agent(testAgent)
+                .build();
+
+        assertThat(task.getInputGuardrails()).isEmpty();
+    }
+
+    @Test
+    void testBuild_withInputGuardrails_stored() {
+        InputGuardrail guardrail = input -> GuardrailResult.success();
+
+        var task = Task.builder()
+                .description("Task")
+                .expectedOutput("Output")
+                .agent(testAgent)
+                .inputGuardrails(List.of(guardrail))
+                .build();
+
+        assertThat(task.getInputGuardrails()).containsExactly(guardrail);
+    }
+
+    @Test
+    void testBuild_inputGuardrailsList_isImmutable() {
+        InputGuardrail guardrail = input -> GuardrailResult.success();
+
+        var task = Task.builder()
+                .description("Task")
+                .expectedOutput("Output")
+                .agent(testAgent)
+                .inputGuardrails(List.of(guardrail))
+                .build();
+
+        assertThat(task.getInputGuardrails()).isUnmodifiable();
+    }
+
+    // ========================
+    // outputGuardrails happy paths
+    // ========================
+
+    @Test
+    void testBuild_defaultOutputGuardrails_isEmpty() {
+        var task = Task.builder()
+                .description("Task")
+                .expectedOutput("Output")
+                .agent(testAgent)
+                .build();
+
+        assertThat(task.getOutputGuardrails()).isEmpty();
+    }
+
+    @Test
+    void testBuild_withOutputGuardrails_stored() {
+        OutputGuardrail guardrail = output -> GuardrailResult.success();
+
+        var task = Task.builder()
+                .description("Task")
+                .expectedOutput("Output")
+                .agent(testAgent)
+                .outputGuardrails(List.of(guardrail))
+                .build();
+
+        assertThat(task.getOutputGuardrails()).containsExactly(guardrail);
+    }
+
+    @Test
+    void testBuild_withBothGuardrails_stored() {
+        InputGuardrail inGuard = input -> GuardrailResult.success();
+        OutputGuardrail outGuard = output -> GuardrailResult.success();
+
+        var task = Task.builder()
+                .description("Task")
+                .expectedOutput("Output")
+                .agent(testAgent)
+                .inputGuardrails(List.of(inGuard))
+                .outputGuardrails(List.of(outGuard))
+                .build();
+
+        assertThat(task.getInputGuardrails()).containsExactly(inGuard);
+        assertThat(task.getOutputGuardrails()).containsExactly(outGuard);
     }
 }

--- a/agentensemble-core/src/test/java/net/agentensemble/agent/AgentExecutorTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/agent/AgentExecutorTest.java
@@ -18,6 +18,8 @@ import net.agentensemble.Task;
 import net.agentensemble.exception.AgentExecutionException;
 import net.agentensemble.exception.MaxIterationsExceededException;
 import net.agentensemble.execution.ExecutionContext;
+import net.agentensemble.guardrail.GuardrailResult;
+import net.agentensemble.guardrail.GuardrailViolationException;
 import net.agentensemble.task.TaskOutput;
 import net.agentensemble.tool.AgentTool;
 import net.agentensemble.tool.ToolResult;
@@ -276,5 +278,204 @@ class AgentExecutorTest {
         assertThat(output.getRaw()).isEqualTo("Article written.");
         // Context is passed to LLM -- verified by the ChatRequest containing context
         verify(mockLlm).chat(any(ChatRequest.class));
+    }
+
+    // ========================
+    // Input guardrails
+    // ========================
+
+    @Test
+    void testExecute_inputGuardrailPasses_executionProceeds() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("Result text"));
+
+        var agent = Agent.builder().role("Writer").goal("Write").llm(mockLlm).build();
+        var task = Task.builder()
+                .description("Write a report")
+                .expectedOutput("Report")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.success()))
+                .build();
+
+        TaskOutput output = executor.execute(task, List.of(), ExecutionContext.disabled());
+
+        assertThat(output.getRaw()).isEqualTo("Result text");
+        verify(mockLlm).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void testExecute_inputGuardrailFails_throwsBeforeLlmCall() {
+        var mockLlm = mock(ChatModel.class);
+
+        var agent = Agent.builder().role("Writer").goal("Write").llm(mockLlm).build();
+        var task = Task.builder()
+                .description("Write a report about SSN 123-45-6789")
+                .expectedOutput("Report")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.failure("contains PII")))
+                .build();
+
+        assertThatThrownBy(() -> executor.execute(task, List.of(), ExecutionContext.disabled()))
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.INPUT);
+                    assertThat(e.getViolationMessage()).isEqualTo("contains PII");
+                    assertThat(e.getAgentRole()).isEqualTo("Writer");
+                    assertThat(e.getTaskDescription()).isEqualTo("Write a report about SSN 123-45-6789");
+                });
+
+        // LLM must NOT have been called
+        verify(mockLlm, org.mockito.Mockito.never()).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void testExecute_multipleInputGuardrails_firstFailureWins() {
+        var mockLlm = mock(ChatModel.class);
+
+        var agent = Agent.builder().role("Writer").goal("Write").llm(mockLlm).build();
+        var task = Task.builder()
+                .description("Write something")
+                .expectedOutput("Output")
+                .agent(agent)
+                .inputGuardrails(List.of(
+                        input -> GuardrailResult.failure("first blocker"),
+                        input -> GuardrailResult.failure("second blocker")))
+                .build();
+
+        assertThatThrownBy(() -> executor.execute(task, List.of(), ExecutionContext.disabled()))
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getViolationMessage()).isEqualTo("first blocker");
+                });
+    }
+
+    @Test
+    void testExecute_inputGuardrailReceivesCorrectContext() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("ok"));
+
+        var agent = Agent.builder().role("Analyst").goal("Analyze").llm(mockLlm).build();
+
+        // Capture the GuardrailInput for assertion
+        var capturedInput = new net.agentensemble.guardrail.GuardrailInput[] {null};
+        var task = Task.builder()
+                .description("Analyze this data")
+                .expectedOutput("Analysis output")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> {
+                    capturedInput[0] = input;
+                    return GuardrailResult.success();
+                }))
+                .build();
+
+        executor.execute(task, List.of(), ExecutionContext.disabled());
+
+        assertThat(capturedInput[0]).isNotNull();
+        assertThat(capturedInput[0].taskDescription()).isEqualTo("Analyze this data");
+        assertThat(capturedInput[0].expectedOutput()).isEqualTo("Analysis output");
+        assertThat(capturedInput[0].agentRole()).isEqualTo("Analyst");
+    }
+
+    // ========================
+    // Output guardrails
+    // ========================
+
+    @Test
+    void testExecute_outputGuardrailPasses_returnsOutput() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("Short response"));
+
+        var agent = Agent.builder().role("Writer").goal("Write").llm(mockLlm).build();
+        var task = Task.builder()
+                .description("Write a summary")
+                .expectedOutput("Summary")
+                .agent(agent)
+                .outputGuardrails(List.of(output -> GuardrailResult.success()))
+                .build();
+
+        TaskOutput result = executor.execute(task, List.of(), ExecutionContext.disabled());
+
+        assertThat(result.getRaw()).isEqualTo("Short response");
+    }
+
+    @Test
+    void testExecute_outputGuardrailFails_throwsAfterLlmCall() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class)))
+                .thenReturn(textResponse("A very very long response that is too long"));
+
+        var agent = Agent.builder().role("Writer").goal("Write").llm(mockLlm).build();
+        var task = Task.builder()
+                .description("Write a summary")
+                .expectedOutput("Summary")
+                .agent(agent)
+                .outputGuardrails(List.of(output -> output.rawResponse().length() > 10
+                        ? GuardrailResult.failure("response exceeds limit")
+                        : GuardrailResult.success()))
+                .build();
+
+        assertThatThrownBy(() -> executor.execute(task, List.of(), ExecutionContext.disabled()))
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.OUTPUT);
+                    assertThat(e.getViolationMessage()).isEqualTo("response exceeds limit");
+                    assertThat(e.getAgentRole()).isEqualTo("Writer");
+                });
+
+        // LLM was called before the guardrail ran
+        verify(mockLlm).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void testExecute_outputGuardrailReceivesCorrectContext() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("agent response here"));
+
+        var agent = Agent.builder().role("Analyst").goal("Analyze").llm(mockLlm).build();
+
+        var capturedOutput = new net.agentensemble.guardrail.GuardrailOutput[] {null};
+        var task = Task.builder()
+                .description("Analyze data")
+                .expectedOutput("Analysis")
+                .agent(agent)
+                .outputGuardrails(List.of(output -> {
+                    capturedOutput[0] = output;
+                    return GuardrailResult.success();
+                }))
+                .build();
+
+        executor.execute(task, List.of(), ExecutionContext.disabled());
+
+        assertThat(capturedOutput[0]).isNotNull();
+        assertThat(capturedOutput[0].rawResponse()).isEqualTo("agent response here");
+        assertThat(capturedOutput[0].agentRole()).isEqualTo("Analyst");
+        assertThat(capturedOutput[0].taskDescription()).isEqualTo("Analyze data");
+        assertThat(capturedOutput[0].parsedOutput()).isNull();
+    }
+
+    @Test
+    void testExecute_multipleOutputGuardrails_firstFailureWins() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("response"));
+
+        var agent = Agent.builder().role("Writer").goal("Write").llm(mockLlm).build();
+        var task = Task.builder()
+                .description("Write")
+                .expectedOutput("Output")
+                .agent(agent)
+                .outputGuardrails(List.of(
+                        output -> GuardrailResult.failure("first output blocker"),
+                        output -> GuardrailResult.failure("second output blocker")))
+                .build();
+
+        assertThatThrownBy(() -> executor.execute(task, List.of(), ExecutionContext.disabled()))
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getViolationMessage()).isEqualTo("first output blocker");
+                });
     }
 }

--- a/agentensemble-core/src/test/java/net/agentensemble/exception/ExceptionHierarchyTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/exception/ExceptionHierarchyTest.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import net.agentensemble.guardrail.GuardrailViolationException;
 import net.agentensemble.task.TaskOutput;
 import org.junit.jupiter.api.Test;
 
@@ -292,5 +293,51 @@ class ExceptionHierarchyTest {
     void outputParsingException_nullRawOutput_isPermitted() {
         var ex = new OutputParsingException("msg", null, String.class, List.of("e1"), 1);
         assertThat(ex.getRawOutput()).isNull();
+    }
+
+    // ========================
+    // GuardrailViolationException
+    // ========================
+
+    @Test
+    void guardrailViolationException_extendsAgentEnsembleException() {
+        var ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.INPUT, "blocked", "task", "agent");
+        assertThat(ex).isInstanceOf(AgentEnsembleException.class);
+        assertThat(ex).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void guardrailViolationException_inputType_fieldsAccessible() {
+        var ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.INPUT, "contains PII", "Summarize text", "writer");
+
+        assertThat(ex.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.INPUT);
+        assertThat(ex.getViolationMessage()).isEqualTo("contains PII");
+        assertThat(ex.getTaskDescription()).isEqualTo("Summarize text");
+        assertThat(ex.getAgentRole()).isEqualTo("writer");
+    }
+
+    @Test
+    void guardrailViolationException_outputType_fieldsAccessible() {
+        var ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.OUTPUT, "response too long", "Write report", "analyst");
+
+        assertThat(ex.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.OUTPUT);
+        assertThat(ex.getViolationMessage()).isEqualTo("response too long");
+        assertThat(ex.getTaskDescription()).isEqualTo("Write report");
+        assertThat(ex.getAgentRole()).isEqualTo("analyst");
+    }
+
+    @Test
+    void guardrailViolationException_messageContainsAllContext() {
+        var ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.OUTPUT, "too long", "Write an essay", "essayist");
+
+        assertThat(ex.getMessage())
+                .contains("OUTPUT")
+                .contains("too long")
+                .contains("Write an essay")
+                .contains("essayist");
     }
 }

--- a/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailInputTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailInputTest.java
@@ -1,0 +1,45 @@
+package net.agentensemble.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import net.agentensemble.task.TaskOutput;
+import org.junit.jupiter.api.Test;
+
+class GuardrailInputTest {
+
+    @Test
+    void constructor_storesAllFields() {
+        TaskOutput ctx = TaskOutput.builder()
+                .raw("some output")
+                .taskDescription("prior task")
+                .agentRole("researcher")
+                .completedAt(Instant.now())
+                .duration(Duration.ofMillis(100))
+                .toolCallCount(0)
+                .build();
+
+        GuardrailInput input = new GuardrailInput("Summarize the news", "A summary", List.of(ctx), "writer");
+
+        assertThat(input.taskDescription()).isEqualTo("Summarize the news");
+        assertThat(input.expectedOutput()).isEqualTo("A summary");
+        assertThat(input.contextOutputs()).containsExactly(ctx);
+        assertThat(input.agentRole()).isEqualTo("writer");
+    }
+
+    @Test
+    void contextOutputs_emptyList() {
+        GuardrailInput input = new GuardrailInput("Do something", "Some output", List.of(), "analyst");
+
+        assertThat(input.contextOutputs()).isEmpty();
+    }
+
+    @Test
+    void contextOutputs_isImmutable() {
+        GuardrailInput input = new GuardrailInput("Do something", "Some output", List.of(), "analyst");
+
+        assertThat(input.contextOutputs()).isUnmodifiable();
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailOutputTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailOutputTest.java
@@ -1,0 +1,36 @@
+package net.agentensemble.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GuardrailOutputTest {
+
+    @Test
+    void constructor_storesAllFields() {
+        GuardrailOutput output = new GuardrailOutput("The response text", "parsed-value", "Summarize", "writer");
+
+        assertThat(output.rawResponse()).isEqualTo("The response text");
+        assertThat(output.parsedOutput()).isEqualTo("parsed-value");
+        assertThat(output.taskDescription()).isEqualTo("Summarize");
+        assertThat(output.agentRole()).isEqualTo("writer");
+    }
+
+    @Test
+    void parsedOutput_canBeNull() {
+        GuardrailOutput output = new GuardrailOutput("raw text", null, "Do a task", "agent");
+
+        assertThat(output.parsedOutput()).isNull();
+    }
+
+    @Test
+    void parsedOutput_withTypedObject() {
+        record Report(String title) {}
+        Report report = new Report("My Report");
+
+        GuardrailOutput output = new GuardrailOutput("{\"title\":\"My Report\"}", report, "Research task", "analyst");
+
+        assertThat(output.parsedOutput()).isEqualTo(report);
+        assertThat(output.parsedOutput()).isInstanceOf(Report.class);
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailResultTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailResultTest.java
@@ -1,0 +1,46 @@
+package net.agentensemble.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+class GuardrailResultTest {
+
+    @Test
+    void success_isSuccess() {
+        GuardrailResult result = GuardrailResult.success();
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    void success_messageIsEmpty() {
+        GuardrailResult result = GuardrailResult.success();
+        assertThat(result.getMessage()).isEmpty();
+    }
+
+    @Test
+    void failure_isNotSuccess() {
+        GuardrailResult result = GuardrailResult.failure("blocked: contains PII");
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    void failure_carresMessage() {
+        GuardrailResult result = GuardrailResult.failure("blocked: contains PII");
+        assertThat(result.getMessage()).isEqualTo("blocked: contains PII");
+    }
+
+    @Test
+    void failure_withNullMessage_throws() {
+        assertThatNullPointerException().isThrownBy(() -> GuardrailResult.failure(null));
+    }
+
+    @Test
+    void distinctSuccessInstances_areEqual() {
+        GuardrailResult a = GuardrailResult.success();
+        GuardrailResult b = GuardrailResult.success();
+        assertThat(a.isSuccess()).isEqualTo(b.isSuccess());
+        assertThat(a.getMessage()).isEqualTo(b.getMessage());
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailViolationExceptionTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/guardrail/GuardrailViolationExceptionTest.java
@@ -1,0 +1,57 @@
+package net.agentensemble.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.agentensemble.exception.AgentEnsembleException;
+import org.junit.jupiter.api.Test;
+
+class GuardrailViolationExceptionTest {
+
+    @Test
+    void extendsAgentEnsembleException() {
+        GuardrailViolationException ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.INPUT, "contains PII", "Summarize", "writer");
+        assertThat(ex).isInstanceOf(AgentEnsembleException.class);
+        assertThat(ex).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void inputType_storesAllFields() {
+        GuardrailViolationException ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.INPUT, "contains PII", "Summarize the news", "writer");
+
+        assertThat(ex.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.INPUT);
+        assertThat(ex.getViolationMessage()).isEqualTo("contains PII");
+        assertThat(ex.getTaskDescription()).isEqualTo("Summarize the news");
+        assertThat(ex.getAgentRole()).isEqualTo("writer");
+    }
+
+    @Test
+    void outputType_storesAllFields() {
+        GuardrailViolationException ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.OUTPUT, "response too long", "Write a report", "analyst");
+
+        assertThat(ex.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.OUTPUT);
+        assertThat(ex.getViolationMessage()).isEqualTo("response too long");
+        assertThat(ex.getTaskDescription()).isEqualTo("Write a report");
+        assertThat(ex.getAgentRole()).isEqualTo("analyst");
+    }
+
+    @Test
+    void message_includesGuardrailTypeAndViolation() {
+        GuardrailViolationException ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.INPUT, "contains PII", "Summarize", "writer");
+
+        assertThat(ex.getMessage()).contains("INPUT");
+        assertThat(ex.getMessage()).contains("contains PII");
+    }
+
+    @Test
+    void message_includesAgentAndTask() {
+        GuardrailViolationException ex = new GuardrailViolationException(
+                GuardrailViolationException.GuardrailType.OUTPUT, "too long", "Write an essay", "essayist");
+
+        assertThat(ex.getMessage()).contains("essayist");
+        assertThat(ex.getMessage()).contains("Write an essay");
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/integration/GuardrailIntegrationTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/integration/GuardrailIntegrationTest.java
@@ -1,0 +1,307 @@
+package net.agentensemble.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.exception.TaskExecutionException;
+import net.agentensemble.guardrail.GuardrailResult;
+import net.agentensemble.guardrail.GuardrailViolationException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration tests for the guardrail system.
+ *
+ * Uses mocked LLMs to exercise the full guardrail lifecycle through
+ * {@link Ensemble#run()} without requiring real API keys.
+ *
+ * Verifies that input guardrails block execution before any LLM call,
+ * output guardrails block acceptance of a response, that first-failure
+ * semantics hold across multiple guardrails, and that TaskFailedEvent
+ * callbacks fire correctly when a guardrail violation occurs.
+ */
+class GuardrailIntegrationTest {
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+    }
+
+    private Agent mockAgent(String role, ChatModel llm) {
+        return Agent.builder().role(role).goal("Do work").llm(llm).build();
+    }
+
+    // ========================
+    // Input guardrail -- happy path
+    // ========================
+
+    @Test
+    void ensemble_inputGuardrailPasses_taskCompletes() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("Result from agent"));
+
+        var agent = mockAgent("Analyst", mockLlm);
+        var task = Task.builder()
+                .description("Analyze trends")
+                .expectedOutput("Analysis")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.success()))
+                .build();
+
+        EnsembleOutput output =
+                Ensemble.builder().agent(agent).task(task).build().run();
+
+        assertThat(output.getRaw()).isEqualTo("Result from agent");
+        verify(mockLlm).chat(any(ChatRequest.class));
+    }
+
+    // ========================
+    // Input guardrail -- violation
+    // ========================
+
+    @Test
+    void ensemble_inputGuardrailBlocks_throwsTaskExecutionException() {
+        var mockLlm = mock(ChatModel.class);
+
+        var agent = mockAgent("Writer", mockLlm);
+        var task = Task.builder()
+                .description("Write sensitive content")
+                .expectedOutput("Content")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.failure("prohibited content in task")))
+                .build();
+
+        assertThatThrownBy(
+                        () -> Ensemble.builder().agent(agent).task(task).build().run())
+                .isInstanceOf(TaskExecutionException.class)
+                .cause()
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.INPUT);
+                    assertThat(e.getViolationMessage()).isEqualTo("prohibited content in task");
+                    assertThat(e.getAgentRole()).isEqualTo("Writer");
+                });
+
+        // LLM must never have been called
+        verify(mockLlm, never()).chat(any(ChatRequest.class));
+    }
+
+    // ========================
+    // Output guardrail -- happy path
+    // ========================
+
+    @Test
+    void ensemble_outputGuardrailPasses_taskCompletes() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("Accepted response"));
+
+        var agent = mockAgent("Analyst", mockLlm);
+        var task = Task.builder()
+                .description("Analyze data")
+                .expectedOutput("Analysis")
+                .agent(agent)
+                .outputGuardrails(List.of(output -> GuardrailResult.success()))
+                .build();
+
+        EnsembleOutput output =
+                Ensemble.builder().agent(agent).task(task).build().run();
+
+        assertThat(output.getRaw()).isEqualTo("Accepted response");
+    }
+
+    // ========================
+    // Output guardrail -- violation
+    // ========================
+
+    @Test
+    void ensemble_outputGuardrailBlocks_throwsTaskExecutionException() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("Toxic response"));
+
+        var agent = mockAgent("Writer", mockLlm);
+        var task = Task.builder()
+                .description("Write an article")
+                .expectedOutput("Article")
+                .agent(agent)
+                .outputGuardrails(List.of(output -> output.rawResponse().contains("Toxic")
+                        ? GuardrailResult.failure("response contains prohibited content")
+                        : GuardrailResult.success()))
+                .build();
+
+        assertThatThrownBy(
+                        () -> Ensemble.builder().agent(agent).task(task).build().run())
+                .isInstanceOf(TaskExecutionException.class)
+                .cause()
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.OUTPUT);
+                    assertThat(e.getViolationMessage()).isEqualTo("response contains prohibited content");
+                });
+
+        // LLM was called before output guardrail ran
+        verify(mockLlm).chat(any(ChatRequest.class));
+    }
+
+    // ========================
+    // Multi-task: only guarded task is blocked
+    // ========================
+
+    @Test
+    void ensemble_twoTasks_inputGuardrailBlocksSecondTask_firstCompletes() {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class))).thenReturn(textResponse("First task done"));
+
+        var agent = mockAgent("Analyst", mockLlm);
+
+        var task1 = Task.builder()
+                .description("First task")
+                .expectedOutput("Output 1")
+                .agent(agent)
+                .build();
+
+        var task2 = Task.builder()
+                .description("Blocked task")
+                .expectedOutput("Output 2")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.failure("blocked")))
+                .build();
+
+        assertThatThrownBy(() -> Ensemble.builder()
+                        .agent(agent)
+                        .tasks(List.of(task1, task2))
+                        .build()
+                        .run())
+                .isInstanceOf(TaskExecutionException.class)
+                .satisfies(ex -> {
+                    var e = (TaskExecutionException) ex;
+                    // First task completed
+                    assertThat(e.getCompletedTaskOutputs()).hasSize(1);
+                    assertThat(e.getCompletedTaskOutputs().get(0).getRaw()).isEqualTo("First task done");
+                    // Second task caused the failure
+                    assertThat(e.getTaskDescription()).isEqualTo("Blocked task");
+                })
+                .cause()
+                .isInstanceOf(GuardrailViolationException.class);
+    }
+
+    // ========================
+    // Multiple guardrails -- first failure wins
+    // ========================
+
+    @Test
+    void ensemble_multipleInputGuardrails_firstFailureReported() {
+        var mockLlm = mock(ChatModel.class);
+        var agent = mockAgent("Writer", mockLlm);
+
+        AtomicInteger secondGuardrailCallCount = new AtomicInteger(0);
+
+        var task = Task.builder()
+                .description("Write content")
+                .expectedOutput("Content")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.failure("first check failed"), input -> {
+                    secondGuardrailCallCount.incrementAndGet();
+                    return GuardrailResult.failure("second check failed");
+                }))
+                .build();
+
+        assertThatThrownBy(
+                        () -> Ensemble.builder().agent(agent).task(task).build().run())
+                .isInstanceOf(TaskExecutionException.class)
+                .cause()
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    assertThat(e.getViolationMessage()).isEqualTo("first check failed");
+                });
+
+        // Second guardrail must not have been evaluated
+        assertThat(secondGuardrailCallCount.get()).isZero();
+        verify(mockLlm, never()).chat(any(ChatRequest.class));
+    }
+
+    // ========================
+    // Callback: TaskFailedEvent fires on guardrail violation
+    // ========================
+
+    @Test
+    void ensemble_inputGuardrailFails_taskFailedEventFired() {
+        var mockLlm = mock(ChatModel.class);
+        var agent = mockAgent("Writer", mockLlm);
+        var task = Task.builder()
+                .description("Write blocked content")
+                .expectedOutput("Content")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.failure("not allowed")))
+                .build();
+
+        var failedEvents = new java.util.ArrayList<net.agentensemble.callback.TaskFailedEvent>();
+
+        try {
+            Ensemble.builder()
+                    .agent(agent)
+                    .task(task)
+                    .onTaskFailed(failedEvents::add)
+                    .build()
+                    .run();
+        } catch (TaskExecutionException ignored) {
+            // expected
+        }
+
+        assertThat(failedEvents).hasSize(1);
+        assertThat(failedEvents.get(0).taskDescription()).isEqualTo("Write blocked content");
+        assertThat(failedEvents.get(0).cause()).isInstanceOf(GuardrailViolationException.class);
+    }
+
+    // ========================
+    // Both input and output guardrails -- input checked first
+    // ========================
+
+    @Test
+    void ensemble_bothGuardrails_inputCheckedBeforeOutput() {
+        var mockLlm = mock(ChatModel.class);
+        var agent = mockAgent("Writer", mockLlm);
+
+        var task = Task.builder()
+                .description("Blocked by input")
+                .expectedOutput("Content")
+                .agent(agent)
+                .inputGuardrails(List.of(input -> GuardrailResult.failure("input rejected")))
+                .outputGuardrails(List.of(output -> GuardrailResult.failure("output rejected")))
+                .build();
+
+        assertThatThrownBy(
+                        () -> Ensemble.builder().agent(agent).task(task).build().run())
+                .isInstanceOf(TaskExecutionException.class)
+                .cause()
+                .isInstanceOf(GuardrailViolationException.class)
+                .satisfies(ex -> {
+                    var e = (GuardrailViolationException) ex;
+                    // Input violation must be the one thrown (before LLM was called)
+                    assertThat(e.getGuardrailType()).isEqualTo(GuardrailViolationException.GuardrailType.INPUT);
+                    assertThat(e.getViolationMessage()).isEqualTo("input rejected");
+                });
+
+        // LLM never called because input guardrail fired first
+        verify(mockLlm, never()).chat(any(ChatRequest.class));
+    }
+}

--- a/docs/design/13-future-roadmap.md
+++ b/docs/design/13-future-roadmap.md
@@ -239,18 +239,46 @@ virtual threads. Listener implementations must be thread-safe when registered wi
 
 ---
 
-## Phase 8: Advanced Features
+## Phase 8: Guardrails (COMPLETE -- v0.8.0)
+
+**Implemented**: `InputGuardrail`, `OutputGuardrail`, `GuardrailInput`, `GuardrailOutput`,
+`GuardrailResult`, `GuardrailViolationException`, and integration in `AgentExecutor` and
+`SequentialWorkflowExecutor`.
+
+### How It Works
+
+- `InputGuardrail` and `OutputGuardrail` are `@FunctionalInterface` types on `Task`.
+- `AgentExecutor` runs input guardrails before building prompts (before any LLM call).
+  The first failure throws `GuardrailViolationException(GuardrailType.INPUT, ...)`.
+- `AgentExecutor` runs output guardrails after the final response (and after structured
+  output parsing when `outputType` is set). The first failure throws
+  `GuardrailViolationException(GuardrailType.OUTPUT, ...)`.
+- `SequentialWorkflowExecutor` catches `GuardrailViolationException` alongside the existing
+  `AgentExecutionException | MaxIterationsExceededException`, fires `TaskFailedEvent`, and
+  wraps in `TaskExecutionException`.
+- `GuardrailResult.success()` / `.failure(String reason)` are the result factory methods.
+- Guardrails are evaluated in order; the first failure stops evaluation.
+
+### Implemented API
+
+```java
+var task = Task.builder()
+    .description("Summarize the article")
+    .expectedOutput("A concise summary")
+    .agent(writer)
+    .inputGuardrails(List.of(noPersonalInfoGuardrail))
+    .outputGuardrails(List.of(lengthLimitGuardrail, toxicityGuardrail))
+    .build();
+```
+
+---
+
+## Phase 9: Advanced Features
 
 ### Streaming Output
 
 - Stream agent responses token-by-token using LangChain4j's `StreamingChatLanguageModel`
 - Useful for real-time UIs showing agent progress
-
-### Guardrails / Output Validation
-
-- Pre-execution guardrails: validate task inputs before sending to LLM
-- Post-execution guardrails: validate outputs against custom rules
-- Pluggable validation interface
 
 ### Built-In Tool Library
 
@@ -282,6 +310,7 @@ A separate module `agentensemble-tools` providing common tools:
 | Phase 5 | v0.5.0 | Parallel workflow |
 | Phase 6 | v0.6.0 | Structured output |
 | Phase 7 | v0.7.0 | Callbacks and observability (COMPLETE) |
-| Phase 8 | v1.0.0 | Streaming, guardrails, built-in tools |
+| Phase 8 | v0.8.0 | Guardrails: pre/post execution validation (COMPLETE) |
+| Phase 9 | v1.0.0 | Streaming, built-in tools |
 
 Each phase should be backward-compatible with previous phases. The API is designed with future phases in mind -- builder methods can be added without breaking existing code.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -100,3 +100,29 @@ Guards prevent:
 - Infinite delegation chains (configurable `maxDelegationDepth`, default 3)
 
 See the [Delegation guide](../guides/delegation.md).
+
+---
+
+## Guardrails
+
+**Guardrails** are pluggable validation hooks configured per task. They give you control over what enters and exits agent execution without modifying agent prompts or task logic.
+
+- **Input guardrails** run before the LLM call. If any fails, execution is blocked immediately and `GuardrailViolationException` is thrown -- no API call is made.
+- **Output guardrails** run after the agent produces a response. If any fails, the response is rejected and `GuardrailViolationException` is thrown.
+
+Both types implement functional interfaces (`InputGuardrail`, `OutputGuardrail`) and return `GuardrailResult.success()` or `GuardrailResult.failure(reason)`.
+
+```java
+var task = Task.builder()
+    .description("Summarize the document")
+    .expectedOutput("A concise summary")
+    .agent(writer)
+    .inputGuardrails(List.of(input -> {
+        return input.taskDescription().length() < 10
+            ? GuardrailResult.failure("Task description too short")
+            : GuardrailResult.success();
+    }))
+    .build();
+```
+
+See the [Guardrails guide](../guides/guardrails.md).

--- a/docs/guides/guardrails.md
+++ b/docs/guides/guardrails.md
@@ -1,0 +1,278 @@
+# Guardrails
+
+Guardrails are pluggable validation hooks that run before and after agent execution, giving you control over what enters and exits each task. They let you enforce content policies, safety constraints, length limits, or any custom validation rule without modifying agent prompts or task logic.
+
+---
+
+## Quick Start
+
+```java
+// Block tasks whose description contains certain keywords
+InputGuardrail noSensitiveDataGuardrail = input -> {
+    if (input.taskDescription().contains("SSN") || input.taskDescription().contains("password")) {
+        return GuardrailResult.failure("Task description contains sensitive data");
+    }
+    return GuardrailResult.success();
+};
+
+// Enforce a maximum response length
+OutputGuardrail lengthGuardrail = output -> {
+    if (output.rawResponse().length() > 5000) {
+        return GuardrailResult.failure("Response exceeds maximum length of 5000 characters");
+    }
+    return GuardrailResult.success();
+};
+
+var task = Task.builder()
+    .description("Write an executive summary")
+    .expectedOutput("A concise summary")
+    .agent(writer)
+    .inputGuardrails(List.of(noSensitiveDataGuardrail))
+    .outputGuardrails(List.of(lengthGuardrail))
+    .build();
+```
+
+---
+
+## Input Guardrails
+
+Input guardrails run **before the LLM call is made**. If any guardrail returns a failure, execution stops immediately and `GuardrailViolationException` is thrown -- the agent's LLM is never contacted.
+
+Implement `InputGuardrail` as a functional interface:
+
+```java
+@FunctionalInterface
+public interface InputGuardrail {
+    GuardrailResult validate(GuardrailInput input);
+}
+```
+
+The `GuardrailInput` record carries everything needed to make a decision:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `taskDescription()` | `String` | The task description |
+| `expectedOutput()` | `String` | The expected output specification |
+| `contextOutputs()` | `List<TaskOutput>` | Outputs from prior context tasks (immutable) |
+| `agentRole()` | `String` | The role of the agent about to execute |
+
+### Example: Keyword filter
+
+```java
+InputGuardrail piiGuardrail = input -> {
+    String desc = input.taskDescription().toLowerCase();
+    if (desc.contains("ssn") || desc.contains("credit card") || desc.contains("passport")) {
+        return GuardrailResult.failure(
+            "Task description may contain personally identifiable information");
+    }
+    return GuardrailResult.success();
+};
+```
+
+### Example: Agent role check
+
+```java
+InputGuardrail roleGuardrail = input -> {
+    if ("Untrusted Agent".equals(input.agentRole())) {
+        return GuardrailResult.failure("Untrusted agents are not permitted on this task");
+    }
+    return GuardrailResult.success();
+};
+```
+
+---
+
+## Output Guardrails
+
+Output guardrails run **after the agent produces a response**. When `task.outputType` is set, output guardrails run after structured output parsing completes -- the parsed Java object is available via `parsedOutput()`.
+
+Implement `OutputGuardrail` as a functional interface:
+
+```java
+@FunctionalInterface
+public interface OutputGuardrail {
+    GuardrailResult validate(GuardrailOutput output);
+}
+```
+
+The `GuardrailOutput` record carries the response for inspection:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rawResponse()` | `String` | The full text produced by the agent |
+| `parsedOutput()` | `Object` | The parsed Java object (null if no `outputType` set) |
+| `taskDescription()` | `String` | The task description |
+| `agentRole()` | `String` | The role of the agent that produced the output |
+
+### Example: Length limit
+
+```java
+OutputGuardrail lengthGuardrail = output -> {
+    int maxChars = 3000;
+    if (output.rawResponse().length() > maxChars) {
+        return GuardrailResult.failure(
+            "Response is " + output.rawResponse().length() +
+            " chars, exceeds limit of " + maxChars);
+    }
+    return GuardrailResult.success();
+};
+```
+
+### Example: Required keyword check
+
+```java
+OutputGuardrail conclusionGuardrail = output -> {
+    if (!output.rawResponse().toLowerCase().contains("conclusion")) {
+        return GuardrailResult.failure(
+            "Response must include a conclusion section");
+    }
+    return GuardrailResult.success();
+};
+```
+
+### Example: Typed output validation
+
+```java
+record ResearchReport(String title, List<String> findings, String conclusion) {}
+
+OutputGuardrail findingsGuardrail = output -> {
+    if (output.parsedOutput() instanceof ResearchReport report) {
+        if (report.findings() == null || report.findings().isEmpty()) {
+            return GuardrailResult.failure("Report must include at least one finding");
+        }
+    }
+    return GuardrailResult.success();
+};
+```
+
+---
+
+## GuardrailResult
+
+Guardrails communicate pass/fail via `GuardrailResult`:
+
+```java
+// Pass
+return GuardrailResult.success();
+
+// Fail with a descriptive reason
+return GuardrailResult.failure("Reason: response contains prohibited content");
+```
+
+The failure reason is included verbatim in the `GuardrailViolationException` message.
+
+---
+
+## Multiple Guardrails
+
+You can configure multiple guardrails per task. They are evaluated **in order** -- the first failure stops evaluation and throws immediately. Subsequent guardrails in the list are not called.
+
+```java
+var task = Task.builder()
+    .description("Write an article")
+    .expectedOutput("An article")
+    .agent(writer)
+    .inputGuardrails(List.of(piiGuardrail, roleGuardrail, domainGuardrail))
+    .outputGuardrails(List.of(lengthGuardrail, conclusionGuardrail, toxicityGuardrail))
+    .build();
+```
+
+To collect all failures rather than stop at the first, compose them into a single guardrail that aggregates results:
+
+```java
+InputGuardrail compositeGuardrail = input -> {
+    List<String> failures = new ArrayList<>();
+    for (InputGuardrail g : List.of(piiGuardrail, roleGuardrail)) {
+        GuardrailResult r = g.validate(input);
+        if (!r.isSuccess()) {
+            failures.add(r.getMessage());
+        }
+    }
+    return failures.isEmpty()
+        ? GuardrailResult.success()
+        : GuardrailResult.failure(String.join("; ", failures));
+};
+```
+
+---
+
+## Exception Handling
+
+When a guardrail fails, `GuardrailViolationException` is thrown. It propagates through the workflow executor and is wrapped in `TaskExecutionException` (the same pattern as other task failures).
+
+```java
+try {
+    ensemble.run();
+} catch (TaskExecutionException ex) {
+    if (ex.getCause() instanceof GuardrailViolationException gve) {
+        System.out.println("Guardrail type: " + gve.getGuardrailType()); // INPUT or OUTPUT
+        System.out.println("Violation: " + gve.getViolationMessage());
+        System.out.println("Task: " + gve.getTaskDescription());
+        System.out.println("Agent: " + gve.getAgentRole());
+    }
+}
+```
+
+`GuardrailViolationException` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `getGuardrailType()` | `GuardrailType` | `INPUT` or `OUTPUT` |
+| `getViolationMessage()` | `String` | The failure reason from `GuardrailResult.failure(reason)` |
+| `getTaskDescription()` | `String` | The task that was blocked |
+| `getAgentRole()` | `String` | The agent assigned to the task |
+
+---
+
+## Guardrails and Callbacks
+
+When a guardrail blocks a task, the `TaskFailedEvent` callback fires before the exception propagates. The `cause` field of `TaskFailedEvent` will be the `GuardrailViolationException`.
+
+```java
+Ensemble.builder()
+    .agent(writer)
+    .task(guardedTask)
+    .onTaskFailed(event -> {
+        if (event.cause() instanceof GuardrailViolationException gve) {
+            metrics.incrementCounter("guardrail.violation." + gve.getGuardrailType());
+        }
+    })
+    .build()
+    .run();
+```
+
+---
+
+## Guardrails and Structured Output
+
+When a task uses `outputType`, the execution order is:
+
+1. Input guardrails run (before LLM)
+2. LLM executes and produces raw text
+3. Structured output parsing (JSON extraction + deserialization)
+4. Output guardrails run (with both `rawResponse()` and `parsedOutput()` available)
+
+This means output guardrails can inspect the typed object directly:
+
+```java
+OutputGuardrail typedGuardrail = output -> {
+    if (output.parsedOutput() instanceof Report r && r.title() == null) {
+        return GuardrailResult.failure("Report title must not be null");
+    }
+    return GuardrailResult.success();
+};
+```
+
+---
+
+## Thread Safety
+
+`InputGuardrail` and `OutputGuardrail` are functional interfaces -- their implementations must be thread-safe when used with `Workflow.PARALLEL`, as multiple tasks may run concurrently and invoke guardrails on separate threads. Stateless guardrails (lambdas with no shared mutable state) are inherently thread-safe.
+
+---
+
+## Reference
+
+- [Task Configuration](../reference/task-configuration.md) -- `inputGuardrails` and `outputGuardrails` fields
+- [Error Handling](error-handling.md) -- exception hierarchy
+- [Exceptions Reference](../reference/exceptions.md) -- `GuardrailViolationException`

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -201,6 +201,40 @@ Unsupported: **primitives** (`int.class`, etc.), **void**, and **top-level array
 
 ---
 
+## Guardrails
+
+Guardrails are validation hooks that run before and after task execution. Configure them with `inputGuardrails` and `outputGuardrails`:
+
+```java
+InputGuardrail noPiiGuardrail = input -> {
+    if (input.taskDescription().contains("SSN")) {
+        return GuardrailResult.failure("Task description contains PII");
+    }
+    return GuardrailResult.success();
+};
+
+OutputGuardrail lengthGuardrail = output -> {
+    if (output.rawResponse().length() > 5000) {
+        return GuardrailResult.failure("Response exceeds 5000 characters");
+    }
+    return GuardrailResult.success();
+};
+
+var task = Task.builder()
+    .description("Summarize the article")
+    .expectedOutput("A concise summary")
+    .agent(writer)
+    .inputGuardrails(List.of(noPiiGuardrail))
+    .outputGuardrails(List.of(lengthGuardrail))
+    .build();
+```
+
+Input guardrails fire before the LLM is called; if any fails, `GuardrailViolationException` is thrown immediately. Output guardrails fire after the response (and after structured output parsing when `outputType` is set).
+
+See the [Guardrails guide](guardrails.md) for full documentation.
+
+---
+
 ## Tasks Are Immutable
 
 Tasks are immutable value objects. The builder produces a new instance on each call to `build()`. Use `toBuilder()` to create modified copies:

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -117,6 +117,24 @@ A `@Tool`-annotated method threw an exception during execution. The exception is
 
 ---
 
+## `GuardrailViolationException`
+
+**Thrown by:** `AgentExecutor` when an `InputGuardrail` or `OutputGuardrail` configured on a `Task` returns a failure result.
+
+Propagates through the workflow executor and is wrapped in `TaskExecutionException` -- catch `TaskExecutionException` and inspect `getCause()` to detect guardrail failures.
+
+Input violations are thrown before any LLM call is made. Output violations are thrown after the agent response (and after structured output parsing when `outputType` is set).
+
+**Methods:**
+| Method | Type | Description |
+|---|---|---|
+| `getGuardrailType()` | `GuardrailType` | `INPUT` (pre-execution) or `OUTPUT` (post-execution) |
+| `getViolationMessage()` | `String` | The failure reason returned by the guardrail |
+| `getTaskDescription()` | `String` | Description of the blocked task |
+| `getAgentRole()` | `String` | Role of the agent assigned to the task |
+
+---
+
 ## Error Handling Guide
 
 See the [Error Handling guide](../guides/error-handling.md) for patterns and examples.

--- a/docs/reference/task-configuration.md
+++ b/docs/reference/task-configuration.md
@@ -10,6 +10,8 @@ All fields available on `Task.builder()`.
 | `context` | `List<Task>` | No | `[]` | Prior tasks whose outputs are injected into this task's agent prompt. Sequential workflow only. |
 | `outputType` | `Class<?>` | No | `null` | Java class to deserialize the agent's output into. When set, the agent is prompted for JSON and the result is parsed automatically. Supported: records, POJOs, `Map<K,V>`, enums, `List<T>`, scalar wrappers (`Boolean`, `Integer`, `Long`, `Double`). Unsupported: primitives, `void`, top-level arrays. |
 | `maxOutputRetries` | `int` | No | `3` | Number of retry attempts if structured output parsing fails. `0` disables retries. Only meaningful when `outputType` is set. |
+| `inputGuardrails` | `List<InputGuardrail>` | No | `[]` | Validation hooks that run before the LLM call. Each guardrail receives a `GuardrailInput` and returns `GuardrailResult.success()` or `GuardrailResult.failure(reason)`. The first failure throws `GuardrailViolationException` and prevents any LLM call. |
+| `outputGuardrails` | `List<OutputGuardrail>` | No | `[]` | Validation hooks that run after the agent produces a response. Each guardrail receives a `GuardrailOutput` (with raw text and optionally the parsed object). The first failure throws `GuardrailViolationException`. |
 
 ---
 
@@ -22,6 +24,8 @@ The following validations are applied at `build()` time:
 - `agent` must not be null
 - `outputType` must not be a primitive, `void`, or a top-level array type (when set)
 - `maxOutputRetries` must be `>= 0`
+- `inputGuardrails` defaults to an empty immutable list (no-op)
+- `outputGuardrails` defaults to an empty immutable list (no-op)
 
 At `Ensemble.run()` time:
 - All context tasks must appear earlier in the ensemble's task list (sequential workflow)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,12 +2,8 @@
 
 ## Current Work Focus
 
-PR #66 open on `fix/javadoc-link-error-add-to-ci`: fixes the broken javadoc `{@link}`
-references that caused the v0.7.0 release workflow to fail, and adds `:agentensemble-core:javadoc`
-to the CI workflow so the same class of error is caught pre-merge.
-
-Full javadoc cleanup (92 remaining warnings) is tracked in issue #65.
-Next after #66 merges: Issue #42 (Execution Metrics) or Issue #58 (Guardrails).
+Feature branch `feature/58-guardrails` implements Issue #58 (Guardrails: pre/post execution
+validation hooks) for v0.8.0. PR to be opened against main. All 563 tests pass.
 
 ## Recent Changes
 

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -126,6 +126,48 @@
 
 ---
 
+## [0.8.0] - 2026-03-03 (Issue #58, feature/58-guardrails)
+
+### Added
+- `net.agentensemble.guardrail` package: `InputGuardrail` (`@FunctionalInterface`),
+  `OutputGuardrail` (`@FunctionalInterface`), `GuardrailResult` (success/failure factory),
+  `GuardrailInput` (record: taskDescription, expectedOutput, contextOutputs, agentRole),
+  `GuardrailOutput` (record: rawResponse, parsedOutput, taskDescription, agentRole),
+  `GuardrailViolationException` (extends `AgentEnsembleException`; carries `GuardrailType` enum,
+  violationMessage, taskDescription, agentRole)
+- `Task.inputGuardrails` field: `List<InputGuardrail>`, default empty immutable list
+- `Task.outputGuardrails` field: `List<OutputGuardrail>`, default empty immutable list
+- 64 new tests (499 -> 563): `GuardrailResultTest` (6), `GuardrailInputTest` (3),
+  `GuardrailOutputTest` (3), `GuardrailViolationExceptionTest` (5),
+  `ExceptionHierarchyTest` (+4), `TaskTest` (+7), `AgentExecutorTest` (+11),
+  `GuardrailIntegrationTest` (8)
+- `docs/guides/guardrails.md`: new guide (quick start, input/output guardrails, multiple
+  guardrails, exception handling, callbacks integration, structured output, thread safety)
+
+### Changed
+- `AgentExecutor.execute()`: runs input guardrails before prompt building (before any LLM call);
+  runs output guardrails after final response and after structured output parsing;
+  throws `GuardrailViolationException` on first failure with full context
+- `SequentialWorkflowExecutor`: catch clause extended to include `GuardrailViolationException`
+  alongside `AgentExecutionException | MaxIterationsExceededException`; fires `TaskFailedEvent`
+  before wrapping in `TaskExecutionException`
+- `docs/guides/tasks.md`: Guardrails section added
+- `docs/reference/task-configuration.md`: `inputGuardrails` and `outputGuardrails` rows added
+- `docs/reference/exceptions.md`: `GuardrailViolationException` section added
+- `docs/getting-started/concepts.md`: Guardrails concept section added
+- `docs/design/13-future-roadmap.md`: Phase 8 (Guardrails) marked COMPLETE; Phase 9 for remaining
+- `mkdocs.yml`: Guardrails guide added to Guides nav
+- `README.md`: Guardrails section, Task Configuration table updated, roadmap updated
+
+### Technical Notes
+- First-failure semantics: guardrails evaluated in order; first failure stops evaluation
+- Input guardrails run before prompts are built -- no LLM calls when input guardrail fails
+- Output guardrails run after structured output parsing (parsedOutput available in GuardrailOutput)
+- GuardrailViolationException is propagated as cause of TaskExecutionException (consistent pattern)
+- ParallelTaskCoordinator already catches all Exception so parallel workflow handles guardrails correctly
+
+---
+
 ## [0.7.0] - 2026-03-03 (Issue #57, feature/57-callbacks-execution-context)
 
 ### Added

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -125,11 +125,19 @@
   - `Ensemble` builder: `.listener()`, `.onTaskStart()`, `.onTaskComplete()`, `.onTaskFailed()`, `.onToolCall()`
   - New tests: ExecutionContextTest(20), EnsembleListenerTest(10), ToolResolverTest(10), CallbackIntegrationTest(14)
   - Docs: `guides/callbacks.md`, roadmap Phase 7 COMPLETE, mkdocs.yml updated
-- [ ] Issue #58 (v0.8.0): Guardrails: Pre/post execution validation
+- [x] Issue #58 (v0.8.0): Guardrails: Pre/post execution validation -- feature/58-guardrails (563 tests, +64)
   - InputGuardrail / OutputGuardrail functional interfaces
-  - GuardrailResult, GuardrailViolationException
-  - Task.inputGuardrails / Task.outputGuardrails builder fields
-  - AgentExecutor invokes guardrails before/after execution
+  - GuardrailResult, GuardrailViolationException (with GuardrailType enum)
+  - GuardrailInput / GuardrailOutput context records
+  - Task.inputGuardrails / Task.outputGuardrails builder fields (immutable lists, default empty)
+  - AgentExecutor invokes input guardrails before prompt building, output guardrails after parsing
+  - SequentialWorkflowExecutor catches GuardrailViolationException, fires TaskFailedEvent, wraps in TaskExecutionException
+  - 64 new tests: GuardrailResultTest(6), GuardrailInputTest(3), GuardrailOutputTest(3),
+    GuardrailViolationExceptionTest(5), ExceptionHierarchyTest(+4), TaskTest(+7),
+    AgentExecutorTest(+11), GuardrailIntegrationTest(8)
+  - Docs: guardrails.md (new guide), tasks.md (guardrails section), task-configuration.md (2 new fields),
+    exceptions.md (GuardrailViolationException), concepts.md (guardrails concept),
+    13-future-roadmap.md (Phase 8 COMPLETE), mkdocs.yml (nav), README.md
 - [ ] Issue #59 (v0.8.0): Rate Limiting: Per-agent/per-LLM
   - RateLimitedChatModel decorator (token-bucket, thread-safe)
   - RateLimit value object with factory methods

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - Delegation: guides/delegation.md
     - Error Handling: guides/error-handling.md
     - Callbacks: guides/callbacks.md
+    - Guardrails: guides/guardrails.md
     - Logging: guides/logging.md
     - Template Variables: guides/template-variables.md
   - Reference:


### PR DESCRIPTION
## Summary

Implements GitHub issue #58: pluggable `InputGuardrail` and `OutputGuardrail` functional interfaces that run before and after agent execution on a per-task basis.

## New Package: `net.agentensemble.guardrail`

| Class | Type | Description |
|---|---|---|
| `InputGuardrail` | `@FunctionalInterface` | `validate(GuardrailInput)` -- runs before LLM call |
| `OutputGuardrail` | `@FunctionalInterface` | `validate(GuardrailOutput)` -- runs after agent response |
| `GuardrailInput` | record | taskDescription, expectedOutput, contextOutputs, agentRole |
| `GuardrailOutput` | record | rawResponse, parsedOutput, taskDescription, agentRole |
| `GuardrailResult` | class | `success()` / `failure(String reason)` factory methods |
| `GuardrailViolationException` | exception | Extends `AgentEnsembleException`; carries `GuardrailType` (INPUT/OUTPUT), violationMessage, taskDescription, agentRole |

## API

```java
var task = Task.builder()
    .description("Summarize the article")
    .expectedOutput("A concise summary")
    .agent(writer)
    .inputGuardrails(List.of(noPersonalInfoGuardrail))
    .outputGuardrails(List.of(lengthLimitGuardrail, toxicityGuardrail))
    .build();
```

## Behaviour

- **Input guardrails** run before prompt building -- if any fails, `GuardrailViolationException` is thrown and no LLM call is made.
- **Output guardrails** run after the final response and after structured output parsing (when `outputType` is set). `parsedOutput` is available in `GuardrailOutput`.
- **First-failure semantics**: guardrails evaluated in list order; first failure stops evaluation immediately.
- `GuardrailViolationException` propagates and is wrapped in `TaskExecutionException` by `SequentialWorkflowExecutor` (consistent with other task failures). `TaskFailedEvent` fires before the exception propagates.
- `ParallelTaskCoordinator` already catches all `Exception`, so parallel workflow handles guardrail violations correctly without additional changes.

## Changes

### Production
- `Task.java`: `inputGuardrails` + `outputGuardrails` fields (immutable lists, empty by default)
- `AgentExecutor.java`: `runInputGuardrails()` before prompt building; `runOutputGuardrails()` after structured output parsing
- `SequentialWorkflowExecutor.java`: catch clause extended to include `GuardrailViolationException`

### Tests (499 -> 563, +64)
- `GuardrailResultTest` (6), `GuardrailInputTest` (3), `GuardrailOutputTest` (3)
- `GuardrailViolationExceptionTest` (5), `ExceptionHierarchyTest` (+4)
- `TaskTest` (+7), `AgentExecutorTest` (+11)
- `GuardrailIntegrationTest` (8) -- end-to-end via Ensemble with mocked LLMs

### Documentation
- `docs/guides/guardrails.md` (new guide)
- `docs/guides/tasks.md` (guardrails section)
- `docs/reference/task-configuration.md` (2 new field rows)
- `docs/reference/exceptions.md` (`GuardrailViolationException` section)
- `docs/getting-started/concepts.md` (guardrails concept)
- `docs/design/13-future-roadmap.md` (Phase 8 marked COMPLETE)
- `mkdocs.yml` (Guardrails guide in nav)
- `README.md` (Guardrails section + task config table + roadmap)

Closes #58