### PR TITLE
docs: dynamic agent creation example and MapReduceEnsemble design (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,60 @@ When using `CONTINUE_ON_ERROR`, a `ParallelExecutionException` is thrown if any 
 
 **Full documentation:** [Workflows Guide](https://docs.agentensemble.net/guides/workflows/) | [Parallel Workflow Example](https://docs.agentensemble.net/examples/parallel-workflow/)
 
+### Dynamic Agent Creation
+
+`Workflow.PARALLEL` works equally well when agents and tasks are constructed programmatically at
+runtime. Because `Agent` and `Task` are plain Java objects, you can build them in a loop from any
+dynamic collection -- the framework does not distinguish between statically-declared and
+dynamically-constructed instances:
+
+```java
+List<Agent> specialistAgents = new ArrayList<>();
+List<Task> dishTasks = new ArrayList<>();
+
+for (OrderItem item : order.getItems()) {
+    Agent specialist = Agent.builder()
+            .role(item.getDish() + " Specialist")
+            .goal("Prepare " + item.getDish())
+            .llm(model)
+            .build();
+
+    Task dishTask = Task.builder()
+            .description("Prepare the recipe for " + item.getDish())
+            .expectedOutput("Recipe with ingredients, steps, and timing")
+            .agent(specialist)
+            .build();
+
+    specialistAgents.add(specialist);
+    dishTasks.add(dishTask);
+}
+
+// Fan-in: Head Chef aggregates all specialist outputs
+Task mealPlan = Task.builder()
+        .description("Coordinate all dish preparations into a final meal service plan.")
+        .expectedOutput("Meal plan with serving order and timing.")
+        .agent(headChef)
+        .context(dishTasks)  // depends on ALL specialist tasks
+        .build();
+
+Ensemble.EnsembleBuilder builder = Ensemble.builder().workflow(Workflow.PARALLEL);
+specialistAgents.forEach(builder::agent);
+builder.agent(headChef);
+dishTasks.forEach(builder::task);
+builder.task(mealPlan);
+
+EnsembleOutput output = builder.build().run();
+// Specialists run concurrently; Head Chef runs after all specialists complete.
+```
+
+**Context size consideration:** with a large number of specialists each producing verbose output,
+the aggregation task's context can become very large. Use `outputType(RecordClass.class)` on
+specialist tasks to produce compact structured JSON, reducing aggregation context by 5-10x.
+For very large N, a tree-reduction approach (planned for `MapReduceEnsemble` in v2.0.0) can
+aggregate results in batches across multiple levels.
+
+**Full documentation:** [Dynamic Agent Creation Example](https://docs.agentensemble.net/examples/dynamic-agents/)
+
 ---
 
 ## Memory System
@@ -933,11 +987,15 @@ export OPENAI_API_KEY=your-api-key
 
 # Hierarchical team -- manager coordinates specialists
 ./gradlew :agentensemble-examples:runHierarchicalTeam
-./gradlew :agentensemble-examples:runHierarchicalTeam --args="Tesla"
+./gradlew :agentensemble-examples:runHierarchicalTeam --args="Acme Corp"
 
 # Parallel workflow -- concurrent DAG-based execution
 ./gradlew :agentensemble-examples:runParallelWorkflow
-./gradlew :agentensemble-examples:runParallelWorkflow --args="Tesla automotive"
+./gradlew :agentensemble-examples:runParallelWorkflow --args="Acme Corp enterprise software"
+
+# Dynamic agent creation -- fan-out/fan-in with runtime-constructed agents
+./gradlew :agentensemble-examples:runDynamicAgents
+./gradlew :agentensemble-examples:runDynamicAgents --args="Risotto Steak Tiramisu"
 
 # Memory across runs -- long-term memory over 3 weekly cycles
 ./gradlew :agentensemble-examples:runMemoryAcrossRuns

--- a/agentensemble-examples/build.gradle.kts
+++ b/agentensemble-examples/build.gradle.kts
@@ -40,8 +40,10 @@ application {
 //
 // Usage:
 //   ./gradlew :agentensemble-examples:runResearchWriter
-//   ./gradlew :agentensemble-examples:runHierarchicalTeam --args="Tesla"
-//   ./gradlew :agentensemble-examples:runParallelWorkflow --args="Tesla"
+//   ./gradlew :agentensemble-examples:runHierarchicalTeam --args="Acme Corp"
+//   ./gradlew :agentensemble-examples:runParallelWorkflow --args="Acme Corp enterprise software"
+//   ./gradlew :agentensemble-examples:runDynamicAgents
+//   ./gradlew :agentensemble-examples:runDynamicAgents --args="Risotto Steak Tiramisu"
 //   ./gradlew :agentensemble-examples:runMemoryAcrossRuns
 //   ./gradlew :agentensemble-examples:runStructuredOutput --args="quantum computing"
 //   ./gradlew :agentensemble-examples:runCallbacks --args="the future of AI agents"
@@ -51,6 +53,7 @@ mapOf(
     "runResearchWriter"  to "net.agentensemble.examples.ResearchWriterExample",
     "runHierarchicalTeam" to "net.agentensemble.examples.HierarchicalTeamExample",
     "runParallelWorkflow" to "net.agentensemble.examples.ParallelCompetitiveIntelligenceExample",
+    "runDynamicAgents" to "net.agentensemble.examples.DynamicAgentsExample",
     "runMemoryAcrossRuns" to "net.agentensemble.examples.MemoryAcrossRunsExample",
     "runStructuredOutput" to "net.agentensemble.examples.StructuredOutputExample",
     "runCallbacks" to "net.agentensemble.examples.CallbackExample",

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/DynamicAgentsExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/DynamicAgentsExample.java
@@ -1,0 +1,187 @@
+package net.agentensemble.examples;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.ArrayList;
+import java.util.List;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.task.TaskOutput;
+import net.agentensemble.workflow.Workflow;
+
+/**
+ * Demonstrates dynamic agent creation using the existing Ensemble + Workflow.PARALLEL API.
+ *
+ * Scenario: a restaurant kitchen receives an order with multiple dishes. A separate
+ * specialist agent is created for each dish (fan-out). All specialists work in parallel.
+ * A Head Chef then aggregates all their preparations into a final meal plan (fan-in).
+ *
+ * Key concepts:
+ * - Agents and Tasks are ordinary Java objects -- they can be created dynamically in a loop.
+ * - Workflow.PARALLEL automatically derives concurrency from context() declarations.
+ * - Independent tasks (map phase) run concurrently; the aggregation task (reduce phase)
+ *   waits for all of them via context().
+ *
+ * Run via:
+ *   ./gradlew :agentensemble-examples:runDynamicAgents
+ *
+ * Pass dish names as arguments:
+ *   ./gradlew :agentensemble-examples:runDynamicAgents --args="Risotto Steak Tiramisu"
+ */
+public class DynamicAgentsExample {
+
+    // ---- Domain model -----
+
+    record OrderItem(String dish, String cuisine, String dietaryNotes) {}
+
+    record Order(String tableNumber, List<OrderItem> items) {}
+
+    // ---- Example entry point -----
+
+    public static void main(String[] args) {
+
+        var model = OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName("gpt-4o-mini")
+                .build();
+
+        Order order = buildOrder(args);
+
+        System.out.printf(
+                "=== Order for Table %s (%d items) ===%n%n",
+                order.tableNumber(), order.items().size());
+        order.items()
+                .forEach(item -> System.out.printf(
+                        "  - %s (%s)%s%n",
+                        item.dish(),
+                        item.cuisine(),
+                        item.dietaryNotes().isEmpty() ? "" : " [" + item.dietaryNotes() + "]"));
+        System.out.println();
+
+        EnsembleOutput output = fulfillOrder(order, model);
+
+        System.out.println("=== Final Meal Plan ===");
+        System.out.println(output.getRaw());
+
+        System.out.println("\n=== Individual Dish Preparations ===");
+        for (TaskOutput taskOutput : output.getTaskOutputs()) {
+            System.out.printf("[%s]%n", taskOutput.getAgentRole());
+            System.out.println(taskOutput.getRaw());
+            System.out.println();
+        }
+
+        System.out.printf(
+                "Completed in %s | %d total tool calls%n", output.getTotalDuration(), output.getTotalToolCalls());
+    }
+
+    // ---- Dynamic ensemble construction -----
+
+    static EnsembleOutput fulfillOrder(Order order, dev.langchain4j.model.chat.ChatModel model) {
+
+        // Phase 1: Dynamically create one specialist agent + task per dish.
+        //
+        // Agent and Task are ordinary immutable value objects built with
+        // standard builders. Creating them in a loop is the same as creating
+        // them individually -- the framework does not care how they were built.
+
+        List<Agent> specialistAgents = new ArrayList<>();
+        List<Task> dishTasks = new ArrayList<>();
+
+        for (OrderItem item : order.items()) {
+            Agent specialist = Agent.builder()
+                    .role(item.dish() + " Specialist")
+                    .goal("Prepare " + item.dish() + " to perfection")
+                    .background("You are an expert in " + item.cuisine() + " cuisine. "
+                            + "You understand the techniques, ingredients, and presentation "
+                            + "standards for classic " + item.cuisine() + " dishes.")
+                    .llm(model)
+                    .build();
+
+            String dietaryClause =
+                    item.dietaryNotes().isEmpty() ? "" : " Dietary requirements: " + item.dietaryNotes() + ".";
+
+            Task dishTask = Task.builder()
+                    .description("Prepare the recipe for " + item.dish() + "."
+                            + dietaryClause
+                            + " Provide key ingredients, preparation steps, cook time, "
+                            + "and plating instructions.")
+                    .expectedOutput("Recipe summary with ingredients list, numbered preparation "
+                            + "steps, total time, and a brief plating description.")
+                    .agent(specialist)
+                    .build();
+
+            specialistAgents.add(specialist);
+            dishTasks.add(dishTask);
+        }
+
+        // Phase 2: Create a single Head Chef agent that aggregates all dish outputs.
+        //
+        // By declaring context(dishTasks), this task depends on ALL specialist tasks.
+        // Workflow.PARALLEL ensures the Head Chef only executes after every
+        // specialist has finished -- but the specialists themselves run concurrently.
+
+        Agent headChef = Agent.builder()
+                .role("Head Chef")
+                .goal("Coordinate all dishes into a cohesive, well-timed meal service")
+                .background("You are a Michelin-starred head chef responsible for the overall "
+                        + "quality and timing of every plate that leaves the kitchen.")
+                .llm(model)
+                .build();
+
+        Task mealPlanTask = Task.builder()
+                .description("Review the preparations for all " + order.items().size()
+                        + " dishes provided in context. Create a final meal plan that "
+                        + "coordinates cooking schedules, plating sequence, and service timing "
+                        + "so all dishes arrive at table " + order.tableNumber()
+                        + " at the right temperature simultaneously.")
+                .expectedOutput("A coordinated meal service plan: serving order, timing for each "
+                        + "dish, any final-minute coordination notes, and a brief quality checklist.")
+                .agent(headChef)
+                .context(dishTasks) // fan-in: waits for all specialist tasks
+                .build();
+
+        // Phase 3: Assemble the ensemble.
+        //
+        // All specialist agents + the Head Chef are registered. All dish tasks +
+        // the meal plan task are registered. Workflow.PARALLEL derives execution
+        // order automatically from the context declarations:
+        //   - Dish tasks have no context dependencies -- they run concurrently.
+        //   - Meal plan task declares context(dishTasks) -- it runs after all dish tasks.
+
+        Ensemble.EnsembleBuilder builder = Ensemble.builder().workflow(Workflow.PARALLEL);
+
+        for (Agent agent : specialistAgents) {
+            builder.agent(agent);
+        }
+        builder.agent(headChef);
+
+        for (Task task : dishTasks) {
+            builder.task(task);
+        }
+        builder.task(mealPlanTask);
+
+        return builder.build().run();
+    }
+
+    // ---- Helpers -----
+
+    private static Order buildOrder(String[] args) {
+        if (args.length > 0) {
+            List<OrderItem> items = new ArrayList<>();
+            for (String dish : args) {
+                items.add(new OrderItem(dish, "International", ""));
+            }
+            return new Order("42", items);
+        }
+
+        // Default order for demonstration
+        return new Order(
+                "7",
+                List.of(
+                        new OrderItem("Truffle Risotto", "Italian", "vegetarian"),
+                        new OrderItem("Pan-seared Duck Breast", "French", ""),
+                        new OrderItem("Miso-glazed Salmon", "Japanese", "gluten-free"),
+                        new OrderItem("Chocolate Fondant", "French", "contains nuts")));
+    }
+}

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/HierarchicalTeamExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/HierarchicalTeamExample.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  *   ./gradlew :agentensemble-examples:runHierarchicalTeam
  *
  * To analyse a different company:
- *   ./gradlew :agentensemble-examples:runHierarchicalTeam --args="Tesla"
+ *   ./gradlew :agentensemble-examples:runHierarchicalTeam --args="Acme Corp"
  */
 public class HierarchicalTeamExample {
 

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/ParallelCompetitiveIntelligenceExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/ParallelCompetitiveIntelligenceExample.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *   ./gradlew :agentensemble-examples:runParallelWorkflow
  *
  * To analyse a different company:
- *   ./gradlew :agentensemble-examples:runParallelWorkflow --args="Tesla"
+ *   ./gradlew :agentensemble-examples:runParallelWorkflow --args="Acme Corp enterprise software"
  */
 public class ParallelCompetitiveIntelligenceExample {
 

--- a/docs/design/13-future-roadmap.md
+++ b/docs/design/13-future-roadmap.md
@@ -438,5 +438,45 @@ See [Built-in Tools guide](../guides/built-in-tools.md) for usage.
 | Phase 7 | v0.7.0 | Callbacks and observability (COMPLETE) |
 | Phase 8 | v0.8.0 | Guardrails: pre/post execution validation (COMPLETE) |
 | Phase 9 | v1.0.0 | Streaming, built-in tools |
+| Phase 10 | v2.0.0 | MapReduceEnsemble (static + adaptive + short-circuit) |
+
+---
+
+## Phase 10: MapReduceEnsemble (v2.0.0)
+
+**Goal**: Provide a first-class builder for the fan-out / tree-reduce pattern, with both a
+static (pre-built DAG) and adaptive (token-budget-driven) execution strategy.
+
+The core problem this solves: when N agents each produce substantial output, a single
+aggregation agent's context can overflow the model's context window. `MapReduceEnsemble`
+automates multi-level tree reduction to keep every reduce step within a configurable token
+budget.
+
+### Three-Issue Delivery Plan
+
+**Issue A: Static MapReduceEnsemble (`chunkSize`)**
+
+Delivers the `MapReduceEnsemble` builder with a fixed `chunkSize` strategy. The entire DAG
+is pre-built before execution. The inner `Ensemble` with `Workflow.PARALLEL` handles
+concurrent execution. Includes `toEnsemble()` for DAG inspection and devtools/viz updates.
+
+**Issue B: Adaptive MapReduceEnsemble (`targetTokenBudget`)**
+
+Extends Issue A with token-budget-aware adaptive execution. After each level completes,
+actual output token counts drive bin-packing to determine the next level's shape. Includes
+`contextWindowSize`/`budgetRatio` convenience, token estimation strategies, `maxReduceLevels`
+safety valve, and trace/metrics aggregation across multiple `Ensemble.run()` calls.
+
+**Issue C: Short-Circuit Optimization**
+
+Extends Issue B with an optional pre-execution size check. When total input fits within the
+token budget, the map-reduce pipeline is bypassed in favour of a single direct task. Requires
+`directAgent` and `directTask` factory configuration.
+
+### Full Design
+
+See [docs/design/14-map-reduce.md](14-map-reduce.md) for the complete specification including
+algorithm pseudocode, API reference, visualization layer changes, edge case table, and
+implementation class structure.
 
 Each phase should be backward-compatible with previous phases. The API is designed with future phases in mind -- builder methods can be added without breaking existing code.

--- a/docs/design/14-map-reduce.md
+++ b/docs/design/14-map-reduce.md
@@ -1,0 +1,662 @@
+# 14 - MapReduceEnsemble
+
+**Target release:** v2.0.0
+
+This document describes the design for `MapReduceEnsemble`, a builder that automates the
+fan-out / tree-reduce pattern for scenarios where a dynamic number of agents process items
+independently and their results are aggregated progressively to fit within a model's context
+window.
+
+---
+
+## 1. Problem Statement
+
+`Workflow.PARALLEL` makes it straightforward to fan out to N agents and aggregate their
+outputs via a single reduce task:
+
+```
+[Agent 1] ----+
+[Agent 2] ----+--> [Aggregator] --> Final Output
+[Agent N] ----+
+```
+
+The aggregator receives all N outputs as context. When N is small or each agent's output is
+compact, this works well. However, when N is large or each output is verbose, the aggregator's
+context may exceed the model's context window. Even before hard token limits are reached,
+context quality degrades when models receive excessively long inputs.
+
+The pattern requires multi-level tree reduction:
+
+```
+Level 0 (Map):    [A1] [A2] [A3] [A4] [A5] [A6]
+                    \    |    /     \    |    /
+Level 1 (Reduce): [Reduce-0-0]      [Reduce-0-1]
+                         \                /
+Level 2 (Final):       [Final Reducer]
+```
+
+Building this DAG by hand is error-prone and requires knowing output sizes upfront.
+`MapReduceEnsemble` automates the construction.
+
+---
+
+## 2. Two Reduction Strategies
+
+`MapReduceEnsemble` supports two strategies, selected by the configuration:
+
+### 2.1 Static Strategy (`chunkSize`)
+
+The entire DAG is pre-built before execution based on a fixed `chunkSize`. The shape of the
+tree is fully determined at build time. `toEnsemble()` returns the pre-built `Ensemble`, which
+can be inspected via devtools before execution.
+
+**Execution model:** a single `Ensemble.run()` with `Workflow.PARALLEL`. The framework's
+existing topological scheduler handles concurrent execution across all levels.
+
+**When to use:**
+- N and average output sizes are known and predictable
+- You want to inspect or export the DAG before executing
+- Determinism (same inputs = same tree shape) is required
+
+### 2.2 Adaptive Strategy (`targetTokenBudget`)
+
+The DAG is built level-by-level at runtime based on actual output token counts. After each
+level executes, the framework measures output sizes and groups them into bins that fit within
+the budget. The tree depth is determined adaptively.
+
+**Execution model:** multiple `Ensemble.run()` calls, one per level. Each level is an
+independent `Ensemble` with `Workflow.PARALLEL`.
+
+**When to use:**
+- N is large or output sizes are unpredictable
+- You want to minimize unnecessary reduce levels when outputs happen to be small
+- Context window constraints are a hard requirement
+
+---
+
+## 3. Short-Circuit Optimization (Adaptive Only)
+
+Before the map phase runs, the framework estimates the total input size. If the estimate is
+below the token budget, the map-reduce is unnecessary and an optional direct task can be used
+instead:
+
+```
+Decision tree:
+
+estimated_input_tokens <= targetTokenBudget AND directAgent/directTask configured?
+  YES --> Short-circuit: run single direct task with all items as input
+  NO  --> Run map phase
+
+After map phase:
+total_output_tokens <= targetTokenBudget?
+  YES --> Single final reduce (no intermediate levels)
+  NO  --> Bin-pack outputs, run reduce level, repeat
+```
+
+The `directAgent` and `directTask` factories are optional. If not provided, the map phase
+runs regardless of input size.
+
+---
+
+## 4. API Design
+
+```java
+// Generic type T: the type of each input item
+MapReduceEnsemble.<OrderItem>builder()
+
+    // -- Required: input items -------------------------------------------------
+    .items(order.getItems())               // List<T>, must not be empty
+
+    // -- Required: map phase factories -----------------------------------------
+    .mapAgent(item -> Agent.builder()      // Function<T, Agent>
+        .role(item.getDish() + " Chef")
+        .goal("Prepare " + item.getDish())
+        .llm(model)
+        .build())
+    .mapTask((item, agent) -> Task.builder() // BiFunction<T, Agent, Task>
+        .description("Execute recipe for " + item.getDish())
+        .expectedOutput("Recipe with steps and timing")
+        .agent(agent)
+        .outputType(DishResult.class)       // structured output works naturally
+        .build())
+
+    // -- Required: reduce phase factories -------------------------------------
+    .reduceAgent(() -> Agent.builder()     // Supplier<Agent>
+        .role("Sub-Chef")
+        .goal("Consolidate preparations")
+        .llm(model)
+        .build())
+    .reduceTask((agent, chunkTasks) ->     // BiFunction<Agent, List<Task>, Task>
+        Task.builder()
+            .description("Consolidate these preparations into a cohesive sub-plan")
+            .expectedOutput("Consolidated plan")
+            .agent(agent)
+            .context(chunkTasks)           // user MUST wire context explicitly
+            .build())
+
+    // -- Reduction strategy (choose one) --------------------------------------
+    .chunkSize(3)                          // Static: fixed groups of 3
+    // OR:
+    .targetTokenBudget(8_000)             // Adaptive: keep reducing until < 8K tokens
+    // OR derive from model context window:
+    .contextWindowSize(128_000)           // Adaptive: 128K * 0.5 = 64K budget
+    .budgetRatio(0.5)                     // fraction of context window for reduce input
+
+    // -- Optional: short-circuit (adaptive only) ------------------------------
+    .directAgent(() -> Agent.builder()
+        .role("Head Chef")
+        .goal("Handle the entire order directly")
+        .llm(model)
+        .build())
+    .directTask((agent, allItems) -> Task.builder()
+        .description("Process all " + allItems.size() + " items directly")
+        .expectedOutput("Complete plan")
+        .agent(agent)
+        .build())
+
+    // -- Optional: safety limits (adaptive only) ------------------------------
+    .maxReduceLevels(10)                  // prevent infinite reduction loops (default: 10)
+
+    // -- Optional: Ensemble passthrough fields ---------------------------------
+    .verbose(true)
+    .listener(myListener)
+    .captureMode(CaptureMode.STANDARD)
+    .parallelErrorStrategy(ParallelErrorStrategy.FAIL_FAST)
+    .costConfiguration(costs)
+    .traceExporter(exporter)
+    .toolExecutor(myExecutor)
+    .toolMetrics(myMetrics)
+    .input("key", "value")               // template variable inputs
+
+    .build()
+    .run();                              // returns EnsembleOutput
+```
+
+### Key design constraints
+
+- `mapAgent`, `mapTask`, `reduceAgent`, `reduceTask` are all required.
+- `chunkSize` and `targetTokenBudget` are **mutually exclusive**. Setting both throws
+  `ValidationException` at `build()` time.
+- When neither is set, the default is `chunkSize(5)` (static mode).
+- `chunkSize` must be >= 2.
+- `budgetRatio` must be in range `(0.0, 1.0]`. Default: `0.5`.
+- `contextWindowSize` and `budgetRatio` together derive `targetTokenBudget`:
+  `targetTokenBudget = (int)(contextWindowSize * budgetRatio)`.
+- The reduce task factory receives the agent as its first argument AND must wire
+  `.context(chunkTasks)` explicitly. The framework does not mutate the returned task.
+  Failing to wire context produces a `ValidationException` when the inner `Ensemble`
+  is validated.
+- `directAgent`/`directTask` are only evaluated in adaptive mode. In static mode they
+  are ignored.
+
+---
+
+## 5. Return Types
+
+| Method | Returns | Description |
+|---|---|---|
+| `build()` | `MapReduceEnsemble<T>` | Configured instance ready to run |
+| `run()` | `EnsembleOutput` | Execute and return aggregated results |
+| `run(Map<String, String>)` | `EnsembleOutput` | Execute with runtime template variable overrides |
+| `toEnsemble()` | `Ensemble` | Static mode only: returns the pre-built `Ensemble`. Throws `UnsupportedOperationException` in adaptive mode. |
+
+---
+
+## 6. Static DAG Construction Algorithm
+
+Given N items and chunkSize K:
+
+1. Create N map agents + N map tasks (no context, all independent).
+2. Partition the map tasks into groups of at most K.
+   - If N <= K: single group; go directly to step 4 (no intermediate levels).
+   - If N > K: multiple groups at level 1.
+3. For each group at level L:
+   - Create one reduce agent (via `reduceAgent` supplier) per group.
+   - Create one reduce task (via `reduceTask` factory) per group, receiving the group tasks
+     as the `chunkTasks` argument.
+   - Collect the reduce tasks as the "current level" output.
+4. If the current level has more than K tasks, partition again and repeat from step 3
+   with L = L+1.
+5. When the current level has K or fewer tasks, create the final reduce task. This is the
+   terminal node; its context wraps all current-level tasks.
+
+**Tree depth:** O(log_K(N)). For N=100, K=5: depth = 3 levels.
+
+**Example: N=7, K=3**
+
+```
+Map level:     [M1] [M2] [M3]   [M4] [M5] [M6]   [M7]
+                     \               \
+Reduce L1:       [R-L1-0]         [R-L1-1]       [R-L1-2 (single item)]
+                     \               /                  /
+Final reduce:              [Final]
+```
+
+Note: when the last group has only 1 item and the next level has <= K tasks, the framework
+still creates a reduce task for the single-item group to keep the DAG shape consistent. The
+reduce agent will effectively receive a single context item, which is valid.
+
+---
+
+## 7. Adaptive Execution Algorithm
+
+```
+INPUT: items, map factories, reduce factories, targetTokenBudget, maxReduceLevels
+
+STEP 1: Input size estimation (short-circuit check)
+  If directAgent and directTask are configured:
+    estimated = sum(estimateTokens(itemDescription(item)) for item in items)
+    If estimated <= targetTokenBudget:
+      Run single direct task containing all items
+      Return EnsembleOutput (single level)
+
+STEP 2: Map phase
+  Build map Ensemble with N independent tasks
+  Run -> collect mapOutputs (list of TaskOutput)
+  Accumulate trace and metrics
+
+STEP 3: Check if single reduce is sufficient
+  totalMapTokens = sum(tokenCount(output) for output in mapOutputs)
+  If totalMapTokens <= targetTokenBudget:
+    Build single final reduce Ensemble
+    Run -> return EnsembleOutput (two levels: map + final reduce)
+
+STEP 4: Adaptive reduce loop
+  currentOutputs = mapOutputs
+  reduceLevels = 0
+
+  WHILE sum(tokenCount(output) for output in currentOutputs) > targetTokenBudget:
+    If reduceLevels >= maxReduceLevels:
+      Log warning: "maxReduceLevels reached; proceeding with final reduce anyway"
+      Break
+
+    bins = binPack(currentOutputs, targetTokenBudget)
+    Build reduce Ensemble with one task per bin
+    Run -> collect reduceOutputs
+    Accumulate trace and metrics
+    currentOutputs = reduceOutputs
+    reduceLevels++
+
+STEP 5: Final reduce
+  Build final reduce Ensemble with single task
+  context = all currentOutputs
+  Run -> collect finalOutput
+  Accumulate trace and metrics
+
+STEP 6: Aggregate all traces and metrics into a single EnsembleOutput
+  Return EnsembleOutput
+```
+
+---
+
+## 8. Token Estimation
+
+Token counts are needed to drive the adaptive reduction decision. The framework uses a
+three-tier estimation strategy:
+
+### 8.1 Post-execution (primary)
+
+After each level runs, `TaskOutput.getMetrics().getOutputTokenCount()` provides the exact
+output token count as reported by the LLM provider. This is the most accurate source and
+is used when available (value != -1).
+
+### 8.2 Heuristic fallback
+
+When the provider returns -1 (token count unavailable), the framework estimates using:
+
+```
+estimatedTokens = rawOutput.length() / 4
+```
+
+This approximates the English-language average of ~4 characters per token. It is not precise
+but is sufficient for bin-packing decisions. The fallback is logged at WARN level so users
+are aware.
+
+### 8.3 Custom estimator
+
+Users can provide a `TokenEstimator` (a `Function<String, Integer>`) to override the default
+heuristic:
+
+```java
+.tokenEstimator(text -> myTokenizer.count(text))
+```
+
+This is useful when using non-English models or when a provider-specific tokenizer is
+available (e.g., `cl100k_base` for OpenAI models via `tiktoken4j`).
+
+---
+
+## 9. Bin-Packing Algorithm
+
+The adaptive reduce loop groups outputs into bins where the total token count of each bin
+does not exceed `targetTokenBudget`. The framework uses a **first-fit-decreasing (FFD)**
+approximation:
+
+1. Sort outputs by token count, descending.
+2. For each output, assign it to the first existing bin that has capacity. If none, open a
+   new bin.
+3. A bin's capacity is `targetTokenBudget`. An output that exceeds `targetTokenBudget` on
+   its own is placed in a bin by itself (cannot be sub-divided further without summarisation).
+
+When an output exceeds `targetTokenBudget` on its own, the framework logs a WARNING:
+```
+MapReduce: single output from agent [{role}] exceeds targetTokenBudget ({actual} > {budget}).
+Proceeding with a single-item reduce group. Consider increasing targetTokenBudget or using
+outputType to produce more compact structured output.
+```
+
+---
+
+## 10. Trace and Metrics Aggregation
+
+The adaptive mode executes multiple `Ensemble.run()` calls. Each call produces its own
+`EnsembleOutput` with its own `ExecutionTrace` and `ExecutionMetrics`. The framework
+aggregates these into a single `EnsembleOutput` returned from `MapReduceEnsemble.run()`.
+
+### Trace aggregation
+
+A synthetic `ExecutionTrace` is produced with:
+- A single `ensembleId` for the entire map-reduce run.
+- `workflow` field: `"MAP_REDUCE_STATIC"` or `"MAP_REDUCE_ADAPTIVE"`.
+- A new top-level field `mapReduceLevels`: list of level summaries (level index, workflow
+  type per level, task count, duration).
+- All `TaskTrace` objects from all levels, annotated with a `mapReduceLevel` field (int)
+  and `nodeType` field (`"map"`, `"reduce"`, `"final-reduce"`, or `"direct"`).
+- `startedAt` from the first map task, `completedAt` from the final reduce task.
+
+### Metrics aggregation
+
+`ExecutionMetrics` fields are summed across all levels:
+- `totalTokens`, `totalInputTokens`, `totalOutputTokens`
+- `totalLlmLatency`, `totalToolExecutionTime`
+- `llmCallCount`, `toolCallCount`
+- `totalCostEstimate` (when `CostConfiguration` is set)
+
+---
+
+## 11. Visualization Layer
+
+### DagModel (devtools)
+
+`DagTaskNode` gains a new optional field:
+
+```java
+public class DagTaskNode {
+    // existing fields ...
+    String nodeType;        // "map", "reduce", "final-reduce", "direct", or null for standard
+    Integer mapReduceLevel; // 0 = map, 1+ = reduce levels; null for non-MapReduce tasks
+}
+```
+
+`DagModel` gains:
+
+```java
+public class DagModel {
+    // existing fields ...
+    String mapReduceMode;   // "STATIC", "ADAPTIVE", or null for non-MapReduce ensembles
+}
+```
+
+`DagExporter` is extended to export `MapReduceEnsemble` via `toEnsemble()` (static mode) or
+from a post-execution DAG snapshot (adaptive mode).
+
+`DagModel.schemaVersion` is bumped to `"1.1"` to reflect the new fields.
+
+### agentensemble-viz (TypeScript)
+
+`DagTaskNode` in `types/dag.ts` gains:
+
+```typescript
+nodeType?: 'map' | 'reduce' | 'final-reduce' | 'direct';
+mapReduceLevel?: number;
+```
+
+`DagModel` in `types/dag.ts` gains:
+
+```typescript
+mapReduceMode?: 'STATIC' | 'ADAPTIVE';
+```
+
+`TaskNode.tsx` renders map and reduce nodes with visually distinct styling:
+- Map nodes: standard task styling with a "MAP" badge.
+- Reduce nodes: a distinct background colour with a "REDUCE L{level}" badge.
+- Final-reduce nodes: an "AGGREGATE" badge.
+- Direct nodes: a "DIRECT" badge.
+
+The **Flow View** groups map nodes visually (same horizontal level) to communicate the
+fan-out structure. Reduce levels are visually stacked below.
+
+---
+
+## 12. Error Handling
+
+### Map phase errors
+
+Errors in map tasks are governed by `parallelErrorStrategy` (passed through to the inner
+`Ensemble`):
+- `FAIL_FAST`: first failure aborts the map phase. `TaskExecutionException` propagates from
+  `MapReduceEnsemble.run()`.
+- `CONTINUE_ON_ERROR`: failed map tasks produce no output. The surviving outputs proceed to
+  the reduce phase. If zero outputs survive, `ParallelExecutionException` propagates.
+
+### Reduce phase errors
+
+Same `parallelErrorStrategy` applies. A failing reduce task causes dependent downstream
+reduce tasks to be skipped. If the final reduce task would have no context (all upstream
+reduce tasks failed), a `TaskExecutionException` is thrown.
+
+### Single output exceeds budget (adaptive)
+
+Logged as a warning; the output is placed in a single-item bin and proceeds to the next
+level. The framework never drops outputs silently.
+
+### maxReduceLevels reached
+
+If `maxReduceLevels` is exhausted before the total token count drops below budget, the
+framework logs a warning and proceeds with the final reduce on whatever current outputs
+remain. This prevents infinite loops at the cost of potentially large context in the final
+reduce.
+
+---
+
+## 13. Validation Rules
+
+At `MapReduceEnsemble.build()` time:
+- `items` must not be null or empty.
+- `mapAgent`, `mapTask`, `reduceAgent`, `reduceTask` must not be null.
+- `chunkSize` (when set) must be >= 2.
+- `chunkSize` and `targetTokenBudget` are mutually exclusive.
+- `budgetRatio` must be in range `(0.0, 1.0]`.
+- `maxReduceLevels` must be >= 1.
+- `contextWindowSize` and `budgetRatio` must both be set if either is set (they derive
+  `targetTokenBudget` together).
+
+At runtime (when the inner `Ensemble` is built per level):
+- The standard `EnsembleValidator` rules apply to each inner `Ensemble`.
+- If the reduce task factory does not wire `context(chunkTasks)`, the inner `Ensemble`
+  validation will throw `ValidationException` (circular context check or missing agent
+  membership). The error message will reference the reduce task.
+
+---
+
+## 14. Edge Cases
+
+| Scenario | Behaviour |
+|---|---|
+| N=1 item | Single map task + single final reduce. No intermediate levels. |
+| N <= chunkSize (static) | Single map level + single final reduce. No intermediate levels. |
+| All map outputs fit in budget (adaptive) | Single final reduce. No intermediate reduce levels. |
+| Single map output exceeds budget | Placed in single-item bin. Warning logged. |
+| Reduce output grows (e.g., verbose reduce prompt) | Next iteration's bin-packing handles it. `maxReduceLevels` prevents infinite loop. |
+| All map tasks fail (FAIL_FAST) | `TaskExecutionException` propagates before reduce phase. |
+| All map tasks fail (CONTINUE_ON_ERROR) | `ParallelExecutionException` propagates before reduce phase. |
+| Some map tasks fail (CONTINUE_ON_ERROR) | Surviving outputs proceed to reduce. |
+| Provider returns -1 for token counts | Heuristic fallback (`length / 4`). WARN logged. |
+| directAgent configured but adaptive mode not enabled | `ValidationException` at build time (directAgent only valid with targetTokenBudget). |
+| chunkSize=2, N=2 | Single reduce level: one group of 2 map tasks, final reduce. |
+
+---
+
+## 15. Full Code Examples
+
+### Static Mode (Kitchen scenario)
+
+```java
+record DishResult(String dish, List<String> ingredients, int prepMinutes, String plating) {}
+record MealPlan(List<DishResult> dishes, String servingOrder, String notes) {}
+
+EnsembleOutput output = MapReduceEnsemble.<OrderItem>builder()
+    .items(order.getItems())
+
+    .mapAgent(item -> Agent.builder()
+        .role(item.getDish() + " Chef")
+        .goal("Prepare " + item.getDish() + " according to " + item.getCuisine() + " tradition")
+        .background("Expert in " + item.getCuisine() + " cuisine.")
+        .llm(model)
+        .build())
+    .mapTask((item, agent) -> Task.builder()
+        .description("Prepare the recipe for " + item.getDish()
+            + ". Dietary requirements: " + item.getDietaryNotes())
+        .expectedOutput("Structured recipe result")
+        .agent(agent)
+        .outputType(DishResult.class)
+        .build())
+
+    .reduceAgent(() -> Agent.builder()
+        .role("Sub-Chef")
+        .goal("Consolidate dish preparations into a cohesive plan")
+        .llm(model)
+        .build())
+    .reduceTask((agent, chunkTasks) -> Task.builder()
+        .description("Consolidate these dish preparations. "
+            + "Ensure timing, dietary restrictions, and plating work together.")
+        .expectedOutput("Consolidated sub-plan with timing and coordination notes")
+        .agent(agent)
+        .context(chunkTasks)
+        .build())
+
+    .chunkSize(3)
+    .verbose(true)
+    .build()
+    .run();
+
+// Inspect the pre-built DAG
+Ensemble innerEnsemble = MapReduceEnsemble.<OrderItem>builder()
+    ...
+    .chunkSize(3)
+    .build()
+    .toEnsemble();
+
+DagExporter.export(innerEnsemble, Path.of("./traces/"));
+```
+
+### Adaptive Mode with Short-Circuit
+
+```java
+EnsembleOutput output = MapReduceEnsemble.<OrderItem>builder()
+    .items(order.getItems())
+
+    .mapAgent(item -> Agent.builder()
+        .role(item.getDish() + " Chef")
+        .goal("Prepare " + item.getDish())
+        .llm(model)
+        .build())
+    .mapTask((item, agent) -> Task.builder()
+        .description("Execute recipe for: " + item.getDish())
+        .expectedOutput("Recipe with ingredients, steps, and timing")
+        .agent(agent)
+        .build())
+
+    .reduceAgent(() -> Agent.builder()
+        .role("Sub-Chef")
+        .goal("Consolidate dish preparations")
+        .llm(model)
+        .build())
+    .reduceTask((agent, chunkTasks) -> Task.builder()
+        .description("Consolidate these dish preparations.")
+        .expectedOutput("Consolidated plan")
+        .agent(agent)
+        .context(chunkTasks)
+        .build())
+
+    // Short-circuit: if total input fits in budget, skip map-reduce entirely
+    .directAgent(() -> Agent.builder()
+        .role("Head Chef")
+        .goal("Handle the entire order directly")
+        .llm(model)
+        .build())
+    .directTask((agent, allItems) -> {
+        String allDishes = allItems.stream()
+            .map(OrderItem::getDish)
+            .collect(Collectors.joining(", "));
+        return Task.builder()
+            .description("Plan the complete meal for: " + allDishes)
+            .expectedOutput("Complete meal plan with all dishes")
+            .agent(agent)
+            .build();
+    })
+
+    .contextWindowSize(128_000)   // GPT-4o context window
+    .budgetRatio(0.5)             // use up to 50% for context input
+    .maxReduceLevels(5)
+    .captureMode(CaptureMode.STANDARD)
+    .build()
+    .run();
+```
+
+---
+
+## 16. Implementation Notes
+
+### Package
+
+`net.agentensemble.mapreduce` (new package in `agentensemble-core`).
+
+### Class structure
+
+```
+MapReduceEnsemble<T>                 -- main builder + runner
+MapReduceConfig<T>                   -- immutable config (extracted from builder)
+MapReduceStaticExecutor<T>           -- builds static DAG, delegates to Ensemble.run()
+MapReduceAdaptiveExecutor<T>         -- level-by-level execution loop
+MapReduceTokenEstimator              -- token estimation (provider count, heuristic, custom)
+MapReduceBinPacker                   -- first-fit-decreasing bin-packing
+MapReduceTraceAggregator             -- combines ExecutionTraces across levels
+MapReduceMetricsAggregator           -- sums ExecutionMetrics across levels
+```
+
+### Testing requirements
+
+**Unit tests:**
+- Builder validation: null items, null factories, chunkSize < 2, both strategies set,
+  contextWindowSize without budgetRatio (and vice versa), directAgent with static mode.
+- Static DAG construction: N=1, N=chunkSize, N=chunkSize+1, N=10/K=3 (verify tree depth),
+  N=100/K=5 (verify tree depth = 3), context wiring correctness at each level.
+- Bin-packing: standard case, single large item, all items equal, items with varied sizes.
+- Token estimation: provider count available, provider count -1 (heuristic), custom estimator.
+
+**Integration tests (mock LLMs):**
+- Static end-to-end: 6 items, chunkSize=3 -- verify 6 map agents called, 2 L1 reduce agents,
+  1 final reduce.
+- Adaptive end-to-end: 6 items with known output sizes -- verify correct number of levels.
+- Short-circuit: items with small total input -- verify single direct task, no map phase.
+- Error propagation: map task failure with FAIL_FAST; map task failure with CONTINUE_ON_ERROR.
+
+**Feature/E2E tests:**
+- Full kitchen example from runnable example class.
+
+---
+
+## 17. Release Plan
+
+`MapReduceEnsemble` is targeted for v2.0.0 and delivered in three issues:
+
+| Issue | Scope | Depends On |
+|---|---|---|
+| Issue A | Static `MapReduceEnsemble` (`chunkSize`) | None |
+| Issue B | Adaptive `MapReduceEnsemble` (`targetTokenBudget`) | Issue A |
+| Issue C | Short-circuit optimization (`directAgent`/`directTask`) | Issue B |
+
+Each issue includes full unit + integration tests, documentation updates (guide, example,
+reference), and visualization layer changes. See the individual GitHub issues for detailed
+acceptance criteria checklists.

--- a/docs/examples/dynamic-agents.md
+++ b/docs/examples/dynamic-agents.md
@@ -1,0 +1,202 @@
+# Example: Dynamic Agent Creation (Fan-Out / Fan-In)
+
+This example demonstrates how to programmatically create agents and tasks at runtime using the
+existing `Workflow.PARALLEL` API. No special framework features are required -- `Agent` and
+`Task` are ordinary Java builder objects and can be constructed in a loop.
+
+## Scenario
+
+A restaurant kitchen receives an order with multiple dishes. Rather than pre-defining a fixed
+set of agents, the kitchen creates a specialist agent for each dish on the fly (fan-out). All
+specialists work in parallel. A Head Chef then aggregates their individual preparations into a
+coordinated meal service plan (fan-in).
+
+This pattern applies whenever:
+
+- The number of agents is not known until runtime
+- Each item in a dynamic collection needs independent processing
+- Results must be aggregated into a single final output
+
+## How It Works
+
+```
+Input: Order with N dishes
+         |
+         +-- [Risotto Specialist] ----+
+         |                            |
+         +-- [Duck Specialist] -------+--> [Head Chef] --> Final Meal Plan
+         |                            |
+         +-- [Salmon Specialist] -----+
+         |                            |
+         +-- [Fondant Specialist] ----+
+```
+
+The specialists have no dependencies on each other and run concurrently. The Head Chef task
+declares `context(allDishTasks)`, which causes `Workflow.PARALLEL` to execute it only after
+every specialist has finished.
+
+## Code
+
+```java
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.ArrayList;
+import java.util.List;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.workflow.Workflow;
+
+public class DynamicAgentsExample {
+
+    record OrderItem(String dish, String cuisine, String dietaryNotes) {}
+    record Order(String tableNumber, List<OrderItem> items) {}
+
+    public static EnsembleOutput fulfillOrder(Order order,
+            dev.langchain4j.model.chat.ChatModel model) {
+
+        // Phase 1: Fan-out -- one specialist agent + task per dish
+        List<Agent> specialistAgents = new ArrayList<>();
+        List<Task> dishTasks = new ArrayList<>();
+
+        for (OrderItem item : order.items()) {
+            Agent specialist = Agent.builder()
+                    .role(item.dish() + " Specialist")
+                    .goal("Prepare " + item.dish() + " to perfection")
+                    .background("You are an expert in " + item.cuisine() + " cuisine.")
+                    .llm(model)
+                    .build();
+
+            Task dishTask = Task.builder()
+                    .description("Prepare the recipe for " + item.dish() + ". "
+                            + "Provide key ingredients, preparation steps, and plating instructions.")
+                    .expectedOutput("Recipe summary with ingredients, steps, total time, "
+                            + "and plating description.")
+                    .agent(specialist)
+                    .build();
+
+            specialistAgents.add(specialist);
+            dishTasks.add(dishTask);
+        }
+
+        // Phase 2: Fan-in -- single Head Chef aggregates all specialist outputs
+        Agent headChef = Agent.builder()
+                .role("Head Chef")
+                .goal("Coordinate all dishes into a cohesive, well-timed meal service")
+                .background("You are a Michelin-starred head chef.")
+                .llm(model)
+                .build();
+
+        Task mealPlanTask = Task.builder()
+                .description("Review the preparations for all dishes. Create a coordinated "
+                        + "meal plan with cooking schedule, plating sequence, and service timing.")
+                .expectedOutput("Coordinated meal service plan with serving order and timing.")
+                .agent(headChef)
+                .context(dishTasks)  // depends on ALL specialist tasks
+                .build();
+
+        // Phase 3: Assemble and run
+        //
+        // Workflow.PARALLEL derives execution order from context() declarations:
+        //   - Dish tasks have no dependencies -> run concurrently
+        //   - Meal plan task declares context(dishTasks) -> runs after all dish tasks
+        Ensemble.EnsembleBuilder builder = Ensemble.builder()
+                .workflow(Workflow.PARALLEL);
+
+        specialistAgents.forEach(builder::agent);
+        builder.agent(headChef);
+
+        dishTasks.forEach(builder::task);
+        builder.task(mealPlanTask);
+
+        return builder.build().run();
+    }
+}
+```
+
+## Running the Example
+
+```bash
+export OPENAI_API_KEY=your-api-key
+
+# Default four-course order
+./gradlew :agentensemble-examples:runDynamicAgents
+
+# Custom dishes (space-separated)
+./gradlew :agentensemble-examples:runDynamicAgents --args="Risotto Steak Tiramisu"
+```
+
+## Key Points
+
+**1. Agents and Tasks are plain Java objects**
+
+There is nothing special about creating them in a loop versus creating them individually. The
+framework does not distinguish between statically-declared and dynamically-constructed instances.
+
+**2. Fan-out is implicit**
+
+Tasks with no `context` declarations are automatically identified as roots by the
+`ParallelWorkflowExecutor` and started immediately. You do not need to mark them as parallel.
+
+**3. Fan-in via `context(list)`**
+
+Passing a `List<Task>` to `context()` creates a dependency on every task in the list. The
+aggregation task starts only after all listed tasks complete -- regardless of how many there are.
+
+**4. Context text grows with the number of tasks**
+
+Each specialist task's output is injected into the Head Chef's user prompt as a "Context from
+prior tasks" section. With many agents, this context can become large. If this is a concern:
+
+- Use `outputType(RecordClass.class)` on each specialist task to produce compact structured
+  JSON instead of verbose prose.
+- For very large N, consider a tree-reduction approach: group specialist outputs into batches,
+  reduce each batch independently, then aggregate the batch summaries.
+
+See the design document for the planned `MapReduceEnsemble` builder, which automates this pattern.
+
+**5. `EnsembleOutput` is always in topological order**
+
+`output.getTaskOutputs()` returns results in dependency order. Specialist outputs come first
+(in completion order), followed by the Head Chef output last.
+
+## Execution Timeline
+
+```
+Time -->
+
+[Risotto Specialist] ------+
+[Duck Specialist] ---------+---> [Head Chef] ---> Final Meal Plan
+[Salmon Specialist] -------+
+[Fondant Specialist] ------+
+```
+
+All four specialists run concurrently. The Head Chef starts as soon as the last specialist
+finishes.
+
+## Context Size Consideration
+
+When `N` specialist agents each produce substantial output, the aggregation task receives
+`N * avg_output_size` tokens of context. For small `N` (up to approximately 5-10 specialists),
+this is typically within all major models' context windows. For larger `N`, use structured
+output to keep each specialist's response compact:
+
+```java
+record DishSummary(String dish, List<String> ingredients, int prepMinutes, String plating) {}
+
+Task dishTask = Task.builder()
+        .description("Prepare the recipe for " + item.dish())
+        .expectedOutput("Structured recipe summary")
+        .agent(specialist)
+        .outputType(DishSummary.class)  // compact JSON instead of prose
+        .build();
+```
+
+A `DishSummary` record typically serializes to 100-200 tokens versus 1,000-2,000 tokens for
+a prose recipe, reducing aggregation context by 5-10x.
+
+## Related
+
+- [Parallel Workflow](parallel-workflow.md) -- static parallel pipeline with fixed agents
+- [Structured Output](structured-output.md) -- compact JSON output from agents
+- [Hierarchical Team](hierarchical-team.md) -- LLM-directed agent routing

--- a/docs/examples/hierarchical-team.md
+++ b/docs/examples/hierarchical-team.md
@@ -134,7 +134,7 @@ export OPENAI_API_KEY=your-api-key
 ./gradlew :agentensemble-examples:runHierarchicalTeam
 
 # Analyse a different company
-./gradlew :agentensemble-examples:runHierarchicalTeam --args="Tesla"
+./gradlew :agentensemble-examples:runHierarchicalTeam --args="Acme Corp"
 ```
 
 ---

--- a/docs/examples/parallel-workflow.md
+++ b/docs/examples/parallel-workflow.md
@@ -148,10 +148,10 @@ export OPENAI_API_KEY=your-api-key
 ./gradlew :agentensemble-examples:runParallelWorkflow
 
 # Analyse a different company
-./gradlew :agentensemble-examples:runParallelWorkflow --args="Tesla"
+./gradlew :agentensemble-examples:runParallelWorkflow --args="Acme Corp"
 
 # Specify company and industry
-./gradlew :agentensemble-examples:runParallelWorkflow --args="Tesla automotive"
+./gradlew :agentensemble-examples:runParallelWorkflow --args="Acme Corp enterprise software"
 ```
 
 ## Execution Timeline

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -286,11 +286,84 @@ Parallel workflow uses `Executors.newVirtualThreadPerTaskExecutor()` (Java 21 st
 
 **MDC propagation**: The ensemble's MDC context (including `ensemble.id`) is captured before tasks are submitted and propagated to each virtual thread. Each thread also sets `agent.role` during its execution.
 
+### Dynamic Agent Creation
+
+`Workflow.PARALLEL` works equally well when agents and tasks are constructed programmatically at
+runtime. Because `Agent` and `Task` are plain immutable value objects, building them in a loop is
+identical to declaring them individually -- the framework does not distinguish between the two.
+
+This is the recommended approach when the number of agents is not known at compile time:
+
+```java
+List<Agent> agents = new ArrayList<>();
+List<Task> tasks = new ArrayList<>();
+
+for (OrderItem item : order.getItems()) {
+    Agent specialist = Agent.builder()
+            .role(item.getDish() + " Specialist")
+            .goal("Prepare " + item.getDish())
+            .llm(model)
+            .build();
+
+    Task dishTask = Task.builder()
+            .description("Prepare the recipe for " + item.getDish())
+            .expectedOutput("Recipe with ingredients, steps, and timing")
+            .agent(specialist)
+            .build();
+
+    agents.add(specialist);
+    tasks.add(dishTask);
+}
+
+// Fan-in: single aggregation task depends on all specialist tasks
+Agent headChef = Agent.builder()
+        .role("Head Chef")
+        .goal("Coordinate all dishes into a cohesive meal plan")
+        .llm(model)
+        .build();
+
+Task mealPlan = Task.builder()
+        .description("Create a coordinated meal service plan from all dish preparations.")
+        .expectedOutput("Meal plan with serving order and timing.")
+        .agent(headChef)
+        .context(tasks)  // depends on ALL specialist tasks
+        .build();
+
+// Assemble and run
+Ensemble.EnsembleBuilder builder = Ensemble.builder()
+        .workflow(Workflow.PARALLEL);
+
+agents.forEach(builder::agent);
+builder.agent(headChef);
+tasks.forEach(builder::task);
+builder.task(mealPlan);
+
+EnsembleOutput output = builder.build().run();
+```
+
+Execution pattern:
+
+```
+[Specialist 1] ----+
+[Specialist 2] ----+--> [Head Chef] --> Final Output
+[Specialist N] ----+
+```
+
+**Context size warning**: Each specialist task's output is injected into the aggregation task's
+prompt. With a large number of specialists each producing verbose output, this context can
+approach or exceed the model's context window. For large `N`, use `outputType(RecordClass.class)`
+on each specialist task to produce compact structured JSON, or implement a tree-reduction pattern
+where outputs are aggregated in batches across multiple levels.
+
+See the [Dynamic Agent Creation example](../examples/dynamic-agents.md) for a full working
+example with the kitchen scenario.
+
 ### When to Use PARALLEL
 
 - Multiple independent tasks can run concurrently to reduce total wall-clock time
 - Your pipeline has a natural DAG structure (some tasks depend on others, some are independent)
 - You want to maximize throughput for LLM API calls
+- The number of agents is not known at compile time (dynamic fan-out/fan-in)
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,6 +2,50 @@
 
 ## Current Work Focus
 
+Dynamic agent creation pattern documented (using current framework) and MapReduceEnsemble
+designed (v2.0.0). Three GitHub issues created (#98, #99, #100) covering the full
+MapReduceEnsemble feature across static, adaptive, and short-circuit strategies.
+
+## Recent Changes
+
+### Dynamic Agent Creation Documentation
+
+Added documentation and example for the fan-out/fan-in pattern using the existing
+`Workflow.PARALLEL` API:
+
+- **`docs/examples/dynamic-agents.md`** -- full example walkthrough with kitchen metaphor
+- **`agentensemble-examples/.../DynamicAgentsExample.java`** -- runnable example (4-dish order,
+  fan-out to specialist agents, fan-in to Head Chef aggregation)
+- **`docs/guides/workflows.md`** -- added "Dynamic Agent Creation" section under PARALLEL
+- **`agentensemble-examples/build.gradle.kts`** -- added `runDynamicAgents` Gradle task
+- **`mkdocs.yml`** -- added "Dynamic Agent Creation" to Examples nav
+- **`README.md`** -- added Dynamic Agent Creation subsection under Parallel Workflow, added
+  `runDynamicAgents` command to examples section
+- All "Tesla" references in docs/examples/source replaced with "Acme Corp"
+
+### MapReduceEnsemble Design (v2.0.0)
+
+- **`docs/design/14-map-reduce.md`** -- comprehensive design document covering: problem
+  statement, two reduction strategies (static/adaptive), short-circuit optimization, full
+  API design, return types, static DAG construction algorithm (O(log_K(N)) depth), adaptive
+  execution algorithm, token estimation (3-tier: provider count, custom, heuristic),
+  bin-packing (first-fit-decreasing), trace/metrics aggregation across multiple runs,
+  visualization layer changes (DagModel schemaVersion 1.1, nodeType/mapReduceLevel fields,
+  TypeScript types, TaskNode.tsx badges), error handling, validation rules, edge cases,
+  full code examples, implementation class structure
+- **`docs/design/13-future-roadmap.md`** -- added Phase 10 (v2.0.0) section + table entry
+- **`mkdocs.yml`** -- added "MapReduceEnsemble: design/14-map-reduce.md" to Design nav
+
+### GitHub Issues Created
+
+- **#98** -- Static MapReduceEnsemble with chunkSize (v2.0.0)
+- **#99** -- Adaptive MapReduceEnsemble with targetTokenBudget (v2.0.0), depends on #98
+- **#100** -- MapReduceEnsemble short-circuit optimization for small inputs (v2.0.0), depends on #99
+
+---
+
+## Previous Work Focus
+
 Issue #94 (Distribute agentensemble-viz via Homebrew tap) has been implemented. The
 `agentensemble-viz` CLI is now distributed as a self-contained binary via a Homebrew tap
 (`agentensemble/tap/agentensemble-viz`) in addition to the existing npm/npx path. Releases

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## [Unreleased] - Dynamic Agent Creation + MapReduceEnsemble Design -- 2026-03-05
+
+### Added (Dynamic Agent Creation -- current framework documentation)
+
+- `docs/examples/dynamic-agents.md`: full "Chef's Kitchen" example walkthrough documenting
+  how to create agents and tasks programmatically at runtime using the existing
+  `Workflow.PARALLEL` API. Covers fan-out/fan-in pattern, context size considerations,
+  structured output tip, execution timeline diagram.
+- `agentensemble-examples/.../DynamicAgentsExample.java`: runnable example with default
+  4-dish order and configurable dishes via command-line args; demonstrates the complete
+  fan-out (N specialist agents) + fan-in (Head Chef aggregation) pattern.
+- `agentensemble-examples/build.gradle.kts`: added `runDynamicAgents` Gradle task.
+- `docs/guides/workflows.md`: added "Dynamic Agent Creation" subsection under PARALLEL
+  workflow with code example, execution pattern diagram, and context size warning.
+- `mkdocs.yml`: added "Dynamic Agent Creation" to Examples nav section.
+- `README.md`: added Dynamic Agent Creation subsection under Parallel Workflow section;
+  added `runDynamicAgents` command to examples section; added MapReduceEnsemble mention
+  in roadmap.
+
+### Changed (Tesla reference removal)
+
+- Replaced `--args="Tesla"` / `--args="Tesla automotive"` with `--args="Acme Corp"` /
+  `--args="Acme Corp enterprise software"` across:
+  - `README.md`
+  - `agentensemble-examples/build.gradle.kts`
+  - `docs/examples/hierarchical-team.md`
+  - `docs/examples/parallel-workflow.md`
+  - `agentensemble-examples/src/.../HierarchicalTeamExample.java`
+  - `agentensemble-examples/src/.../ParallelCompetitiveIntelligenceExample.java`
+
+### Added (MapReduceEnsemble Design -- v2.0.0)
+
+- `docs/design/14-map-reduce.md`: comprehensive design document for `MapReduceEnsemble`.
+  17 sections covering: problem statement, two reduction strategies (static with chunkSize /
+  adaptive with targetTokenBudget), short-circuit optimization, full API design, return
+  types, static DAG construction algorithm (O(log_K(N)) tree depth), adaptive execution
+  algorithm (level-by-level with bin-packing), three-tier token estimation, first-fit-
+  decreasing bin-packing algorithm, trace/metrics aggregation across multiple Ensemble.run()
+  calls, visualization layer changes (DagModel schemaVersion 1.1, DagTaskNode.nodeType /
+  mapReduceLevel fields, DagModel.mapReduceMode, TypeScript types, TaskNode.tsx badge
+  rendering), error handling, validation rules, edge cases table, full code examples,
+  implementation class structure.
+- `docs/design/13-future-roadmap.md`: added Phase 10 (v2.0.0) with MapReduceEnsemble
+  three-issue delivery plan; added table entry.
+- `mkdocs.yml`: added "MapReduceEnsemble: design/14-map-reduce.md" to Design nav.
+
+### Added (GitHub Issues)
+
+- Issue #98: "feat: Static MapReduceEnsemble with chunkSize (v2.0.0)" -- comprehensive
+  acceptance criteria checklist covering core implementation, edge cases, tests (unit +
+  integration), visualization layer (devtools + viz), example, documentation, memory bank,
+  build.
+- Issue #99: "feat: Adaptive MapReduceEnsemble with targetTokenBudget (v2.0.0)" -- depends
+  on #98; covers targetTokenBudget, contextWindowSize/budgetRatio convenience, maxReduceLevels,
+  tokenEstimator, bin-packing, trace/metrics aggregation, adaptive execution loop, full
+  test matrix.
+- Issue #100: "feat: MapReduceEnsemble short-circuit optimization for small inputs (v2.0.0)"
+  -- depends on #99; covers directAgent, directTask, inputEstimator, decision tree, input
+  size estimation, full test matrix.
+
+---
+
 ## [Unreleased] - Issue #94 -- Homebrew Tap Distribution -- 2026-03-05
 
 ### Added (Issue #94 -- Distribute agentensemble-viz via Homebrew tap)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -130,6 +130,27 @@ All tools extend `AbstractAgentTool` with automatic metrics, logging, exception 
 
 ## What's Left to Build
 
+### v2.0.0 -- MapReduceEnsemble (Issues #98, #99, #100)
+
+Three-issue series targeting v2.0.0:
+
+| Issue | Title | Strategy |
+|---|---|---|
+| #98 | Static MapReduceEnsemble with chunkSize | Fixed DAG, pre-built before execution |
+| #99 | Adaptive MapReduceEnsemble with targetTokenBudget | Level-by-level, token-budget-driven |
+| #100 | Short-circuit optimization | Skip map-reduce when input fits in budget |
+
+Design fully specified in `docs/design/14-map-reduce.md`.
+
+Key implementation work in #98:
+- `net.agentensemble.mapreduce.MapReduceEnsemble<T>` class
+- Static DAG construction algorithm (O(log_K(N)) tree depth)
+- `toEnsemble()` for devtools inspection
+- `DagTaskNode.nodeType` + `DagTaskNode.mapReduceLevel` fields (devtools)
+- `DagModel.mapReduceMode` field (devtools)
+- TypeScript types + TaskNode.tsx badge rendering (viz)
+- Full unit + integration tests, `MapReduceKitchenExample.java`
+
 ### Near-term (follow-up issues)
 - MCP (Model Context Protocol) integration (`McpAgentTool`)
 - GraalVM polyglot tool support

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Research and Writer: examples/research-writer.md
     - Hierarchical Team: examples/hierarchical-team.md
     - Parallel Workflow: examples/parallel-workflow.md
+    - Dynamic Agent Creation: examples/dynamic-agents.md
     - Memory Across Runs: examples/memory-across-runs.md
     - Structured Output: examples/structured-output.md
     - Callbacks: examples/callbacks.md
@@ -118,3 +119,4 @@ nav:
     - Configuration Reference: design/11-configuration.md
     - Testing Strategy: design/12-testing-strategy.md
     - Future Roadmap: design/13-future-roadmap.md
+    - MapReduceEnsemble: design/14-map-reduce.md


### PR DESCRIPTION
## Summary

Documents the fan-out/fan-in pattern for dynamic agent creation using the existing framework, and introduces the comprehensive design for `MapReduceEnsemble` (v2.0.0).

---

## Deliverable 1: Dynamic Agent Creation (Current Framework)

Shows how to create N agents and tasks programmatically at runtime using `Workflow.PARALLEL` today -- no new framework code required.

```java
// Fan-out: one specialist per dish
for (OrderItem item : order.getItems()) {
    Agent specialist = Agent.builder().role(item.getDish() + " Chef")...build();
    Task dishTask = Task.builder()...agent(specialist).build();
    agents.add(specialist);
    tasks.add(dishTask);
}

// Fan-in: Head Chef waits for all specialists
Task mealPlan = Task.builder()
    .agent(headChef)
    .context(tasks)          // depends on ALL specialist tasks
    .build();
```

**Files changed:**
- `docs/examples/dynamic-agents.md` -- new example walkthrough
- `agentensemble-examples/.../DynamicAgentsExample.java` -- runnable example
- `docs/guides/workflows.md` -- new Dynamic Agent Creation subsection under PARALLEL
- `README.md` -- Dynamic Agent Creation subsection + `runDynamicAgents` command
- `agentensemble-examples/build.gradle.kts` -- `runDynamicAgents` task
- All `Tesla` references in docs/examples/source replaced with `Acme Corp`

---

## Deliverable 2: MapReduceEnsemble Design

`docs/design/14-map-reduce.md` -- comprehensive 17-section design for the `MapReduceEnsemble` builder planned for v2.0.0. Addresses the context-window overflow problem when N agents each produce substantial output.

**Two reduction strategies:**

| Strategy | Config | Behaviour |
|---|---|---|
| Static | `chunkSize(3)` | Pre-built DAG, single `Ensemble.run()`, inspectable via `toEnsemble()` |
| Adaptive | `targetTokenBudget(8_000)` | Level-by-level, bin-packed by actual token counts |

**Short-circuit:** when total input fits in budget, skip map-reduce entirely via optional `directAgent`/`directTask`.

**Design covers:** API, static DAG algorithm (O(log_K(N)) depth), adaptive execution loop, first-fit-decreasing bin-packing, three-tier token estimation, trace/metrics aggregation across multiple `Ensemble.run()` calls, visualization layer changes (`DagTaskNode.nodeType`, `mapReduceLevel`, `DagModel.mapReduceMode`, TypeScript types, `TaskNode.tsx` badges), error handling, validation, edge case table, implementation class structure.

**Also updated:**
- `docs/design/13-future-roadmap.md` -- Phase 10 (v2.0.0) section
- `mkdocs.yml` -- nav entries for new example and design pages

---

## Related Issues

- #98 -- Static MapReduceEnsemble with `chunkSize`
- #99 -- Adaptive MapReduceEnsemble with `targetTokenBudget` (depends on #98)
- #100 -- Short-circuit optimization (depends on #99)

---

## Testing

```bash
# New example compiles and runs
./gradlew :agentensemble-examples:compileJava   # BUILD SUCCESSFUL
./gradlew :agentensemble-examples:runDynamicAgents --args="Risotto Steak Tiramisu"
```

No production code changes -- docs and examples only.