### PR TITLE
feat: distribute agentensemble-viz via Homebrew tap (#94)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,62 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build agentensemble-viz
+        working-directory: agentensemble-viz
+        run: |
+          npm ci
+          npm run build
+
+      - name: Compile agentensemble-viz binaries
+        # Bun cross-compilation downloads the target runtime from the Bun CDN.
+        # Each compile call overwrites the agentensemble-viz output file, so the
+        # tarball is created before the next compile run.
+        working-directory: agentensemble-viz
+        run: |
+          npm run compile:darwin-arm64
+          tar czf agentensemble-viz-darwin-arm64.tar.gz agentensemble-viz
+          rm agentensemble-viz
+
+          npm run compile:darwin-x64
+          tar czf agentensemble-viz-darwin-x64.tar.gz agentensemble-viz
+          rm agentensemble-viz
+
+          npm run compile:linux-x64
+          tar czf agentensemble-viz-linux-x64.tar.gz agentensemble-viz
+          rm agentensemble-viz
+
+      - name: Upload viz binaries to GitHub Release
+        working-directory: agentensemble-viz
+        run: |
+          gh release upload ${{ steps.version.outputs.tag }} \
+            agentensemble-viz-darwin-arm64.tar.gz \
+            agentensemble-viz-darwin-x64.tar.gz \
+            agentensemble-viz-linux-x64.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dispatch Homebrew formula update
+        # Triggers update-formula.yml in AgentEnsemble/homebrew-tap to recompute
+        # SHA256 hashes and commit the updated formula. Requires a PAT with
+        # repo scope on homebrew-tap stored as ORG_HOMEBREW_TAP_TOKEN.
+        run: |
+          curl --silent --fail -X POST \
+            -H "Authorization: Bearer ${{ secrets.ORG_HOMEBREW_TAP_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/AgentEnsemble/homebrew-tap/dispatches \
+            --data "{\"event_type\":\"new-release\",\"client_payload\":{\"version\":\"${{ steps.version.outputs.version }}\"}}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Bump version to next SNAPSHOT
         run: |
           IFS='.' read -ra PARTS <<< "${{ steps.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -621,6 +621,41 @@ See the [Metrics and Observability guide](docs/guides/metrics.md) and
 
 ---
 
+## Execution Graph Visualization
+
+Export the task dependency graph and execution timeline to JSON files with `agentensemble-devtools`,
+then open them in the interactive `agentensemble-viz` viewer:
+
+```java
+// Export the planned DAG (no execution needed)
+EnsembleDevTools.exportDag(ensemble, Path.of("./traces/"));
+
+// Export the post-execution trace
+EnsembleDevTools.exportTrace(output, Path.of("./traces/"));
+
+// Or both in one call
+EnsembleDevTools.export(ensemble, output, Path.of("./traces/"));
+```
+
+Open the viewer:
+
+```bash
+# Homebrew (macOS and Linux -- self-contained binary, no Node.js required)
+brew install agentensemble/tap/agentensemble-viz
+agentensemble-viz ./traces/
+
+# Or via npx (no install)
+npx @agentensemble/viz ./traces/
+```
+
+The viewer starts at `http://localhost:7329` and auto-discovers all `.dag.json` and `.trace.json`
+files in the directory. The **Flow View** shows the dependency graph with critical-path highlighting;
+the **Timeline View** shows a Gantt-chart breakdown of task, LLM call, and tool execution timing.
+
+**Full documentation:** [Visualization Guide](https://docs.agentensemble.net/guides/visualization/) | [Visualization Example](https://docs.agentensemble.net/examples/visualization/)
+
+---
+
 ## CaptureMode
 
 `CaptureMode` transparently enables deep data collection -- full LLM conversation history,
@@ -956,9 +991,9 @@ Full documentation is available at **[docs.agentensemble.net](https://docs.agent
 | Section | Description |
 |---|---|
 | [Getting Started](https://docs.agentensemble.net/getting-started/installation/) | Installation, quickstart, core concepts |
-| [Guides](https://docs.agentensemble.net/guides/agents/) | Agents, tasks, workflows, tools, memory, delegation, error handling, logging |
+| [Guides](https://docs.agentensemble.net/guides/agents/) | Agents, tasks, workflows, tools, memory, delegation, error handling, logging, visualization |
 | [Reference](https://docs.agentensemble.net/reference/ensemble-configuration/) | Complete configuration field tables |
-| [Examples](https://docs.agentensemble.net/examples/research-writer/) | Runnable annotated example walkthroughs |
+| [Examples](https://docs.agentensemble.net/examples/research-writer/) | Runnable annotated example walkthroughs including [visualization](https://docs.agentensemble.net/examples/visualization/) |
 | [Design Specs](docs/design/) | Internal architecture and design documentation |
 
 ---

--- a/agentensemble-viz/cli.js
+++ b/agentensemble-viz/cli.js
@@ -12,15 +12,32 @@
 
 import { createServer } from 'node:http';
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
-import { join, extname, resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, extname, resolve } from 'node:path';
 import { exec } from 'node:child_process';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+// Resolve version from package.json. Using new URL so Bun embeds package.json
+// into the compiled binary alongside the dist/ assets.
+let cliVersion = 'unknown';
+try {
+  const pkg = JSON.parse(
+    readFileSync(new URL('./package.json', import.meta.url).pathname, 'utf8'),
+  );
+  cliVersion = pkg.version ?? 'unknown';
+} catch {
+  // package.json not accessible in this environment
+}
+
+// Handle --version before starting the server (required by the Homebrew formula test)
+if (process.argv.includes('--version')) {
+  console.log(`agentensemble-viz/${cliVersion}`);
+  process.exit(0);
+}
 
 // Resolve the traces directory from the CLI argument or default
 const tracesDir = process.argv[2] ? resolve(process.argv[2]) : resolve('./traces');
-const distDir = join(__dirname, 'dist');
+
+// Using new URL so Bun embeds the entire dist/ directory into the compiled binary
+const distDir = new URL('./dist/', import.meta.url).pathname;
 const PORT = parseInt(process.env.PORT ?? '7329', 10);
 
 const MIME_TYPES = {

--- a/agentensemble-viz/package.json
+++ b/agentensemble-viz/package.json
@@ -20,7 +20,10 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "compile:darwin-arm64": "bun build --compile --target=bun-darwin-arm64 cli.js --outfile agentensemble-viz",
+    "compile:darwin-x64": "bun build --compile --target=bun-darwin-x64 cli.js --outfile agentensemble-viz",
+    "compile:linux-x64": "bun build --compile --target=bun-linux-x64 cli.js --outfile agentensemble-viz"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.0.4",

--- a/agentensemble-viz/src/__tests__/cli.test.ts
+++ b/agentensemble-viz/src/__tests__/cli.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+/**
+ * CLI integration tests.
+ *
+ * These tests spawn the Node.js process directly so they exercise the real
+ * runtime behaviour without jsdom. They do NOT import cli.js (which would
+ * start the HTTP server on import) - instead they use child_process.spawnSync
+ * to run the script as a subprocess.
+ *
+ * NODE_OPTIONS is stripped from the child environment to prevent vitest's
+ * internal loader flags (e.g. --import @vitest/...) from interfering with
+ * the spawned process.
+ */
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = resolve(__dirname, '../../cli.js');
+
+/**
+ * Build a clean environment for spawned subprocesses by stripping vitest-
+ * injected flags that would cause the child process to fail.
+ */
+function cleanEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env['NODE_OPTIONS'];
+  delete env['NODE_V8_COVERAGE'];
+  return env;
+}
+
+describe('agentensemble-viz CLI', () => {
+  describe('--version flag', () => {
+    it('prints the version string and exits with code 0', () => {
+      const result = spawnSync(process.execPath, [CLI_PATH, '--version'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        env: cleanEnv(),
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/^agentensemble-viz\/\d+\.\d+\.\d+/);
+    });
+
+    it('includes the package version number in the output', () => {
+      const result = spawnSync(process.execPath, [CLI_PATH, '--version'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        env: cleanEnv(),
+      });
+
+      // The version embedded in the binary must match the semver format
+      const match = result.stdout.match(/agentensemble-viz\/(\d+\.\d+\.\d+)/);
+      expect(match).not.toBeNull();
+    });
+
+    it('does not start the HTTP server when --version is passed', () => {
+      const result = spawnSync(process.execPath, [CLI_PATH, '--version'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        env: cleanEnv(),
+      });
+
+      // Server startup banner must NOT appear
+      expect(result.stdout).not.toContain('AgentEnsemble Trace Viewer');
+    });
+
+    it('exits cleanly with no stderr output', () => {
+      const result = spawnSync(process.execPath, [CLI_PATH, '--version'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        env: cleanEnv(),
+      });
+
+      expect(result.stderr.trim()).toBe('');
+    });
+  });
+});

--- a/docs/examples/visualization.md
+++ b/docs/examples/visualization.md
@@ -146,12 +146,28 @@ EnsembleDevTools.exportDag(ensemble, Path.of("./traces/"));
 
 ## Running the Viewer
 
-```bash
-# Auto-loads all .dag.json and .trace.json files from the directory
-npx @agentensemble/viz ./traces/
+**Homebrew (macOS and Linux):**
 
-# Or open at a custom port
-PORT=8080 npx @agentensemble/viz ./traces/
+```bash
+# Install once
+brew install agentensemble/tap/agentensemble-viz
+
+# Run
+agentensemble-viz ./traces/
 ```
 
-The viewer opens at `http://localhost:7329` (or your custom port) and auto-discovers the files.
+**npx (no installation required):**
+
+```bash
+npx @agentensemble/viz ./traces/
+```
+
+**Custom port:**
+
+```bash
+PORT=8080 agentensemble-viz ./traces/
+# or: PORT=8080 npx @agentensemble/viz ./traces/
+```
+
+The viewer opens at `http://localhost:7329` (or your custom port) and auto-discovers all
+`.dag.json` and `.trace.json` files in the directory.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -174,6 +174,40 @@ See the [Logging guide](../guides/logging.md) for configuration details.
 
 ---
 
+## Execution Graph Visualizer: agentensemble-viz
+
+`agentensemble-viz` is a standalone developer tool for visualizing task dependency graphs
+and execution timelines. It reads JSON files exported by `agentensemble-devtools` and
+renders them in a local web UI.
+
+**Homebrew (macOS and Linux):**
+
+```bash
+brew install agentensemble/tap/agentensemble-viz
+agentensemble-viz ./traces/
+```
+
+This installs a self-contained native binary (no Node.js required). The formula is updated
+automatically on every AgentEnsemble release.
+
+**npx (no installation required):**
+
+```bash
+npx @agentensemble/viz ./traces/
+```
+
+**Global npm install:**
+
+```bash
+npm install -g @agentensemble/viz
+agentensemble-viz ./traces/
+```
+
+See the [Visualization Guide](../guides/visualization.md) for the complete workflow including
+how to export DAGs and execution traces from your Java application.
+
+---
+
 ## Next Steps
 
 - [Quickstart](quickstart.md) -- Build your first ensemble

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -39,13 +39,30 @@ Add `agentensemble-devtools` as a dependency. Use `test` or `runtime` scope sinc
 
 ### Viewer: agentensemble-viz
 
-No installation required. Use `npx`:
+**Option 1 — Homebrew (macOS and Linux, recommended for regular use):**
+
+```bash
+brew install agentensemble/tap/agentensemble-viz
+agentensemble-viz ./traces/
+```
+
+The Homebrew formula distributes a self-contained native binary compiled with Bun. No
+Node.js or npm required on the user's machine. The formula is updated automatically
+on every AgentEnsemble release.
+
+To upgrade to the latest version:
+
+```bash
+brew upgrade agentensemble-viz
+```
+
+**Option 2 — npx (no installation, runs via Node.js):**
 
 ```bash
 npx @agentensemble/viz ./traces/
 ```
 
-Or install globally:
+**Option 3 — Global npm install:**
 
 ```bash
 npm install -g @agentensemble/viz

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,11 +2,58 @@
 
 ## Current Work Focus
 
-Issue #44 (Interactive execution graph visualization) has been implemented, incorporating the
-work from issues #42 (Execution metrics) and #89 (CaptureMode) which were already completed.
-Two new modules were created: `agentensemble-devtools` (Java) and `agentensemble-viz` (TypeScript).
+Issue #94 (Distribute agentensemble-viz via Homebrew tap) has been implemented. The
+`agentensemble-viz` CLI is now distributed as a self-contained binary via a Homebrew tap
+(`agentensemble/tap/agentensemble-viz`) in addition to the existing npm/npx path. Releases
+are fully automated: tag push -> Bun cross-compile -> tarball upload -> formula update with
+zero manual steps.
 
 ## Recent Changes
+
+### Issue #94 -- Homebrew Tap Distribution
+
+**`agentensemble-viz/cli.js` changes:**
+- Replaced `__dirname`-based `distDir` with `new URL('./dist/', import.meta.url).pathname` so
+  Bun embeds the dist directory into the compiled binary
+- Added version reading via `readFileSync(new URL('./package.json', import.meta.url).pathname)`
+  using the same URL pattern so Bun embeds package.json too
+- Added `--version` flag handler that prints `agentensemble-viz/<version>` and exits 0
+
+**`agentensemble-viz/package.json` changes:**
+- Added three compile scripts: `compile:darwin-arm64`, `compile:darwin-x64`, `compile:linux-x64`
+  using `bun build --compile --target=<target>`
+
+**`.github/workflows/release.yml` changes:**
+- Added Node.js setup, Bun setup (oven-sh/setup-bun@v2), viz build, cross-compilation for 3
+  platforms, tarball creation, upload to GitHub Release, and `repository_dispatch` to
+  homebrew-tap -- all in sequence after the Java artifacts are uploaded
+
+**`AgentEnsemble/homebrew-tap` repo:**
+- `Formula/agentensemble-viz.rb`: platform-aware formula with `on_macos`/`on_linux` blocks,
+  comment-anchored SHA256 values for automated updates
+- `.github/workflows/update-formula.yml`: triggered by `repository_dispatch` event from the
+  main repo; downloads tarballs, computes SHA256, updates formula, commits and pushes
+
+**Tests:**
+- `agentensemble-viz/src/__tests__/cli.test.ts`: 4 new integration tests for the `--version`
+  flag (exit code, output format, no server start, clean stderr); uses `// @vitest-environment node`
+  pragma and strips `NODE_OPTIONS` from child process env to avoid vitest interference
+
+**Documentation:**
+- `docs/guides/visualization.md`: Homebrew listed as Option 1 (recommended for regular use)
+- `docs/examples/visualization.md`: Homebrew option added to "Running the Viewer" section
+- `docs/getting-started/installation.md`: new "Execution Graph Visualizer" section with all
+  three install options (Homebrew, npx, global npm)
+- `README.md`: new "Execution Graph Visualization" section with Homebrew + npx install
+  commands; docs table updated
+
+## Next Steps (after #94 PR merges)
+
+- Secret `ORG_HOMEBREW_TAP_TOKEN` must be added to the main repo's GitHub Secrets (PAT with
+  `repo` scope on `AgentEnsemble/homebrew-tap`)
+- Issue #44 PR -- close out the visualization issue
+- MCP (Model Context Protocol) integration (`McpAgentTool`)
+- See `design/13-future-roadmap.md` for overall roadmap
 
 ### Issue #44 -- Interactive Execution Graph Visualization
 

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [Unreleased] - Issue #94 -- Homebrew Tap Distribution -- 2026-03-05
+
+### Added (Issue #94 -- Distribute agentensemble-viz via Homebrew tap)
+
+**`agentensemble-viz/cli.js` changes:**
+- Replaced `__dirname`-based `distDir` with `new URL('./dist/', import.meta.url).pathname`
+  so Bun's `--compile` embeds the entire `dist/` directory into the binary at compile time
+- Added version reading: `readFileSync(new URL('./package.json', import.meta.url).pathname)`
+  so Bun embeds `package.json` into the binary (same URL pattern)
+- Added `--version` flag: prints `agentensemble-viz/<semver>` to stdout and exits 0;
+  must run before the HTTP server starts (required by Homebrew formula test block)
+
+**`agentensemble-viz/package.json` changes:**
+- Added `compile:darwin-arm64`, `compile:darwin-x64`, `compile:linux-x64` scripts using
+  `bun build --compile --target=<target> cli.js --outfile agentensemble-viz`
+
+**`.github/workflows/release.yml` changes:**
+- After Java artifact upload: set up Node 20 + Bun (`oven-sh/setup-bun@v2`)
+- `npm ci && npm run build` in `agentensemble-viz/`
+- Sequential Bun cross-compile for 3 targets; each compile: create tarball, remove binary
+  to avoid filename collision before next target
+- Upload 3 tarballs (`agentensemble-viz-darwin-arm64.tar.gz`, etc.) to the GitHub Release
+- Fire `repository_dispatch` event (`new-release` type) to `AgentEnsemble/homebrew-tap`
+  with `version` in the payload; requires `ORG_HOMEBREW_TAP_TOKEN` secret (PAT, `repo` scope)
+
+**`AgentEnsemble/homebrew-tap` repo (new files, already pushed to main):**
+- `Formula/agentensemble-viz.rb`: platform-aware Homebrew formula with `on_macos`/`on_linux`
+  DSL blocks; SHA256 lines use `# DARWIN_ARM64_SHA256`, `# DARWIN_X64_SHA256`,
+  `# LINUX_X64_SHA256` comment anchors for reliable sed-based updates; test block validates
+  `--version` output against `version.to_s`
+- `.github/workflows/update-formula.yml`: triggered by `repository_dispatch` event;
+  downloads all 3 tarballs from the GitHub Release, computes SHA256 with `sha256sum`,
+  updates version field + download URLs + SHA256 values in the formula using `sed`,
+  commits and pushes; zero manual interaction
+
+**Tests:**
+- `agentensemble-viz/src/__tests__/cli.test.ts`: new test file (4 tests);
+  `// @vitest-environment node` pragma; strips `NODE_OPTIONS` from child process env to
+  prevent vitest's internal loader flags from interfering with the spawned Node.js process;
+  covers: exit code 0 for `--version`, semver output format, no server startup, clean stderr
+
+**Documentation:**
+- `docs/guides/visualization.md`: Homebrew listed as Option 1 (recommended for regular use),
+  npx as Option 2, global npm as Option 3
+- `docs/examples/visualization.md`: Homebrew added to "Running the Viewer" section
+- `docs/getting-started/installation.md`: new "Execution Graph Visualizer" section with all
+  three install options and link to visualization guide
+- `README.md`: new "Execution Graph Visualization" section with Homebrew + npx install
+  commands, Flow View / Timeline View description, links to guide and example; docs
+  navigation table updated to include visualization in Guides and Examples
+
+### Notes
+- The `ORG_HOMEBREW_TAP_TOKEN` secret must be added to the main repo before the first
+  release to enable the `repository_dispatch` step to succeed
+- Bun cross-compilation downloads target runtimes from the Bun CDN at compile time (adds
+  ~1-2 min to release CI per target); produced binaries are ~30 MB each
+- The npm distribution (`npx @agentensemble/viz`) remains the primary path; Homebrew is
+  the recommended alternative for users who prefer native package management
+
+---
+
 ## [Unreleased] - Issue #44 -- Execution Graph Visualization -- 2026-03-05
 
 ### Added (Issue #44 -- Interactive execution graph visualization)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,6 +2,31 @@
 
 ## What Works
 
+### Homebrew Distribution (Issue #94)
+
+**`agentensemble-viz` Homebrew tap (`agentensemble/tap`):**
+- Self-contained native binary distributed via `brew install agentensemble/tap/agentensemble-viz`
+- Bun `--compile` cross-compilation for darwin-arm64, darwin-x64, linux-x64 in CI
+- Formula: `AgentEnsemble/homebrew-tap/Formula/agentensemble-viz.rb` with platform-aware
+  `on_macos`/`on_linux` blocks, comment-anchored SHA256 values
+- Auto-update workflow: `AgentEnsemble/homebrew-tap/.github/workflows/update-formula.yml`
+  triggered by `repository_dispatch` from main repo; zero manual steps
+
+**`cli.js` adaptations for Bun compile:**
+- `distDir` uses `new URL('./dist/', import.meta.url).pathname` (Bun embeds dist)
+- Package version read via `readFileSync(new URL('./package.json', import.meta.url))` (Bun embeds pkg)
+- `--version` flag: prints `agentensemble-viz/<version>`, exits 0
+
+**Release pipeline (`release.yml`):**
+- Node 20 + Bun setup after Java artifact upload
+- `npm ci && npm run build` in agentensemble-viz/
+- Three sequential Bun cross-compiles -> tarballs -> upload to GitHub Release
+- `curl` `repository_dispatch` to `AgentEnsemble/homebrew-tap` with version payload
+
+**Tests:**
+- 4 new CLI integration tests (45 total passing): `--version` exit code, output format,
+  no-server-start, clean stderr; `// @vitest-environment node` + stripped `NODE_OPTIONS`
+
 ### Visualization Tooling (Issue #44)
 
 **`agentensemble-devtools` Java module:**
@@ -106,7 +131,6 @@ All tools extend `AbstractAgentTool` with automatic metrics, logging, exception 
 ## What's Left to Build
 
 ### Near-term (follow-up issues)
-- Issue #94: Distribute `agentensemble-viz` via Homebrew tap
 - MCP (Model Context Protocol) integration (`McpAgentTool`)
 - GraalVM polyglot tool support
 - Tool output validation / schema enforcement


### PR DESCRIPTION
## Summary

Implements [#94](https://github.com/AgentEnsemble/agentensemble/issues/94) -- distributes the `agentensemble-viz` trace viewer CLI as a self-contained native binary via a Homebrew tap.

```bash
# Install
brew install agentensemble/tap/agentensemble-viz

# Use
agentensemble-viz ./traces/

# Update
brew upgrade agentensemble-viz
```

## Changes

### `agentensemble-viz/cli.js`
- `distDir` now uses `new URL('./dist/', import.meta.url).pathname` so Bun embeds the entire `dist/` directory into the compiled binary
- Package version read via `readFileSync(new URL('./package.json', import.meta.url))` (Bun embeds `package.json` too)
- `--version` flag: prints `agentensemble-viz/<semver>` and exits 0 (required by Homebrew formula test block)

### `agentensemble-viz/package.json`
- Added `compile:darwin-arm64`, `compile:darwin-x64`, `compile:linux-x64` scripts using `bun build --compile`

### `.github/workflows/release.yml`
- After Java artifact upload: sets up Node 20 + Bun (`oven-sh/setup-bun@v2`)
- Builds viz, cross-compiles for 3 targets, creates tarballs, uploads to GitHub Release
- Fires `repository_dispatch` to `AgentEnsemble/homebrew-tap` with version payload

### `AgentEnsemble/homebrew-tap` (already pushed to that repo's main)
- `Formula/agentensemble-viz.rb`: platform-aware formula (`on_macos`/`on_linux` blocks)
- `.github/workflows/update-formula.yml`: triggered by dispatch; downloads tarballs, computes SHA256, updates formula, commits and pushes -- fully automated

### Tests
- `agentensemble-viz/src/__tests__/cli.test.ts`: 4 new CLI integration tests covering `--version` exit code, output format, no server start, clean stderr

### Documentation
- `docs/guides/visualization.md`: Homebrew listed as Option 1 (recommended)
- `docs/examples/visualization.md`: Homebrew option added
- `docs/getting-started/installation.md`: new Execution Graph Visualizer section
- `README.md`: new Execution Graph Visualization section

## Required Secret

Before the first release using this workflow, add to the main repo's GitHub Secrets:

- **`ORG_HOMEBREW_TAP_TOKEN`**: Personal Access Token with `repo` scope on `AgentEnsemble/homebrew-tap`

## Test Results

All 45 viz tests pass (`npm test`), TypeScript compiles cleanly (`npm run typecheck`).