### PR TITLE
fix: use ORG_RELEASE_TOKEN to bypass branch protection on SNAPSHOT bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.ORG_RELEASE_TOKEN }}
 
       - name: Set up Java 21
         uses: actions/setup-java@v5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=net.agentensemble
-version=1.3.1-SNAPSHOT
+version=1.4.1-SNAPSHOT


### PR DESCRIPTION
## Problem

The release workflow's `Bump version to next SNAPSHOT` step pushes directly to `main` after tagging a release. With branch protection now requiring PRs and a passing `Build and Test` status check, the default `GITHUB_TOKEN` is rejected:

```
GH006: Protected branch update failed for refs/heads/main.
- Changes must be made through a pull request.
- Required status check "Build and Test" is expected.
```

This caused run [22730573513](https://github.com/AgentEnsemble/agentensemble/actions/runs/22730573513/job/65918190892) to fail at the final step after a successful v1.4.0 release.

## Fix

Pass `ORG_RELEASE_TOKEN` to `actions/checkout` in `release.yml`. This configures the git remote with the PAT, so all subsequent `git push` calls (including the SNAPSHOT bump) use a token belonging to an actor listed as a bypass actor in the branch protection rule -- allowing the direct push to succeed.

```yaml
- name: Checkout
  uses: actions/checkout@v6
  with:
    token: ${{ secrets.ORG_RELEASE_TOKEN }}
```

## Also included

Bumps `gradle.properties` from `1.3.1-SNAPSHOT` to `1.4.1-SNAPSHOT` to apply the version bump that the failed v1.4.0 release run could not push.