### PR TITLE
fix: address Copilot review comments from PR #96

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         # SHA256 hashes and commit the updated formula. Requires a PAT with
         # repo scope on homebrew-tap stored as ORG_HOMEBREW_TAP_TOKEN.
         run: |
-          curl --silent --fail -X POST \
+          curl --silent --show-error --fail-with-body -X POST \
             -H "Authorization: Bearer ${{ secrets.ORG_HOMEBREW_TAP_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Content-Type: application/json" \

--- a/agentensemble-viz/cli.js
+++ b/agentensemble-viz/cli.js
@@ -13,14 +13,18 @@
 import { createServer } from 'node:http';
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { exec } from 'node:child_process';
 
-// Resolve version from package.json. Using new URL so Bun embeds package.json
-// into the compiled binary alongside the dist/ assets.
+// Resolve version from package.json. The new URL() reference is intentional:
+// it allows Bun's --compile to detect and embed package.json into the binary.
+// fileURLToPath() is used instead of .pathname so that paths with spaces or
+// other special characters are correctly decoded (URL encoding is not valid
+// for filesystem APIs).
 let cliVersion = 'unknown';
 try {
   const pkg = JSON.parse(
-    readFileSync(new URL('./package.json', import.meta.url).pathname, 'utf8'),
+    readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8'),
   );
   cliVersion = pkg.version ?? 'unknown';
 } catch {
@@ -36,8 +40,10 @@ if (process.argv.includes('--version')) {
 // Resolve the traces directory from the CLI argument or default
 const tracesDir = process.argv[2] ? resolve(process.argv[2]) : resolve('./traces');
 
-// Using new URL so Bun embeds the entire dist/ directory into the compiled binary
-const distDir = new URL('./dist/', import.meta.url).pathname;
+// Using new URL so Bun embeds the entire dist/ directory into the compiled binary.
+// fileURLToPath() decodes URL percent-encoding so paths with spaces or special
+// characters resolve correctly on the filesystem.
+const distDir = fileURLToPath(new URL('./dist/', import.meta.url));
 const PORT = parseInt(process.env.PORT ?? '7329', 10);
 
 const MIME_TYPES = {


### PR DESCRIPTION
## Summary

Addresses the Copilot inline review comments on PR #96 (merged).

## Changes

### `agentensemble-viz/cli.js`

Both `package.json` and `dist/` path resolutions now use `fileURLToPath()` instead of `.pathname`.

**Before:**
```js
readFileSync(new URL('./package.json', import.meta.url).pathname, 'utf8')
const distDir = new URL('./dist/', import.meta.url).pathname;
```

**After:**
```js
readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8')
const distDir = fileURLToPath(new URL('./dist/', import.meta.url));
```

The `new URL(..., import.meta.url)` reference is retained so Bun's `--compile` still detects and embeds the files into the binary. `fileURLToPath()` correctly decodes URL percent-encoding (e.g. `%20` → space) so paths resolve properly on filesystems with spaces or other special characters.

### `.github/workflows/release.yml`

Added `--show-error --fail-with-body` to the `curl` dispatch command so the API response body is printed in CI logs when the `repository_dispatch` call fails.

**Before:** `curl --silent --fail`
**After:** `curl --silent --show-error --fail-with-body`

## Tests

All 45 viz tests pass (`npm test`).