### PR TITLE
feat: explicit tool pipeline / chaining (issue #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Built natively in Java on top of [LangChain4j](https://github.com/langchain4j/la
 | **Task** | A unit of work assigned to an agent, with a description and expected output |
 | **Ensemble** | A group of agents working together on a sequence of tasks |
 | **Tool** | A capability an agent can invoke (e.g., search, calculate) |
+| **Tool Pipeline** | A chain of tools that execute sequentially inside a single LLM tool call, with no round-trips between steps |
 | **Workflow** | How tasks are executed: `SEQUENTIAL`, `HIERARCHICAL` (manager delegates to workers), or `PARALLEL` (concurrent DAG-based execution) |
 | **Memory** | Optional per-run and cross-run context: short-term, long-term (vector store), and entity memory |
 
@@ -1010,7 +1011,33 @@ var agent = Agent.builder()
 
 Both approaches can be combined in a single agent's tool list.
 
-**Full documentation:** [Tools Guide](https://docs.agentensemble.net/guides/tools/)
+### Option 3: Chain tools with `ToolPipeline`
+
+`ToolPipeline` wraps multiple tools into a single compound tool that the LLM calls once. All steps execute inside that single call with no LLM round-trips between them -- reducing token cost and latency for deterministic data-transformation chains.
+
+```java
+import net.agentensemble.tool.ToolPipeline;
+import net.agentensemble.tool.PipelineErrorStrategy;
+
+// JsonParserTool extracts a price; adapter reshapes it; CalculatorTool applies markup
+ToolPipeline priceCalculator = ToolPipeline.builder()
+    .name("extract_and_calculate")
+    .description("Extracts the base_price field from a JSON payload and returns the "
+        + "price with a 10% markup applied. Input: JSON with a product object.")
+    .step(new JsonParserTool())
+    .adapter(result -> result.getOutput() + " * 1.1")
+    .step(new CalculatorTool())
+    .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+    .build();
+
+// Register on a task -- the LLM sees one tool and calls it once
+var task = Task.builder()
+    .description("Calculate the retail price from the product data")
+    .tools(List.of(priceCalculator))
+    .build();
+```
+
+**Full documentation:** [Tool Pipeline Guide](https://docs.agentensemble.net/guides/tool-pipeline/) | [Tool Pipeline Example](https://docs.agentensemble.net/examples/tool-pipeline/)
 
 ---
 
@@ -1133,6 +1160,9 @@ export OPENAI_API_KEY=your-api-key
 # Callbacks -- event listeners observing task and tool lifecycle
 ./gradlew :agentensemble-examples:runCallbacks
 ./gradlew :agentensemble-examples:runCallbacks --args="the future of AI agents"
+
+# Tool Pipeline -- chain tools into a single LLM call, no round-trips between steps
+./gradlew :agentensemble-examples:runToolPipeline
 ```
 
 **Full documentation:** [Examples](https://docs.agentensemble.net/examples/research-writer/)
@@ -1168,6 +1198,7 @@ See [`docs/design/`](docs/design/) for full specifications:
 - [14 - MapReduceEnsemble](docs/design/14-map-reduce.md)
 - [15 - v2.0.0 Architecture](docs/design/15-v2-architecture.md)
 - [16 - Live Execution Dashboard](docs/design/16-live-dashboard.md)
+- [17 - Tool Pipeline](docs/design/17-tool-pipeline.md)
 
 ---
 

--- a/agentensemble-core/src/main/java/net/agentensemble/tool/PipelineErrorStrategy.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/tool/PipelineErrorStrategy.java
@@ -1,0 +1,38 @@
+package net.agentensemble.tool;
+
+/**
+ * Controls how a {@link ToolPipeline} behaves when an intermediate step fails.
+ *
+ * <p>A step is considered failed when its {@link ToolResult#isSuccess()} returns {@code false},
+ * or when its {@link AgentTool#execute(String)} throws an exception (which
+ * {@link AbstractAgentTool} automatically converts to a {@link ToolResult#failure(String)}).
+ *
+ * @see ToolPipeline.Builder#errorStrategy(PipelineErrorStrategy)
+ */
+public enum PipelineErrorStrategy {
+
+    /**
+     * Stop the pipeline on the first failed step and return that step's
+     * {@link ToolResult} directly.
+     *
+     * <p>This is the default strategy. Steps after the failed step are never executed.
+     *
+     * <p>Example: in a three-step pipeline {@code A -> B -> C}, if B fails, C is
+     * skipped and the pipeline returns B's failure result immediately.
+     */
+    FAIL_FAST,
+
+    /**
+     * Continue executing subsequent steps even when an intermediate step fails.
+     *
+     * <p>When a step fails, its {@link ToolResult#getErrorMessage()} is used as the
+     * input to the next step (or an empty string if the error message is null). The
+     * final result of the pipeline is the result of the last step, regardless of
+     * whether any intermediate steps failed.
+     *
+     * <p>Use this strategy when downstream steps can handle or recover from upstream
+     * errors, or when the pipeline should always produce an output even if intermediate
+     * transformations fail.
+     */
+    CONTINUE_ON_FAILURE
+}

--- a/agentensemble-core/src/main/java/net/agentensemble/tool/ToolPipeline.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/tool/ToolPipeline.java
@@ -1,0 +1,438 @@
+package net.agentensemble.tool;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A composite {@link AgentTool} that chains multiple tools together in a linear pipeline,
+ * analogous to a Unix pipe ({@code tool_a | tool_b | tool_c}).
+ *
+ * <h2>How It Works</h2>
+ *
+ * <p>When the LLM calls the pipeline, all steps execute sequentially inside a single
+ * {@link #execute(String)} call -- no LLM round-trips occur between steps. The output of
+ * each step becomes the input to the next step. The pipeline exposes a single
+ * {@link dev.langchain4j.agent.tool.ToolSpecification} to the LLM, so the LLM treats the
+ * entire chain as one atomic tool call.
+ *
+ * <p>This reduces token cost and latency for deterministic, data-transformation-style
+ * pipelines where no LLM reasoning is needed between steps.
+ *
+ * <h2>Data Handoff Between Steps</h2>
+ *
+ * <p>By default, {@link ToolResult#getOutput()} (a plain {@code String}) from step N is
+ * passed verbatim as the {@code input} to step N+1. When you need to reshape the output
+ * before it reaches the next step -- for example, to extract a specific field or reformat
+ * a JSON string -- attach an adapter after the source step using
+ * the builder's {@link Builder#adapter(java.util.function.Function)} method.
+ *
+ * <h2>Usage</h2>
+ *
+ * <pre>
+ * // Simple pipeline (auto-generated name and description)
+ * ToolPipeline pipeline = ToolPipeline.of(
+ *     new WebSearchTool(provider),
+ *     new JsonParserTool(),
+ *     FileWriteTool.of(outputPath)
+ * );
+ *
+ * // Builder with explicit name, description, adapters, and error strategy
+ * ToolPipeline pipeline = ToolPipeline.builder()
+ *     .name("search_and_save")
+ *     .description("Search for information, extract the top result, and save it to disk")
+ *     .step(new WebSearchTool(provider))
+ *     .adapter(result -> "results[0]\n" + result.getOutput())  // reshape for JsonParserTool
+ *     .step(new JsonParserTool())
+ *     .step(FileWriteTool.of(outputPath))
+ *     .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+ *     .build();
+ *
+ * // Register as a single tool on an agent (v2: on Task)
+ * var task = Task.builder()
+ *     .description("Research and save AI trends")
+ *     .tools(List.of(pipeline))
+ *     .build();
+ * </pre>
+ *
+ * <h2>Error Handling</h2>
+ *
+ * <p>The default {@link PipelineErrorStrategy#FAIL_FAST} strategy stops the pipeline and
+ * returns the failed step's {@link ToolResult} immediately. Use
+ * {@link PipelineErrorStrategy#CONTINUE_ON_FAILURE} to let the pipeline always run to
+ * completion, passing the failed step's error message as input to the next step.
+ *
+ * <h2>Metrics and Logging</h2>
+ *
+ * <p>Each step that extends {@link AbstractAgentTool} has its own metrics automatically
+ * recorded (timing, success/failure counters). The pipeline itself also records aggregate
+ * timing and a single success/failure counter via the inherited
+ * {@link AbstractAgentTool#execute(String)} instrumentation.
+ *
+ * <h2>Approval Gates</h2>
+ *
+ * <p>Steps that extend {@link AbstractAgentTool} and call {@link AbstractAgentTool#requestApproval}
+ * will pause for human review mid-pipeline. The {@link ToolContext} (including the review
+ * handler) is propagated from the pipeline to all nested {@code AbstractAgentTool} steps
+ * automatically when the framework injects context via {@link ToolContextInjector}.
+ *
+ * <h2>Thread Safety</h2>
+ *
+ * <p>Instances are immutable after construction. Steps are executed sequentially and are not
+ * called concurrently within a single pipeline execution, but the pipeline itself may be called
+ * concurrently from multiple virtual threads in a parallel agent executor turn.
+ * Each step must be individually thread-safe.
+ */
+public final class ToolPipeline extends AbstractAgentTool {
+
+    private final String name;
+    private final String description;
+    private final List<PipelineStep> steps;
+    private final PipelineErrorStrategy errorStrategy;
+
+    private ToolPipeline(Builder builder) {
+        this.name = builder.name;
+        this.description = builder.description;
+        this.steps = Collections.unmodifiableList(new ArrayList<>(builder.steps));
+        this.errorStrategy = builder.errorStrategy;
+    }
+
+    /**
+     * Propagate the injected {@link ToolContext} to all nested steps that extend
+     * {@link AbstractAgentTool}, so each step receives the same metrics backend,
+     * executor, logger, and review handler as the pipeline itself.
+     */
+    @Override
+    void setContext(ToolContext toolContext) {
+        super.setContext(toolContext);
+        for (PipelineStep step : steps) {
+            if (step.tool() instanceof AbstractAgentTool abstractStep) {
+                abstractStep.setContext(toolContext);
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String name() {
+        return name;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String description() {
+        return description;
+    }
+
+    /**
+     * Execute all pipeline steps sequentially. The output of each step (transformed by
+     * any attached adapter) becomes the input to the next step.
+     *
+     * <p>If a step fails and the error strategy is {@link PipelineErrorStrategy#FAIL_FAST},
+     * the pipeline returns that step's failure result immediately and skips all subsequent
+     * steps. If the strategy is {@link PipelineErrorStrategy#CONTINUE_ON_FAILURE}, the error
+     * message is forwarded as the next step's input and the pipeline continues to completion.
+     *
+     * <p>Returns {@link ToolResult#success(String) success(input)} when the pipeline has no
+     * steps (pass-through).
+     *
+     * @param input the initial input string from the LLM tool call
+     * @return the result of the last executed step, or a pass-through success if no steps
+     */
+    @Override
+    protected ToolResult doExecute(String input) {
+        if (steps.isEmpty()) {
+            return ToolResult.success(input != null ? input : "");
+        }
+
+        String currentInput = input != null ? input : "";
+        ToolResult lastResult = null;
+
+        for (int i = 0; i < steps.size(); i++) {
+            PipelineStep step = steps.get(i);
+            log().debug(
+                            "Pipeline '{}': executing step [{}/{}] '{}'",
+                            name,
+                            i + 1,
+                            steps.size(),
+                            step.tool().name());
+
+            lastResult = step.tool().execute(currentInput);
+
+            if (!lastResult.isSuccess()) {
+                log().debug(
+                                "Pipeline '{}': step '{}' failed: {}",
+                                name,
+                                step.tool().name(),
+                                lastResult.getErrorMessage());
+                if (errorStrategy == PipelineErrorStrategy.FAIL_FAST) {
+                    return lastResult;
+                }
+                // CONTINUE_ON_FAILURE: forward the error message as the next step's input
+                currentInput = lastResult.getErrorMessage() != null ? lastResult.getErrorMessage() : "";
+            } else if (i < steps.size() - 1) {
+                // Adapt the successful result before passing it to the next step
+                currentInput = step.adaptOutput(lastResult);
+            }
+        }
+
+        return lastResult;
+    }
+
+    /**
+     * Returns the ordered list of tools that make up this pipeline's steps.
+     * The returned list is unmodifiable.
+     *
+     * @return the pipeline steps in execution order
+     */
+    public List<AgentTool> getSteps() {
+        return steps.stream().map(PipelineStep::tool).collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Returns the error strategy configured on this pipeline.
+     *
+     * @return the error strategy; never null
+     */
+    public PipelineErrorStrategy getErrorStrategy() {
+        return errorStrategy;
+    }
+
+    // ========================
+    // Factory methods
+    // ========================
+
+    /**
+     * Create a pipeline from two or more tools with an auto-generated name and description.
+     *
+     * <p>The pipeline name is the step names joined with {@code "_then_"}, and the description
+     * is {@code "Pipeline: step1 -> step2 -> ..."}. Use {@link Builder} for full control over
+     * name, description, adapters, and error strategy.
+     *
+     * <p>The error strategy defaults to {@link PipelineErrorStrategy#FAIL_FAST}.
+     *
+     * @param first the first step in the pipeline; must not be null
+     * @param rest  the remaining steps, in order; must not contain null elements
+     * @return a new ToolPipeline
+     */
+    public static ToolPipeline of(AgentTool first, AgentTool... rest) {
+        if (first == null) {
+            throw new IllegalArgumentException("first step must not be null");
+        }
+        List<AgentTool> allSteps = new ArrayList<>();
+        allSteps.add(first);
+        if (rest != null) {
+            for (AgentTool step : rest) {
+                if (step == null) {
+                    throw new IllegalArgumentException("pipeline steps must not contain null elements");
+                }
+                allSteps.add(step);
+            }
+        }
+
+        String autoName = allSteps.stream().map(AgentTool::name).collect(Collectors.joining("_then_"));
+        String autoDesc = "Pipeline: " + allSteps.stream().map(AgentTool::name).collect(Collectors.joining(" -> "));
+
+        Builder b = builder().name(autoName).description(autoDesc);
+        allSteps.forEach(b::step);
+        return b.build();
+    }
+
+    /**
+     * Create a pipeline with an explicit name and description.
+     *
+     * <p>The error strategy defaults to {@link PipelineErrorStrategy#FAIL_FAST}. Use
+     * {@link Builder} when you need adapters between steps or a different error strategy.
+     *
+     * @param name        the tool name exposed to the LLM; must not be blank
+     * @param description the tool description shown to the LLM; must not be blank
+     * @param first       the first step; must not be null
+     * @param rest        the remaining steps, in order; must not contain null elements
+     * @return a new ToolPipeline
+     */
+    public static ToolPipeline of(String name, String description, AgentTool first, AgentTool... rest) {
+        if (first == null) {
+            throw new IllegalArgumentException("first step must not be null");
+        }
+        Builder b = builder().name(name).description(description).step(first);
+        if (rest != null) {
+            Arrays.stream(rest).forEach(b::step);
+        }
+        return b.build();
+    }
+
+    /**
+     * Create a new {@link Builder} for full control over the pipeline configuration.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // ========================
+    // Builder
+    // ========================
+
+    /**
+     * Builder for {@link ToolPipeline}.
+     *
+     * <p>Call {@link #step(AgentTool)} to add each step in order. Optionally follow a step
+     * with {@link #adapter(Function)} to attach an output transformer that reshapes the step's
+     * result before it is passed to the next step.
+     *
+     * <pre>
+     * ToolPipeline pipeline = ToolPipeline.builder()
+     *     .name("extract_and_calculate")
+     *     .description("Extract a numeric field from JSON and evaluate a formula on it")
+     *     .step(new JsonParserTool())
+     *     .adapter(result -> result.getOutput() + " * 1.1")   // append formula for CalculatorTool
+     *     .step(new CalculatorTool())
+     *     .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+     *     .build();
+     * </pre>
+     */
+    public static final class Builder {
+
+        private String name;
+        private String description;
+        private final List<PipelineStep> steps = new ArrayList<>();
+        private PipelineErrorStrategy errorStrategy = PipelineErrorStrategy.FAIL_FAST;
+
+        private Builder() {}
+
+        /**
+         * Set the tool name exposed to the LLM.
+         *
+         * @param name the tool name; must not be blank
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Set the description shown to the LLM when it selects this tool.
+         *
+         * @param description the tool description; must not be blank
+         * @return this builder
+         */
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        /**
+         * Add a step to the pipeline.
+         *
+         * <p>Steps execute in the order they are added. Each step's output becomes the next
+         * step's input (unless an {@link #adapter(Function) adapter} is attached).
+         *
+         * @param tool the tool to add as a pipeline step; must not be null
+         * @return this builder
+         */
+        public Builder step(AgentTool tool) {
+            if (tool == null) {
+                throw new IllegalArgumentException("step tool must not be null");
+            }
+            steps.add(new PipelineStep(tool, null));
+            return this;
+        }
+
+        /**
+         * Attach an output adapter to the most recently added step.
+         *
+         * <p>The adapter receives the most recent step's {@link ToolResult} and returns the
+         * {@code String} that will be passed as input to the next step. If the step failed and
+         * the pipeline strategy is {@link PipelineErrorStrategy#CONTINUE_ON_FAILURE}, the
+         * adapter is NOT called -- the error message is forwarded directly.
+         *
+         * <p>Must be called immediately after a {@link #step(AgentTool)} call. Calling this
+         * method without a preceding step throws {@link IllegalStateException}.
+         *
+         * <p>Example -- reshape a JSON search result to provide a path expression for
+         * {@code JsonParserTool}:
+         *
+         * <pre>
+         * .step(new WebSearchTool(provider))
+         * .adapter(result -> "results[0].title\n" + result.getOutput())
+         * .step(new JsonParserTool())
+         * </pre>
+         *
+         * @param adapter a function that transforms the preceding step's result into the next
+         *                step's input string; must not be null
+         * @return this builder
+         * @throws IllegalStateException if called before any {@link #step(AgentTool)} call
+         */
+        public Builder adapter(Function<ToolResult, String> adapter) {
+            if (steps.isEmpty()) {
+                throw new IllegalStateException("adapter() must be called after a step()");
+            }
+            if (adapter == null) {
+                throw new IllegalArgumentException("adapter must not be null");
+            }
+            // Replace the most recent step with the same tool but the provided adapter
+            PipelineStep last = steps.remove(steps.size() - 1);
+            steps.add(new PipelineStep(last.tool(), adapter));
+            return this;
+        }
+
+        /**
+         * Set the error strategy for this pipeline.
+         *
+         * <p>Defaults to {@link PipelineErrorStrategy#FAIL_FAST} when not set.
+         *
+         * @param errorStrategy the strategy to use; must not be null
+         * @return this builder
+         */
+        public Builder errorStrategy(PipelineErrorStrategy errorStrategy) {
+            if (errorStrategy == null) {
+                throw new IllegalArgumentException("errorStrategy must not be null");
+            }
+            this.errorStrategy = errorStrategy;
+            return this;
+        }
+
+        /**
+         * Build the {@link ToolPipeline}.
+         *
+         * @return a new ToolPipeline
+         * @throws IllegalArgumentException if name or description is blank
+         */
+        public ToolPipeline build() {
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("ToolPipeline name must not be blank");
+            }
+            if (description == null || description.isBlank()) {
+                throw new IllegalArgumentException("ToolPipeline description must not be blank");
+            }
+            return new ToolPipeline(this);
+        }
+    }
+
+    // ========================
+    // Internal: step record
+    // ========================
+
+    /**
+     * Internal record pairing a pipeline step tool with an optional output adapter.
+     * The adapter transforms the step's ToolResult into the String input for the next step.
+     */
+    private record PipelineStep(AgentTool tool, Function<ToolResult, String> adapter) {
+
+        /**
+         * Apply the adapter (if present) to transform the result, or return
+         * {@link ToolResult#getOutput()} as-is when no adapter is configured.
+         */
+        String adaptOutput(ToolResult result) {
+            if (adapter != null) {
+                return adapter.apply(result);
+            }
+            return result.getOutput();
+        }
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/integration/ToolPipelineIntegrationTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/integration/ToolPipelineIntegrationTest.java
@@ -1,0 +1,417 @@
+package net.agentensemble.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.ensemble.ExitReason;
+import net.agentensemble.tool.AgentTool;
+import net.agentensemble.tool.PipelineErrorStrategy;
+import net.agentensemble.tool.ToolPipeline;
+import net.agentensemble.tool.ToolResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration tests for ToolPipeline running inside a full ensemble execution.
+ *
+ * <p>These tests verify that a ToolPipeline:
+ * <ul>
+ *   <li>Appears as a single tool in the LLM's tool specification</li>
+ *   <li>Executes all steps without additional LLM round-trips between steps</li>
+ *   <li>Returns a single result to the LLM after all steps complete</li>
+ *   <li>Correctly propagates ToolContext (metrics, logging) to nested steps</li>
+ *   <li>Respects error strategy within a live ensemble execution</li>
+ * </ul>
+ *
+ * <p>Uses Mockito-mocked LLMs (no real network calls). The mock LLM:
+ * <ol>
+ *   <li>Returns a tool-call response for the pipeline on the first invocation</li>
+ *   <li>Returns a final text response on the second invocation</li>
+ * </ol>
+ */
+class ToolPipelineIntegrationTest {
+
+    // ========================
+    // Fixture tools
+    // ========================
+
+    static AgentTool upperCaseTool() {
+        return new AgentTool() {
+            @Override
+            public String name() {
+                return "upper_case";
+            }
+
+            @Override
+            public String description() {
+                return "Converts input to upper case";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success(input == null ? "" : input.toUpperCase());
+            }
+        };
+    }
+
+    static AgentTool appendSuffixTool(String suffix) {
+        return new AgentTool() {
+            @Override
+            public String name() {
+                return "append_suffix";
+            }
+
+            @Override
+            public String description() {
+                return "Appends '" + suffix + "' to input";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success((input != null ? input : "") + suffix);
+            }
+        };
+    }
+
+    static AgentTool failingTool(String errorMessage) {
+        return new AgentTool() {
+            @Override
+            public String name() {
+                return "failing_step";
+            }
+
+            @Override
+            public String description() {
+                return "Always fails";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.failure(errorMessage);
+            }
+        };
+    }
+
+    /** A tool that counts how many times it has been called. */
+    static class CallCountingTool implements AgentTool {
+        final AtomicInteger callCount = new AtomicInteger(0);
+        final String toolName;
+
+        CallCountingTool(String name) {
+            this.toolName = name;
+        }
+
+        @Override
+        public String name() {
+            return toolName;
+        }
+
+        @Override
+        public String description() {
+            return "Counts calls";
+        }
+
+        @Override
+        public ToolResult execute(String input) {
+            callCount.incrementAndGet();
+            return ToolResult.success("counted: " + callCount.get());
+        }
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private static ChatResponse textResponse(String text) {
+        return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+    }
+
+    private static ChatResponse toolCallResponse(String toolName, String input) {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("req-1")
+                .name(toolName)
+                .arguments("{\"input\":\"" + input + "\"}")
+                .build();
+        return ChatResponse.builder().aiMessage(new AiMessage(List.of(request))).build();
+    }
+
+    private static Agent agentWithPipelineCall(
+            String pipelineName, String pipelineInput, String finalAnswer, AgentTool... tools) {
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class)))
+                .thenReturn(toolCallResponse(pipelineName, pipelineInput))
+                .thenReturn(textResponse(finalAnswer));
+        return Agent.builder()
+                .role("Worker")
+                .goal("Complete the task using the pipeline")
+                .llm(mockLlm)
+                .tools(List.of(tools))
+                .build();
+    }
+
+    // ========================
+    // Pipeline appears as a single tool
+    // ========================
+
+    @Test
+    void pipeline_appearsAsSingleToolToLlm_allStepsExecutedWithinOneLlmTurn() {
+        var step1CallCount = new AtomicInteger(0);
+        var step2CallCount = new AtomicInteger(0);
+        var step1 = new AgentTool() {
+            @Override
+            public String name() {
+                return "step1";
+            }
+
+            @Override
+            public String description() {
+                return "";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                step1CallCount.incrementAndGet();
+                return ToolResult.success(input + "_step1");
+            }
+        };
+        var step2 = new AgentTool() {
+            @Override
+            public String name() {
+                return "step2";
+            }
+
+            @Override
+            public String description() {
+                return "";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                step2CallCount.incrementAndGet();
+                return ToolResult.success(input + "_step2");
+            }
+        };
+
+        var pipeline = ToolPipeline.of("my_pipeline", "Runs step1 then step2", step1, step2);
+        var agent = agentWithPipelineCall("my_pipeline", "initial_input", "Pipeline ran successfully", pipeline);
+        var task = Task.builder()
+                .description("Run the pipeline")
+                .expectedOutput("Confirmation")
+                .agent(agent)
+                .build();
+
+        EnsembleOutput output = Ensemble.builder().task(task).build().run();
+
+        // Ensemble completes
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+        assertThat(output.getRaw()).isEqualTo("Pipeline ran successfully");
+
+        // Both steps ran exactly once -- no extra LLM round-trips triggered them
+        assertThat(step1CallCount.get()).isEqualTo(1);
+        assertThat(step2CallCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void pipeline_returnsChainedOutputToLlm_singleToolCallResult() {
+        // The LLM receives the final output of the pipeline chain in one tool result
+        var upperCase = upperCaseTool();
+        var appendSuffix = appendSuffixTool("_processed");
+        var pipeline = ToolPipeline.of("transform", "Transform data", upperCase, appendSuffix);
+
+        var agent = agentWithPipelineCall("transform", "hello world", "Data has been transformed", pipeline);
+        var task = Task.builder()
+                .description("Transform the data")
+                .expectedOutput("Confirmation")
+                .agent(agent)
+                .build();
+
+        EnsembleOutput output = Ensemble.builder().task(task).build().run();
+
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+        // The LLM received "HELLO WORLD_processed" as the tool result (step1->step2 chained)
+        // and produced its final answer
+        assertThat(output.getRaw()).isEqualTo("Data has been transformed");
+    }
+
+    // ========================
+    // Error strategy in ensemble context
+    // ========================
+
+    @Test
+    void pipeline_failFast_failedMiddleStep_llmReceivesErrorMessage() {
+        var step3CallCount = new AtomicInteger(0);
+        var pipeline = ToolPipeline.builder()
+                .name("pipeline_with_failure")
+                .description("Pipeline that fails in the middle")
+                .step(upperCaseTool())
+                .step(failingTool("middle step failed"))
+                .step(new AgentTool() {
+                    @Override
+                    public String name() {
+                        return "step3";
+                    }
+
+                    @Override
+                    public String description() {
+                        return "";
+                    }
+
+                    @Override
+                    public ToolResult execute(String input) {
+                        step3CallCount.incrementAndGet();
+                        return ToolResult.success("should not run");
+                    }
+                })
+                .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+                .build();
+
+        // LLM receives the pipeline error and adapts
+        var agent = agentWithPipelineCall(
+                "pipeline_with_failure", "input", "Could not process: middle step failed", pipeline);
+        var task = Task.builder()
+                .description("Process data")
+                .expectedOutput("Result")
+                .agent(agent)
+                .build();
+
+        EnsembleOutput output = Ensemble.builder().task(task).build().run();
+
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+        // Step3 was never called because of FAIL_FAST
+        assertThat(step3CallCount.get()).isEqualTo(0);
+    }
+
+    @Test
+    void pipeline_continueOnFailure_allStepsRun_llmReceivesFinalResult() {
+        var step3 = new CallCountingTool("step3");
+        var pipeline = ToolPipeline.builder()
+                .name("resilient_pipeline")
+                .description("Continues even on failure")
+                .step(upperCaseTool())
+                .step(failingTool("non-fatal error"))
+                .step(step3)
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        var agent = agentWithPipelineCall("resilient_pipeline", "data", "Processed with partial errors", pipeline);
+        var task = Task.builder()
+                .description("Process data resiliently")
+                .expectedOutput("Result")
+                .agent(agent)
+                .build();
+
+        EnsembleOutput output = Ensemble.builder().task(task).build().run();
+
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+        // Step3 ran despite step2's failure
+        assertThat(step3.callCount.get()).isEqualTo(1);
+    }
+
+    // ========================
+    // ToolContext propagation through ensemble
+    // ========================
+
+    @Test
+    void pipeline_toolContextPropagated_metricsRecordedForNestedAbstractAgentToolSteps() {
+        // This uses the v2 task-first API with auto-synthesized agent and mocked LLM
+        // to verify that metrics/logging are wired through to pipeline steps.
+        var pipeline = ToolPipeline.of("pipeline", "desc", upperCaseTool(), appendSuffixTool("_done"));
+
+        var agent = agentWithPipelineCall("pipeline", "test", "Done", pipeline);
+        var task = Task.builder()
+                .description("Use the pipeline")
+                .expectedOutput("Result")
+                .agent(agent)
+                .build();
+
+        // The test verifies no exceptions are thrown during context injection and execution
+        EnsembleOutput output = Ensemble.builder().task(task).build().run();
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+    }
+
+    // ========================
+    // Pipeline with adapter in ensemble context
+    // ========================
+
+    @Test
+    void pipeline_withAdapter_transformsBetweenSteps_ensembleCompletesSuccessfully() {
+        var step2Recording = new java.util.ArrayList<String>();
+        var step2 = new AgentTool() {
+            @Override
+            public String name() {
+                return "step2";
+            }
+
+            @Override
+            public String description() {
+                return "";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                step2Recording.add(input);
+                return ToolResult.success("processed: " + input);
+            }
+        };
+
+        var pipeline = ToolPipeline.builder()
+                .name("pipeline_with_adapter")
+                .description("Transforms between steps")
+                .step(upperCaseTool())
+                .adapter(result -> "PREFIX_" + result.getOutput())
+                .step(step2)
+                .build();
+
+        var agent = agentWithPipelineCall("pipeline_with_adapter", "hello", "Adapter pipeline succeeded", pipeline);
+        var task = Task.builder()
+                .description("Run the adapted pipeline")
+                .expectedOutput("Result")
+                .agent(agent)
+                .build();
+
+        EnsembleOutput output = Ensemble.builder().task(task).build().run();
+
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+        // Step2 received the adapter's output, not the raw upper-case result
+        assertThat(step2Recording).containsExactly("PREFIX_HELLO");
+    }
+
+    // ========================
+    // Pipeline registered via Task.builder().tools() (v2 task-first API)
+    // ========================
+
+    @Test
+    void pipeline_registeredOnTask_autoSynthesizedAgent_executes() {
+        var pipeline = ToolPipeline.of("task_pipeline", "Pipeline on task", upperCaseTool());
+
+        // v2: no explicit agent -- agent is synthesized from task description
+        var mockLlm = mock(ChatModel.class);
+        when(mockLlm.chat(any(ChatRequest.class)))
+                .thenReturn(toolCallResponse("task_pipeline", "synthesized"))
+                .thenReturn(textResponse("Task-first pipeline works"));
+
+        var task = Task.builder()
+                .description("Run the pipeline tool")
+                .expectedOutput("Result")
+                .tools(List.of(pipeline))
+                .build();
+
+        EnsembleOutput output =
+                Ensemble.builder().chatLanguageModel(mockLlm).task(task).build().run();
+
+        assertThat(output.getExitReason()).isEqualTo(ExitReason.COMPLETED);
+        assertThat(output.getRaw()).isEqualTo("Task-first pipeline works");
+    }
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/tool/ToolPipelineTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/tool/ToolPipelineTest.java
@@ -1,0 +1,757 @@
+package net.agentensemble.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for ToolPipeline: step chaining, error strategies, adapters,
+ * ToolContext propagation, factory methods, and builder validation.
+ */
+class ToolPipelineTest {
+
+    // ========================
+    // Test tool fixtures
+    // ========================
+
+    /** Returns a tool that echoes its input prefixed with the given label. */
+    static AgentTool prefixTool(String name, String prefix) {
+        return new AgentTool() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String description() {
+                return "Prepends '" + prefix + "' to input";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success(prefix + input);
+            }
+        };
+    }
+
+    /** Returns a tool that always succeeds with the given fixed output. */
+    static AgentTool fixedOutputTool(String name, String output) {
+        return new AgentTool() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String description() {
+                return "Always returns: " + output;
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success(output);
+            }
+        };
+    }
+
+    /** Returns a tool that always fails with the given error message. */
+    static AgentTool failingTool(String name, String errorMessage) {
+        return new AgentTool() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String description() {
+                return "Always fails";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.failure(errorMessage);
+            }
+        };
+    }
+
+    /** A tool that records every input it receives. */
+    static class RecordingTool implements AgentTool {
+        final String name;
+        final List<String> receivedInputs = new ArrayList<>();
+        private final String outputSuffix;
+
+        RecordingTool(String name, String outputSuffix) {
+            this.name = name;
+            this.outputSuffix = outputSuffix;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public String description() {
+            return "Records inputs";
+        }
+
+        @Override
+        public ToolResult execute(String input) {
+            receivedInputs.add(input);
+            return ToolResult.success(input + outputSuffix);
+        }
+    }
+
+    /** An AbstractAgentTool subclass for testing context propagation. */
+    static class ContextCapturingTool extends AbstractAgentTool {
+        private final String toolName;
+        boolean contextWasInjected = false;
+
+        ContextCapturingTool(String name) {
+            this.toolName = name;
+        }
+
+        @Override
+        public String name() {
+            return toolName;
+        }
+
+        @Override
+        public String description() {
+            return "Captures context";
+        }
+
+        @Override
+        protected ToolResult doExecute(String input) {
+            contextWasInjected = !(metrics() instanceof NoOpToolMetrics);
+            return ToolResult.success("context: " + contextWasInjected);
+        }
+    }
+
+    // ========================
+    // Happy path: chaining
+    // ========================
+
+    @Test
+    void execute_singleStep_returnsStepOutput() {
+        var pipeline = ToolPipeline.of("single", "Single step", prefixTool("step_a", "A:"));
+
+        ToolResult result = pipeline.execute("hello");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEqualTo("A:hello");
+    }
+
+    @Test
+    void execute_twoSteps_outputOfFirstIsInputToSecond() {
+        var stepA = new RecordingTool("step_a", "_processed");
+        var stepB = new RecordingTool("step_b", "_done");
+        var pipeline = ToolPipeline.of("two_step_pipeline", "Two steps", stepA, stepB);
+
+        ToolResult result = pipeline.execute("start");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEqualTo("start_processed_done");
+        assertThat(stepA.receivedInputs).containsExactly("start");
+        assertThat(stepB.receivedInputs).containsExactly("start_processed");
+    }
+
+    @Test
+    void execute_threeSteps_chainsAllOutputsCorrectly() {
+        var pipeline =
+                ToolPipeline.of(prefixTool("step_a", "A:"), prefixTool("step_b", "B:"), prefixTool("step_c", "C:"));
+
+        ToolResult result = pipeline.execute("x");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEqualTo("C:B:A:x");
+    }
+
+    @Test
+    void execute_emptyPipeline_returnsInputAsPassThrough() {
+        var pipeline = ToolPipeline.builder()
+                .name("empty")
+                .description("Empty pipeline")
+                .build();
+
+        ToolResult result = pipeline.execute("pass-through");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEqualTo("pass-through");
+    }
+
+    @Test
+    void execute_emptyPipelineWithNullInput_returnsEmptySuccess() {
+        var pipeline = ToolPipeline.builder()
+                .name("empty")
+                .description("Empty pipeline")
+                .build();
+
+        ToolResult result = pipeline.execute(null);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEmpty();
+    }
+
+    @Test
+    void execute_nullInput_isPassedToFirstStep() {
+        var recording = new RecordingTool("step_a", "_done");
+        var pipeline = ToolPipeline.of("p", "Pipeline", recording);
+
+        pipeline.execute(null);
+
+        assertThat(recording.receivedInputs).containsExactly("");
+    }
+
+    // ========================
+    // Error strategy: FAIL_FAST (default)
+    // ========================
+
+    @Test
+    void execute_failFast_firstStepFails_returnsFailureImmediately() {
+        var step2Called = new AtomicInteger(0);
+        var failingFirst = failingTool("fail_first", "step1 error");
+        var countingSecond = new AgentTool() {
+            @Override
+            public String name() {
+                return "step_b";
+            }
+
+            @Override
+            public String description() {
+                return "";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                step2Called.incrementAndGet();
+                return ToolResult.success("should not be reached");
+            }
+        };
+
+        var pipeline = ToolPipeline.builder()
+                .name("pipeline")
+                .description("desc")
+                .step(failingFirst)
+                .step(countingSecond)
+                .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+                .build();
+
+        ToolResult result = pipeline.execute("input");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).isEqualTo("step1 error");
+        assertThat(step2Called.get()).isEqualTo(0);
+    }
+
+    @Test
+    void execute_failFast_middleStepFails_skipsRemainingSteps() {
+        var step3Called = new AtomicInteger(0);
+        var pipeline = ToolPipeline.builder()
+                .name("pipeline")
+                .description("desc")
+                .step(prefixTool("step_a", "A:"))
+                .step(failingTool("step_b", "B failed"))
+                .step(new AgentTool() {
+                    @Override
+                    public String name() {
+                        return "step_c";
+                    }
+
+                    @Override
+                    public String description() {
+                        return "";
+                    }
+
+                    @Override
+                    public ToolResult execute(String input) {
+                        step3Called.incrementAndGet();
+                        return ToolResult.success("C done");
+                    }
+                })
+                .build(); // FAIL_FAST is default
+
+        ToolResult result = pipeline.execute("x");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).isEqualTo("B failed");
+        assertThat(step3Called.get()).isEqualTo(0);
+    }
+
+    @Test
+    void execute_failFast_lastStepFails_returnsLastFailure() {
+        var pipeline = ToolPipeline.of(prefixTool("step_a", "A:"), failingTool("step_b", "final step failed"));
+
+        ToolResult result = pipeline.execute("input");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).isEqualTo("final step failed");
+    }
+
+    @Test
+    void execute_failFast_isDefaultStrategy() {
+        var pipeline = ToolPipeline.builder().name("p").description("d").build();
+
+        assertThat(pipeline.getErrorStrategy()).isEqualTo(PipelineErrorStrategy.FAIL_FAST);
+    }
+
+    // ========================
+    // Error strategy: CONTINUE_ON_FAILURE
+    // ========================
+
+    @Test
+    void execute_continueOnFailure_failedStepErrorMessagePassedToNextStep() {
+        var recording = new RecordingTool("step_b", "_done");
+        var pipeline = ToolPipeline.builder()
+                .name("pipeline")
+                .description("desc")
+                .step(failingTool("step_a", "step_a_error"))
+                .step(recording)
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        ToolResult result = pipeline.execute("input");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOutput()).isEqualTo("step_a_error_done");
+        assertThat(recording.receivedInputs).containsExactly("step_a_error");
+    }
+
+    @Test
+    void execute_continueOnFailure_allStepsRun() {
+        var step1 = new RecordingTool("step_a", "_ok");
+        var step3 = new RecordingTool("step_c", "_end");
+        var pipeline = ToolPipeline.builder()
+                .name("pipeline")
+                .description("desc")
+                .step(step1)
+                .step(failingTool("step_b", "b_error"))
+                .step(step3)
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        pipeline.execute("start");
+
+        assertThat(step1.receivedInputs).containsExactly("start");
+        assertThat(step3.receivedInputs).containsExactly("b_error");
+    }
+
+    @Test
+    void execute_continueOnFailure_failedStepNullErrorMessage_emptyStringPassedToNext() {
+        var recording = new RecordingTool("step_b", "_done");
+        var nullErrorTool = new AgentTool() {
+            @Override
+            public String name() {
+                return "null_error_tool";
+            }
+
+            @Override
+            public String description() {
+                return "";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.failure(null);
+            }
+        };
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(nullErrorTool)
+                .step(recording)
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        pipeline.execute("x");
+
+        // ToolResult.failure(null) normalizes errorMessage to a default; never truly null
+        assertThat(recording.receivedInputs.get(0)).isNotNull();
+    }
+
+    @Test
+    void execute_continueOnFailure_finalResultIsLastStepResult() {
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(failingTool("step_a", "error"))
+                .step(failingTool("step_b", "final_error"))
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        ToolResult result = pipeline.execute("x");
+
+        // Last step's result is returned
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).isEqualTo("final_error");
+    }
+
+    // ========================
+    // Step adapters
+    // ========================
+
+    @Test
+    void execute_adapterBetweenSteps_transformsOutputBeforeNextInput() {
+        var recording = new RecordingTool("step_b", "_done");
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(fixedOutputTool("step_a", "raw_output"))
+                .adapter(result -> result.getOutput().toUpperCase())
+                .step(recording)
+                .build();
+
+        pipeline.execute("x");
+
+        assertThat(recording.receivedInputs).containsExactly("RAW_OUTPUT");
+    }
+
+    @Test
+    void execute_adapterOnLastStep_adapterNotCalledForLastStep() {
+        // Adapter is attached to last step but has no effect (no next step)
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(fixedOutputTool("step_a", "raw"))
+                .adapter(result -> "THIS_SHOULD_NOT_APPEAR")
+                .build();
+
+        ToolResult result = pipeline.execute("x");
+
+        // The adapter on the last step is never called; pipeline returns raw output
+        assertThat(result.getOutput()).isEqualTo("raw");
+    }
+
+    @Test
+    void execute_adapterOnlyOnFirstOfTwoSteps_secondStepReceivesAdaptedOutput() {
+        var recording = new RecordingTool("step_b", "_done");
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(fixedOutputTool("step_a", "original"))
+                .adapter(result -> "adapted:" + result.getOutput())
+                .step(recording)
+                .build();
+
+        pipeline.execute("ignored_by_first_step");
+
+        assertThat(recording.receivedInputs).containsExactly("adapted:original");
+    }
+
+    @Test
+    void execute_adapterWithStructuredOutput_canAccessStructuredPayload() {
+        record MyPayload(int value) {}
+        var toolWithStructured = new AgentTool() {
+            @Override
+            public String name() {
+                return "structured_tool";
+            }
+
+            @Override
+            public String description() {
+                return "";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success("42", new MyPayload(42));
+            }
+        };
+        var recording = new RecordingTool("step_b", "_received");
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(toolWithStructured)
+                .adapter(result -> {
+                    MyPayload payload = result.getStructuredOutput(MyPayload.class);
+                    return "value=" + (payload != null ? payload.value() : "null");
+                })
+                .step(recording)
+                .build();
+
+        pipeline.execute("x");
+
+        assertThat(recording.receivedInputs).containsExactly("value=42");
+    }
+
+    // ========================
+    // ToolContext propagation
+    // ========================
+
+    @Test
+    void setContext_propagatedToAbstractAgentToolSteps() {
+        var contextCapturingStep = new ContextCapturingTool("context_capturing");
+        var pipeline = ToolPipeline.of("p", "desc", contextCapturingStep);
+
+        // Inject a non-default context via ToolContextInjector
+        var metrics = new RecordingMetrics();
+        var ctx = ToolContext.of("p", metrics, Executors.newVirtualThreadPerTaskExecutor());
+        ToolContextInjector.injectContext(pipeline, ctx);
+
+        pipeline.execute("test");
+
+        assertThat(contextCapturingStep.contextWasInjected).isTrue();
+    }
+
+    @Test
+    void setContext_nonAbstractAgentToolSteps_notAffected() {
+        // Plain AgentTool steps (not AbstractAgentTool) should not cause errors during injection
+        var plainStep = prefixTool("plain", "P:");
+        var pipeline = ToolPipeline.of("p", "desc", plainStep);
+
+        var ctx = ToolContext.of("p", NoOpToolMetrics.INSTANCE, Executors.newVirtualThreadPerTaskExecutor());
+
+        // Should not throw
+        ToolContextInjector.injectContext(pipeline, ctx);
+        ToolResult result = pipeline.execute("test");
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    // ========================
+    // getSteps() and getErrorStrategy()
+    // ========================
+
+    @Test
+    void getSteps_returnsStepsInOrder() {
+        var stepA = prefixTool("step_a", "A:");
+        var stepB = prefixTool("step_b", "B:");
+        var stepC = prefixTool("step_c", "C:");
+        var pipeline = ToolPipeline.of("p", "desc", stepA, stepB, stepC);
+
+        assertThat(pipeline.getSteps()).containsExactly(stepA, stepB, stepC);
+    }
+
+    @Test
+    void getSteps_returnedListIsUnmodifiable() {
+        var pipeline = ToolPipeline.of("p", "desc", prefixTool("a", "A:"));
+
+        assertThatThrownBy(() -> pipeline.getSteps().add(prefixTool("b", "B:")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void getErrorStrategy_defaultIsFailFast() {
+        var pipeline = ToolPipeline.of("p", "desc", prefixTool("a", "A:"));
+        assertThat(pipeline.getErrorStrategy()).isEqualTo(PipelineErrorStrategy.FAIL_FAST);
+    }
+
+    @Test
+    void getErrorStrategy_reflectsBuilderSetting() {
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(prefixTool("a", "A:"))
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        assertThat(pipeline.getErrorStrategy()).isEqualTo(PipelineErrorStrategy.CONTINUE_ON_FAILURE);
+    }
+
+    // ========================
+    // Factory method: of(AgentTool first, AgentTool... rest)
+    // ========================
+
+    @Test
+    void of_autoGeneratesNameFromStepNames() {
+        var pipeline = ToolPipeline.of(prefixTool("step_a", "A:"), prefixTool("step_b", "B:"));
+
+        assertThat(pipeline.name()).isEqualTo("step_a_then_step_b");
+    }
+
+    @Test
+    void of_autoGeneratesDescriptionFromStepNames() {
+        var pipeline = ToolPipeline.of(prefixTool("step_a", "A:"), prefixTool("step_b", "B:"));
+
+        assertThat(pipeline.description()).isEqualTo("Pipeline: step_a -> step_b");
+    }
+
+    @Test
+    void of_singleStep_nameIsJustStepName() {
+        var pipeline = ToolPipeline.of(prefixTool("solo", "S:"));
+
+        assertThat(pipeline.name()).isEqualTo("solo");
+        assertThat(pipeline.description()).isEqualTo("Pipeline: solo");
+    }
+
+    @Test
+    void of_nullFirstStep_throws() {
+        assertThatThrownBy(() -> ToolPipeline.of((AgentTool) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("first step");
+    }
+
+    @Test
+    void of_nullElementInRest_throws() {
+        assertThatThrownBy(() -> ToolPipeline.of(prefixTool("a", "A:"), (AgentTool) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null elements");
+    }
+
+    // ========================
+    // Factory method: of(String name, String description, ...)
+    // ========================
+
+    @Test
+    void of_withExplicitNameAndDescription_usesProvidedValues() {
+        var pipeline = ToolPipeline.of(
+                "my_pipeline", "Does something useful", prefixTool("step_a", "A:"), prefixTool("step_b", "B:"));
+
+        assertThat(pipeline.name()).isEqualTo("my_pipeline");
+        assertThat(pipeline.description()).isEqualTo("Does something useful");
+    }
+
+    // ========================
+    // Builder validation
+    // ========================
+
+    @Test
+    void builder_blankName_throws() {
+        assertThatThrownBy(() ->
+                        ToolPipeline.builder().name(" ").description("desc").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void builder_nullName_throws() {
+        assertThatThrownBy(() -> ToolPipeline.builder().description("desc").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void builder_blankDescription_throws() {
+        assertThatThrownBy(
+                        () -> ToolPipeline.builder().name("p").description("  ").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("description");
+    }
+
+    @Test
+    void builder_nullStep_throws() {
+        assertThatThrownBy(
+                        () -> ToolPipeline.builder().name("p").description("d").step(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("step tool");
+    }
+
+    @Test
+    void builder_adapterBeforeAnyStep_throws() {
+        assertThatThrownBy(
+                        () -> ToolPipeline.builder().name("p").description("d").adapter(result -> result.getOutput()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("adapter() must be called after a step()");
+    }
+
+    @Test
+    void builder_nullAdapter_throws() {
+        assertThatThrownBy(() -> ToolPipeline.builder()
+                        .name("p")
+                        .description("d")
+                        .step(prefixTool("a", "A:"))
+                        .adapter(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("adapter");
+    }
+
+    @Test
+    void builder_nullErrorStrategy_throws() {
+        assertThatThrownBy(
+                        () -> ToolPipeline.builder().name("p").description("d").errorStrategy(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("errorStrategy");
+    }
+
+    // ========================
+    // AgentTool interface contract
+    // ========================
+
+    @Test
+    void name_returnsConfiguredName() {
+        var pipeline =
+                ToolPipeline.builder().name("my_pipeline").description("desc").build();
+
+        assertThat(pipeline.name()).isEqualTo("my_pipeline");
+    }
+
+    @Test
+    void description_returnsConfiguredDescription() {
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("does useful things")
+                .build();
+
+        assertThat(pipeline.description()).isEqualTo("does useful things");
+    }
+
+    @Test
+    void pipeline_implementsAgentTool() {
+        var pipeline = ToolPipeline.of("p", "d", prefixTool("a", "A:"));
+        assertThat(pipeline).isInstanceOf(AgentTool.class);
+    }
+
+    @Test
+    void pipeline_extendsAbstractAgentTool() {
+        var pipeline = ToolPipeline.of("p", "d", prefixTool("a", "A:"));
+        assertThat(pipeline).isInstanceOf(AbstractAgentTool.class);
+    }
+
+    // ========================
+    // Opportunistic: adapter not called when previous step fails (CONTINUE_ON_FAILURE)
+    // ========================
+
+    @Test
+    void adapter_notCalledWhenPrecedingStepFailedAndStrategyIsContinue() {
+        var adapterCalled = new AtomicInteger(0);
+        var recording = new RecordingTool("step_b", "_done");
+        var pipeline = ToolPipeline.builder()
+                .name("p")
+                .description("d")
+                .step(failingTool("step_a", "error_from_a"))
+                .adapter(result -> {
+                    adapterCalled.incrementAndGet();
+                    return "ADAPTED";
+                })
+                .step(recording)
+                .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+                .build();
+
+        pipeline.execute("x");
+
+        // Adapter must not be called when its step failed
+        assertThat(adapterCalled.get()).isEqualTo(0);
+        // Error message is forwarded directly
+        assertThat(recording.receivedInputs).containsExactly("error_from_a");
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    static class RecordingMetrics implements ToolMetrics {
+        @Override
+        public void incrementSuccess(String toolName, String agentRole) {}
+
+        @Override
+        public void incrementFailure(String toolName, String agentRole) {}
+
+        @Override
+        public void incrementError(String toolName, String agentRole) {}
+
+        @Override
+        public void recordDuration(String toolName, String agentRole, Duration duration) {}
+
+        @Override
+        public void incrementCounter(String metricName, String toolName, Map<String, String> tags) {}
+
+        @Override
+        public void recordValue(String metricName, String toolName, double value, Map<String, String> tags) {}
+    }
+}

--- a/agentensemble-examples/build.gradle.kts
+++ b/agentensemble-examples/build.gradle.kts
@@ -52,6 +52,7 @@ application {
 //   ./gradlew :agentensemble-examples:runCaptureMode
 //   ./gradlew :agentensemble-examples:runHumanInTheLoop --args="AgentEnsemble v2"
 //   ./gradlew :agentensemble-examples:runCrossRunMemory --args="renewable energy"
+//   ./gradlew :agentensemble-examples:runToolPipeline
 
 mapOf(
     "runResearchWriter"  to "net.agentensemble.examples.ResearchWriterExample",
@@ -69,6 +70,7 @@ mapOf(
     "runCaptureMode" to "net.agentensemble.examples.CaptureModeExample",
     "runHumanInTheLoop" to "net.agentensemble.examples.HumanInTheLoopExample",
     "runCrossRunMemory" to "net.agentensemble.examples.CrossRunMemoryExample",
+    "runToolPipeline" to "net.agentensemble.examples.ToolPipelineExample",
 ).forEach { (taskName, mainClassName) ->
     tasks.register<JavaExec>(taskName) {
         group = "examples"

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/ToolPipelineExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/ToolPipelineExample.java
@@ -1,0 +1,166 @@
+package net.agentensemble.examples;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.List;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.tool.PipelineErrorStrategy;
+import net.agentensemble.tool.ToolPipeline;
+import net.agentensemble.tools.calculator.CalculatorTool;
+import net.agentensemble.tools.json.JsonParserTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demonstrates ToolPipeline: chaining multiple tools into a single compound tool that
+ * the LLM calls once, with all steps executing without LLM round-trips between them.
+ *
+ * This example builds two pipelines:
+ *
+ * Pipeline 1 -- "extract_and_calculate":
+ *   Step 1: JsonParserTool  -- extracts a numeric value from a JSON payload
+ *   Step 2: CalculatorTool  -- applies a 10% markup formula to the extracted number
+ *   Adapter: reshapes the extracted number into a formula string for CalculatorTool
+ *
+ * Pipeline 2 -- "json_multi_extract":
+ *   Step 1: JsonParserTool  -- extracts the first field
+ *   Step 2: JsonParserTool  -- extracts a nested field from the result of step 1
+ *   Demonstrates chaining the same tool type multiple times
+ *
+ * The LLM calls each pipeline exactly once. Both steps inside each pipeline run
+ * without any LLM inference between them -- reducing token cost and latency compared
+ * to asking the LLM to call two separate tools sequentially via the ReAct loop.
+ *
+ * Usage:
+ *   Set OPENAI_API_KEY environment variable, then run:
+ *   ./gradlew :agentensemble-examples:runToolPipeline
+ */
+public class ToolPipelineExample {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolPipelineExample.class);
+
+    // Sample data used as the tool call input from the LLM
+    static final String PRODUCT_JSON =
+            "{\"product\": {\"name\": \"Widget Pro\", \"base_price\": 149.99, \"category\": \"hardware\"}}";
+
+    public static void main(String[] args) throws Exception {
+        log.info("Starting ToolPipeline example");
+
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException(
+                    "OPENAI_API_KEY environment variable is not set. " + "Please set it to your OpenAI API key.");
+        }
+
+        var model = OpenAiChatModel.builder()
+                .apiKey(apiKey)
+                .modelName("gpt-4o-mini")
+                .build();
+
+        // ========================
+        // Pipeline 1: JSON extraction -> arithmetic
+        //
+        // The LLM calls this pipeline with a JSON payload.
+        // Step 1 (JsonParserTool) extracts the base_price field.
+        // The adapter reshapes "149.99" into "149.99 * 1.1" for the calculator.
+        // Step 2 (CalculatorTool) evaluates "149.99 * 1.1" -> "164.989".
+        //
+        // The LLM receives one tool result: "164.989"
+        // No LLM inference occurs between the two steps.
+        // ========================
+        ToolPipeline extractAndCalculate = ToolPipeline.builder()
+                .name("extract_and_calculate")
+                .description("Given a JSON payload with a 'product.base_price' field, extracts the price "
+                        + "and returns the price with a 10% markup applied. "
+                        + "Input: a JSON string containing a product object.")
+                .step(new JsonParserTool())
+                .adapter(result -> result.getOutput() + " * 1.1")
+                .step(new CalculatorTool())
+                .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+                .build();
+
+        // ========================
+        // Pipeline 2: chained JSON extraction
+        //
+        // Step 1: extracts the whole "product" object from the outer JSON.
+        // Step 2: extracts the "name" field from the product object.
+        // Demonstrates chaining the same tool type and how string piping works.
+        // ========================
+        ToolPipeline chainedExtract = ToolPipeline.builder()
+                .name("extract_product_name")
+                .description("Given a JSON payload with a nested 'product' object, extracts the product name. "
+                        + "Input: a JSON string containing a product object.")
+                .step(new JsonParserTool())
+                .adapter(result -> "name\n" + result.getOutput())
+                .step(new JsonParserTool())
+                .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+                .build();
+
+        System.out.println("\n" + "=".repeat(60));
+        System.out.println("PIPELINE DEMO");
+        System.out.println("=".repeat(60));
+        System.out.println("Input JSON: " + PRODUCT_JSON);
+        System.out.println();
+
+        // ========================
+        // Task using the extract_and_calculate pipeline
+        // ========================
+        var priceTask = Task.builder()
+                .description("Use the extract_and_calculate tool to compute the retail price (base price + 10% "
+                        + "markup) from the following product JSON:\n\n"
+                        + "product.base_price\n"
+                        + PRODUCT_JSON
+                        + "\n\nReport the retail price.")
+                .expectedOutput("The retail price for Widget Pro with a 10% markup applied.")
+                .tools(List.of(extractAndCalculate))
+                .build();
+
+        EnsembleOutput priceOutput = Ensemble.builder()
+                .chatLanguageModel(model)
+                .task(priceTask)
+                .build()
+                .run();
+
+        System.out.println("--- extract_and_calculate pipeline result ---");
+        System.out.println(priceOutput.getRaw());
+        System.out.printf(
+                "Tool calls: %d | Duration: %s%n%n", priceOutput.getTotalToolCalls(), priceOutput.getTotalDuration());
+
+        // ========================
+        // Task using the chained extract pipeline
+        // ========================
+        var nameTask = Task.builder()
+                .description("Use the extract_product_name tool to extract the product name from this JSON:\n\n"
+                        + "product\n"
+                        + PRODUCT_JSON
+                        + "\n\nReport the product name.")
+                .expectedOutput("The name of the product extracted from the JSON.")
+                .tools(List.of(chainedExtract))
+                .build();
+
+        EnsembleOutput nameOutput = Ensemble.builder()
+                .chatLanguageModel(model)
+                .task(nameTask)
+                .build()
+                .run();
+
+        System.out.println("--- extract_product_name pipeline result ---");
+        System.out.println(nameOutput.getRaw());
+        System.out.printf(
+                "Tool calls: %d | Duration: %s%n%n", nameOutput.getTotalToolCalls(), nameOutput.getTotalDuration());
+
+        // ========================
+        // Show pipeline structure
+        // ========================
+        System.out.println("--- Pipeline structure ---");
+        System.out.println("Pipeline: " + extractAndCalculate.name());
+        System.out.println("  Error strategy: " + extractAndCalculate.getErrorStrategy());
+        System.out.println("  Steps (" + extractAndCalculate.getSteps().size() + "):");
+        for (int i = 0; i < extractAndCalculate.getSteps().size(); i++) {
+            System.out.printf(
+                    "    [%d] %s%n",
+                    i + 1, extractAndCalculate.getSteps().get(i).name());
+        }
+    }
+}

--- a/docs/design/06-tool-system.md
+++ b/docs/design/06-tool-system.md
@@ -340,6 +340,47 @@ doExecute(String input):
 
 ---
 
+## Tool Pipeline
+
+`ToolPipeline` chains multiple `AgentTool` instances together into a single compound tool that
+the LLM calls once. All steps execute sequentially inside a single `execute(String)` call with
+no LLM round-trips between them. Full specification: [Design: Tool Pipeline](17-tool-pipeline.md).
+
+### Class Structure
+
+```
+AbstractAgentTool
+  ToolPipeline              -- chains List<PipelineStep> sequentially
+  
+PipelineErrorStrategy       -- FAIL_FAST | CONTINUE_ON_FAILURE
+```
+
+### Registration
+
+`ToolPipeline implements AgentTool`. No changes to `ToolResolver`, `LangChain4jToolAdapter`,
+or agent/task registration are needed. It is registered and adapted exactly like any other tool.
+
+### Context Propagation
+
+`ToolPipeline` overrides the package-private `setContext(ToolContext)` to propagate the injected
+context to all nested steps that are `AbstractAgentTool` instances. Plain `AgentTool` steps
+receive no injection.
+
+### Error Strategies
+
+| Strategy | On step failure |
+|---|---|
+| `FAIL_FAST` (default) | Return the failed step's `ToolResult` immediately; skip remaining steps |
+| `CONTINUE_ON_FAILURE` | Forward the error message as the next step's input; run to completion |
+
+### Step Adapters
+
+An optional `Function<ToolResult, String>` adapter can be attached to any step via
+`Builder.adapter()`. The adapter transforms that step's output before it is passed to the next
+step. Adapters are only called when the step **succeeds** and only when there is a next step.
+
+---
+
 ## Logging
 
 | Level | What |

--- a/docs/design/17-tool-pipeline.md
+++ b/docs/design/17-tool-pipeline.md
@@ -1,0 +1,192 @@
+# 17 - Tool Pipeline
+
+This document specifies the `ToolPipeline` mechanism: a Unix-pipe-style composition of multiple
+`AgentTool` instances into a single compound tool that the LLM calls once.
+
+## Motivation
+
+Tool chaining in the ReAct loop is **LLM-mediated**: each step in a `search -> filter -> format`
+chain requires a full LLM inference round-trip. For deterministic, data-transformation pipelines
+the LLM adds no reasoning value but does add latency and token cost.
+
+`ToolPipeline` eliminates those intermediate round-trips by executing all steps inside a single
+`AgentTool.execute(String)` call. The LLM sees one atomic tool and calls it once; all steps run
+without further LLM involvement.
+
+## Classes
+
+```
+AgentTool (interface)
+  AbstractAgentTool (abstract)
+    ToolPipeline (final)           -- the pipeline
+
+PipelineErrorStrategy (enum)      -- FAIL_FAST | CONTINUE_ON_FAILURE
+```
+
+`ToolPipeline` lives in `net.agentensemble.tool` alongside the rest of the tool package.
+Being in the same package lets it override the package-private `setContext()` on
+`AbstractAgentTool` to propagate context injection to nested steps.
+
+## Data Handoff
+
+The uniform `String -> ToolResult` contract on `AgentTool` is the natural pipe interface:
+
+```
+step 1 execute(input)  -> ToolResult
+        |
+        | getOutput() (or adapter function)
+        v
+step 2 execute(adaptedInput) -> ToolResult
+        |
+        | getOutput() (or adapter function)
+        v
+       ...
+        |
+        v
+step N execute(...) -> ToolResult  <- returned to LLM
+```
+
+By default `ToolResult.getOutput()` is forwarded verbatim. When the output needs to be reshaped
+before the next step (for example, to inject a path expression prefix for `JsonParserTool`), an
+**output adapter** (`Function<ToolResult, String>`) can be attached to any step via the builder.
+
+Adapters have access to the full `ToolResult`, including `getStructuredOutput()`, so typed
+payloads can be unpacked and formatted.
+
+### Adapter Invocation Rules
+
+- The adapter attached to step N is called only when step N **succeeds** (`isSuccess() == true`).
+- When step N fails and the strategy is `CONTINUE_ON_FAILURE`, the error message is forwarded
+  directly and the adapter is **not** called.
+- The adapter on the **last** step is never called (no next step to receive its output).
+
+## Error Strategy
+
+| Strategy | Behaviour on step failure |
+|---|---|
+| `FAIL_FAST` (default) | Stop immediately; return the failed `ToolResult` to the LLM. Subsequent steps are skipped. |
+| `CONTINUE_ON_FAILURE` | Forward `ToolResult.getErrorMessage()` (or empty string) as the next step's input. Continue to the final step. Return the last step's result. |
+
+`FAIL_FAST` is consistent with how individual tools behave: a single failed tool returns an
+error to the LLM without running further tools.
+
+`CONTINUE_ON_FAILURE` is for resilient pipelines where downstream steps can handle or recover
+from upstream errors.
+
+## ToolContext Propagation
+
+When the framework injects a `ToolContext` into the pipeline via `ToolContextInjector`, the
+pipeline's overridden `setContext()` iterates all steps and calls `setContext()` on any step
+that is an `AbstractAgentTool`. This ensures:
+
+- Each step gets the same `ToolMetrics`, `Executor`, and `Logger` as the pipeline.
+- Approval-gate steps receive the ensemble's `ReviewHandler`.
+
+Plain `AgentTool` steps (not `AbstractAgentTool`) are unaffected: they receive no context injection
+and rely on their own internal state.
+
+## Metrics
+
+| Level | What is recorded |
+|---|---|
+| Pipeline | Aggregate: single success/failure/error count + total duration for the whole pipeline (via `AbstractAgentTool.execute()`) |
+| Each AbstractAgentTool step | Per-step: individual success/failure/error counts + duration (via their own `AbstractAgentTool.execute()`) |
+
+## LLM Integration
+
+`ToolPipeline extends AbstractAgentTool implements AgentTool`. The existing
+`LangChain4jToolAdapter` adapts any `AgentTool` into a `ToolSpecification` with a single
+`"input"` string parameter. No special handling is required in `ToolResolver` or
+`LangChain4jToolAdapter`. The pipeline is registered exactly like any other tool.
+
+## Execution Flow
+
+```
+LLM tool call: pipeline("initial input")
+  |
+  v
+AbstractAgentTool.execute("initial input")
+  [timing start]
+  |
+  v
+ToolPipeline.doExecute("initial input")
+  |
+  +---> step1.execute("initial input")       -> ToolResult{output="A"}
+  |        [metrics recorded for step1]
+  |
+  +---> adapter1(ToolResult{output="A"})     -> "adapted_A"
+  |        [only if step1 succeeded]
+  |
+  +---> step2.execute("adapted_A")           -> ToolResult{output="B"}
+  |        [metrics recorded for step2]
+  |
+  +---> step3.execute("B")                   -> ToolResult{output="final"}
+  |        [metrics recorded for step3]
+  |        [last step: adapter not called]
+  |
+  v
+  returns ToolResult{output="final"}
+  [timing stop]
+  [pipeline aggregate metrics recorded]
+  |
+  v
+LLM receives: "final" as tool result
+```
+
+## Builder API
+
+```java
+// Minimal factory -- auto-generates name and description
+ToolPipeline pipeline = ToolPipeline.of(
+    new JsonParserTool(),
+    new CalculatorTool()
+);
+// name: "json_parser_then_calculator"
+// description: "Pipeline: json_parser -> calculator"
+
+// Named factory
+ToolPipeline pipeline = ToolPipeline.of(
+    "extract_and_calculate",
+    "Extracts a numeric field and applies a formula",
+    new JsonParserTool(),
+    new CalculatorTool()
+);
+
+// Full builder
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("search_and_save")
+    .description("Search for information and save the result to disk")
+    .step(new WebSearchTool(provider))
+    .adapter(result -> "results[0]\n" + result.getOutput())
+    .step(new JsonParserTool())
+    .step(FileWriteTool.of(outputPath))
+    .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+    .build();
+```
+
+## Design Decisions
+
+### Why `AbstractAgentTool` (not just `AgentTool`)
+
+Extending `AbstractAgentTool` gives the pipeline automatic metrics, exception safety, structured
+logging, and approval-gate capability for free. The pipeline itself is instrumented without any
+extra code. The `execute()` method is `final` in `AbstractAgentTool`, so framework instrumentation
+cannot be bypassed.
+
+### Why package-private `setContext()` override
+
+The `setContext()` method is intentionally package-private in `AbstractAgentTool` to prevent
+user code from calling it. Placing `ToolPipeline` in `net.agentensemble.tool` gives it access to
+this method to propagate context to nested steps, without exposing the method to application code.
+
+### Why not a recursive/tree pipeline
+
+Issue #74 explicitly identified fan-out/fan-in as a future extension. The linear model covers
+the common case (`search -> filter -> write`) cleanly. Parallel branches can be addressed in a
+follow-up by composing pipelines with the existing parallel execution infrastructure.
+
+### Why string-based handoff (not typed)
+
+The `AgentTool` interface uses `String` input universally. A typed contract would require
+changing the interface and adding generics. String-based handoff is consistent with the existing
+tool model. Adapters provide the escape hatch for typed reshaping when needed.

--- a/docs/examples/tool-pipeline.md
+++ b/docs/examples/tool-pipeline.md
@@ -1,0 +1,151 @@
+# Tool Pipeline Example
+
+Source: [`ToolPipelineExample.java`](https://github.com/AgentEnsemble/agentensemble/blob/main/agentensemble-examples/src/main/java/net/agentensemble/examples/ToolPipelineExample.java)
+
+This example demonstrates `ToolPipeline`: chaining multiple tools into a single compound tool
+that the LLM calls once. All steps execute sequentially inside a single tool call, with no LLM
+round-trips between steps.
+
+---
+
+## Run It
+
+```bash
+export OPENAI_API_KEY=your-api-key
+./gradlew :agentensemble-examples:runToolPipeline
+```
+
+---
+
+## What It Demonstrates
+
+Two pipelines are built and each is registered as the only tool on a separate task:
+
+### Pipeline 1 -- `extract_and_calculate`
+
+| Step | Tool | What it does |
+|------|------|--------------|
+| 1 | `JsonParserTool` | Extracts `product.base_price` from a JSON payload (`149.99`) |
+| (adapter) | Lambda | Reshapes `"149.99"` into `"149.99 * 1.1"` |
+| 2 | `CalculatorTool` | Evaluates `"149.99 * 1.1"` and returns the retail price |
+
+The LLM calls `extract_and_calculate` once with the JSON string. It receives the final numeric
+result. No LLM inference occurs between steps 1 and 2.
+
+### Pipeline 2 -- `extract_product_name`
+
+| Step | Tool | What it does |
+|------|------|--------------|
+| 1 | `JsonParserTool` | Extracts the whole `product` object |
+| (adapter) | Lambda | Prepends `"name\n"` to produce the path expression for step 2 |
+| 2 | `JsonParserTool` | Extracts the `name` field from the product object |
+
+This pipeline shows that the same tool type can be chained multiple times, and that adapters
+reshape the output at each stage.
+
+---
+
+## Code Walk-through
+
+### Build the pipeline
+
+```java
+ToolPipeline extractAndCalculate = ToolPipeline.builder()
+    .name("extract_and_calculate")
+    .description("Given a JSON payload with a 'product.base_price' field, extracts the price "
+        + "and returns the price with a 10% markup applied. "
+        + "Input: a JSON string containing a product object.")
+    .step(new JsonParserTool())
+    .adapter(result -> result.getOutput() + " * 1.1")  // (1)
+    .step(new CalculatorTool())
+    .errorStrategy(PipelineErrorStrategy.FAIL_FAST)    // (2)
+    .build();
+```
+
+1. The adapter runs after `JsonParserTool` succeeds. It takes the extracted price string
+   (e.g., `"149.99"`) and appends the markup formula, producing `"149.99 * 1.1"` for
+   `CalculatorTool`.
+2. `FAIL_FAST` (the default) stops the pipeline and returns an error to the LLM if any step
+   fails. The LLM can adapt based on the error message.
+
+### Register on a task
+
+```java
+var priceTask = Task.builder()
+    .description("Use the extract_and_calculate tool to compute the retail price...")
+    .expectedOutput("The retail price for Widget Pro with a 10% markup applied.")
+    .tools(List.of(extractAndCalculate))  // (1)
+    .build();
+```
+
+1. In v2, tools are registered on the task rather than on an explicit agent. The framework
+   synthesizes an agent from the task description and attaches the pipeline to it.
+
+### Run the ensemble
+
+```java
+EnsembleOutput output = Ensemble.builder()
+    .chatLanguageModel(model)
+    .task(priceTask)
+    .build()
+    .run();
+```
+
+The LLM calls `extract_and_calculate` once with the JSON string. Both steps (`JsonParserTool`
+and `CalculatorTool`) execute inside that single call. The LLM receives one tool result and
+produces its final answer.
+
+---
+
+## Sample Output
+
+```
+============================================================
+PIPELINE DEMO
+============================================================
+Input JSON: {"product": {"name": "Widget Pro", "base_price": 149.99, "category": "hardware"}}
+
+--- extract_and_calculate pipeline result ---
+The retail price for Widget Pro with a 10% markup applied is $164.99.
+Tool calls: 1 | Duration: PT2.341S
+
+--- extract_product_name pipeline result ---
+The product name is Widget Pro.
+Tool calls: 1 | Duration: PT1.876S
+
+--- Pipeline structure ---
+Pipeline: extract_and_calculate
+  Error strategy: FAIL_FAST
+  Steps (2):
+    [1] json_parser
+    [2] calculator
+```
+
+Each task made exactly **1 tool call** despite involving 2 underlying tool executions. Without a
+pipeline, the LLM would have needed 2 separate tool calls (and 2 LLM inference round-trips).
+
+---
+
+## Key Concepts
+
+### No LLM round-trips between steps
+
+The LLM calls the pipeline once. All internal steps run as ordinary Java method calls within
+that single tool invocation. This is the core benefit: deterministic pipelines no longer pay
+the per-step LLM inference cost.
+
+### Adapters bridge format mismatches
+
+The adapter lambda `result -> result.getOutput() + " * 1.1"` bridges the mismatch between
+`JsonParserTool`'s output format and `CalculatorTool`'s input format. Adapters can contain any
+logic and can read `ToolResult.getStructuredOutput()` for typed payloads.
+
+### The pipeline is a single tool
+
+From the LLM's perspective, `extract_and_calculate` is a regular tool with a name, description,
+and a single `String` input. The LLM does not know or need to know that two tools are running
+inside it.
+
+---
+
+**Full documentation:** [Tool Pipeline Guide](../guides/tool-pipeline.md) | [Design: Tool Pipeline](../design/17-tool-pipeline.md)

--- a/docs/guides/built-in-tools.md
+++ b/docs/guides/built-in-tools.md
@@ -360,3 +360,44 @@ var agent = Agent.builder()
     .maxIterations(15)
     .build();
 ```
+
+---
+
+## Pipelining Built-in Tools
+
+Use `ToolPipeline` to chain built-in tools together so they execute sequentially inside a
+single LLM tool call, with no LLM round-trips between steps.
+
+```java
+import net.agentensemble.tool.ToolPipeline;
+import net.agentensemble.tool.PipelineErrorStrategy;
+
+// Chain JsonParserTool and CalculatorTool: extract a number, then apply a formula
+ToolPipeline extractAndCalculate = ToolPipeline.builder()
+    .name("extract_and_calculate")
+    .description("Extracts a numeric field from JSON and applies a 10% markup formula. "
+        + "Input: path on first line, JSON on remaining lines.")
+    .step(new JsonParserTool())
+    .adapter(result -> result.getOutput() + " * 1.1")  // reshape for CalculatorTool
+    .step(new CalculatorTool())
+    .build();
+
+// Chain search, extract, and save -- three steps, one LLM tool call
+ToolPipeline searchAndSave = ToolPipeline.builder()
+    .name("search_and_save")
+    .description("Searches the web, extracts the first result title, and saves it.")
+    .step(WebSearchTool.ofTavily(apiKey))
+    .adapter(result -> "results[0].title\n" + result.getOutput())
+    .step(new JsonParserTool())
+    .step(FileWriteTool.of(Path.of("/workspace/output")))
+    .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
+    .build();
+
+// Register on a task -- the pipeline appears as a single tool to the LLM
+var task = Task.builder()
+    .description("Research AI trends and save the top result")
+    .tools(List.of(searchAndSave))
+    .build();
+```
+
+**Full documentation:** [Tool Pipeline Guide](tool-pipeline.md)

--- a/docs/guides/tool-pipeline.md
+++ b/docs/guides/tool-pipeline.md
@@ -1,0 +1,316 @@
+# Tool Pipeline
+
+`ToolPipeline` chains multiple tools together into a single compound tool that the LLM calls
+once. All steps execute sequentially **without LLM round-trips between them**, eliminating the
+token cost and latency of letting the LLM mediate each step in the ReAct loop.
+
+---
+
+## The Problem It Solves
+
+In a standard ReAct loop, tool chaining looks like this:
+
+```
+LLM -> calls search_tool     -> receives results
+LLM -> calls filter_tool     -> receives filtered output   (1 extra LLM round-trip)
+LLM -> calls format_tool     -> receives formatted output  (1 extra LLM round-trip)
+LLM -> produces final answer
+```
+
+Every step requires full LLM inference. For deterministic data transformations the LLM adds no
+reasoning value but does add latency and tokens.
+
+With `ToolPipeline`:
+
+```
+LLM -> calls search_then_filter_then_format  -> receives final output  (0 extra round-trips)
+LLM -> produces final answer
+```
+
+---
+
+## Quick Start
+
+=== "Simple (auto-generated name)"
+
+    ```java
+    import net.agentensemble.tool.ToolPipeline;
+    import net.agentensemble.tools.web.search.WebSearchTool;
+    import net.agentensemble.tools.json.JsonParserTool;
+    import net.agentensemble.tools.io.FileWriteTool;
+
+    ToolPipeline pipeline = ToolPipeline.of(
+        new WebSearchTool(provider),
+        new JsonParserTool(),
+        FileWriteTool.of(outputPath)
+    );
+    // name: "web_search_then_json_parser_then_file_write"
+    ```
+
+=== "Named (explicit name and description)"
+
+    ```java
+    ToolPipeline pipeline = ToolPipeline.of(
+        "search_and_save",
+        "Search for information, extract the top result, and save it to disk",
+        new WebSearchTool(provider),
+        new JsonParserTool(),
+        FileWriteTool.of(outputPath)
+    );
+    ```
+
+Register it on a task just like any other tool:
+
+```java
+var task = Task.builder()
+    .description("Research AI trends and save the top result to disk")
+    .expectedOutput("Confirmation that the result was saved")
+    .tools(List.of(pipeline))
+    .build();
+
+EnsembleOutput output = Ensemble.builder()
+    .chatLanguageModel(model)
+    .task(task)
+    .build()
+    .run();
+```
+
+---
+
+## How Data Flows Between Steps
+
+By default, `ToolResult.getOutput()` (a plain `String`) from step N is passed as the `input`
+to step N+1.
+
+```
+initial input  ---> [step 1]  --output--> [step 2]  --output--> [step 3]  --output--> LLM
+```
+
+When you need to reshape or reformat the output before it reaches the next step, attach an
+**adapter** using the builder:
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("extract_and_calculate")
+    .description("Extract a numeric field from JSON and apply a formula to it")
+    .step(new JsonParserTool())
+    .adapter(result -> result.getOutput() + " * 1.1")   // (1)
+    .step(new CalculatorTool())
+    .build();
+```
+
+1. The adapter transforms the `JsonParserTool` output (e.g., `"149.99"`) into a calculator
+   expression (`"149.99 * 1.1"`) before passing it to `CalculatorTool`.
+
+Adapters have full access to the `ToolResult`, including `getStructuredOutput()` for typed
+payloads:
+
+```java
+.adapter(result -> {
+    MyRecord payload = result.getStructuredOutput(MyRecord.class);
+    return payload != null ? String.valueOf(payload.value()) : result.getOutput();
+})
+```
+
+---
+
+## Error Strategies
+
+### `FAIL_FAST` (default)
+
+Stop the pipeline on the first failed step and return that failure to the LLM immediately.
+Subsequent steps are never executed.
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("my_pipeline")
+    .description("desc")
+    .step(stepA)
+    .step(stepB)   // if stepA fails, stepB is never called
+    .step(stepC)
+    .errorStrategy(PipelineErrorStrategy.FAIL_FAST)  // default, may be omitted
+    .build();
+```
+
+### `CONTINUE_ON_FAILURE`
+
+Continue executing subsequent steps even when an intermediate step fails. The failed step's
+error message is forwarded as input to the next step. The final result of the pipeline is the
+result of the last step.
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("resilient_pipeline")
+    .description("Continues even when a step fails")
+    .step(stepA)
+    .step(stepB)   // stepB receives stepA's error message if stepA fails
+    .step(stepC)
+    .errorStrategy(PipelineErrorStrategy.CONTINUE_ON_FAILURE)
+    .build();
+```
+
+Use `CONTINUE_ON_FAILURE` when downstream steps can handle or recover from upstream failures,
+or when you always want to produce an output regardless of partial failures.
+
+---
+
+## Full Builder Reference
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("my_pipeline")                              // required: tool name shown to LLM
+    .description("What this pipeline does")           // required: tool description shown to LLM
+    .step(new WebSearchTool(provider))                // step 1
+    .adapter(result -> "title\n" + result.getOutput()) // adapter: reshape step 1 output
+    .step(new JsonParserTool())                       // step 2
+    .step(FileWriteTool.of(outputPath))               // step 3 (no adapter -- raw output passed)
+    .errorStrategy(PipelineErrorStrategy.FAIL_FAST)   // default
+    .build();
+```
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `name(String)` | Yes | Tool name exposed to the LLM. Must be unique within the task's tool list. |
+| `description(String)` | Yes | Tool description shown to the LLM to help it select this tool. |
+| `step(AgentTool)` | At least one | Add a step. Steps execute in registration order. |
+| `adapter(Function<ToolResult, String>)` | No | Transform the output of the preceding step before passing it to the next step. Called only on success. |
+| `errorStrategy(PipelineErrorStrategy)` | No | `FAIL_FAST` (default) or `CONTINUE_ON_FAILURE`. |
+
+---
+
+## Factory Methods
+
+For simple cases without adapters or custom error strategies:
+
+```java
+// Auto-generated name from step names joined with "_then_"
+ToolPipeline pipeline = ToolPipeline.of(stepA, stepB, stepC);
+// name: "step_a_then_step_b_then_step_c"
+// description: "Pipeline: step_a -> step_b -> step_c"
+
+// Explicit name and description
+ToolPipeline pipeline = ToolPipeline.of(
+    "search_and_parse",
+    "Search for information and extract the top result title",
+    new WebSearchTool(provider),
+    new JsonParserTool()
+);
+```
+
+---
+
+## Inspecting a Pipeline
+
+```java
+// Get the ordered list of steps
+List<AgentTool> steps = pipeline.getSteps();
+System.out.println("Pipeline has " + steps.size() + " steps:");
+for (int i = 0; i < steps.size(); i++) {
+    System.out.printf("  [%d] %s%n", i + 1, steps.get(i).name());
+}
+
+// Get the configured error strategy
+PipelineErrorStrategy strategy = pipeline.getErrorStrategy();
+System.out.println("Error strategy: " + strategy);  // FAIL_FAST or CONTINUE_ON_FAILURE
+```
+
+---
+
+## Metrics
+
+Each step that extends `AbstractAgentTool` records its own metrics (timing, success/failure
+counts) as it normally would. The pipeline itself also records an **aggregate** timing and
+success/failure count for the whole chain via the inherited `AbstractAgentTool` instrumentation.
+
+When Micrometer metrics are configured on the ensemble, you will see per-step and per-pipeline
+metrics in your metrics backend.
+
+---
+
+## Approval Gates Within Pipelines
+
+Steps inside a pipeline that extend `AbstractAgentTool` and call `requestApproval()` will pause
+for human review mid-pipeline, exactly as if they were standalone tools. The pipeline propagates
+the ensemble's `ReviewHandler` to all nested steps automatically.
+
+```java
+ToolPipeline pipeline = ToolPipeline.of(
+    new JsonParserTool(),
+    FileWriteTool.builder(outputPath)     // requires approval before writing
+        .requireApproval(true)
+        .build()
+);
+
+Ensemble.builder()
+    .task(task)
+    .reviewHandler(ReviewHandler.console())   // reviewer sees the write request mid-pipeline
+    .build()
+    .run();
+```
+
+---
+
+## Common Patterns
+
+### JSON extraction and arithmetic
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("extract_and_calculate")
+    .description("Extract a numeric field from JSON and apply a formula to it. "
+        + "Input format: path on first line, JSON on remaining lines.")
+    .step(new JsonParserTool())
+    .adapter(result -> result.getOutput() + " * 1.1")
+    .step(new CalculatorTool())
+    .build();
+```
+
+### Web search, extract, and save
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("research_and_save")
+    .description("Search the web for a query, extract the first result title, "
+        + "and write it to a file. Input: a search query.")
+    .step(new WebSearchTool(provider))
+    .adapter(result -> "results[0].title\n" + result.getOutput())
+    .step(new JsonParserTool())
+    .step(FileWriteTool.of(outputPath))
+    .build();
+```
+
+### Chaining the same tool type
+
+```java
+ToolPipeline pipeline = ToolPipeline.builder()
+    .name("deep_extract")
+    .description("Extracts a deeply nested field from JSON in two steps. "
+        + "Input: 'outer_field' on first line, outer JSON on remaining lines.")
+    .step(new JsonParserTool())                          // extracts outer object
+    .adapter(result -> "nested_field\n" + result.getOutput())
+    .step(new JsonParserTool())                          // extracts nested field
+    .build();
+```
+
+---
+
+## Nesting Pipelines
+
+A `ToolPipeline` implements `AgentTool`, so it can be used as a step inside another pipeline:
+
+```java
+ToolPipeline innerPipeline = ToolPipeline.of("step_a", "desc", toolA, toolB);
+ToolPipeline outerPipeline = ToolPipeline.of("outer", "desc", innerPipeline, toolC);
+```
+
+---
+
+## When to Use ToolPipeline vs. Separate Tools
+
+| Use `ToolPipeline` when... | Use separate tools when... |
+|----------------------------|---------------------------|
+| Steps are deterministic and order-locked -- the LLM should not skip or reorder them | The LLM needs to reason between steps (e.g., decide which tool to call next based on intermediate results) |
+| You want to reduce token costs for data transformation chains | The pipeline structure should be flexible and LLM-directed |
+| The full chain should appear as one operation to the LLM | Intermediate results are useful for the LLM to see and reason about |
+
+**Full documentation:** [Design: Tool Pipeline](../design/17-tool-pipeline.md) | [Built-in Tools](built-in-tools.md)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,10 +2,46 @@
 
 ## Current Work Focus
 
-Issue #130 (v2.1.0 agentensemble-web module -- WebSocket server + protocol) is complete
-on branch `feat/130-agentensemble-web`. PR #138 is open against main.
+Issue #74 (Tool Pipeline / Chaining) is implemented on branch `feature/tool-pipeline-74`.
 
 ## Recent Changes
+
+### Issue #74: Explicit Tool Pipeline / Chaining (Unix-pipe-style composition)
+
+**New classes in `agentensemble-core` (`net.agentensemble.tool`):**
+- `PipelineErrorStrategy` enum -- `FAIL_FAST` (default) and `CONTINUE_ON_FAILURE`
+- `ToolPipeline` -- `AbstractAgentTool` subclass; builder pattern; `step(AgentTool)` + `adapter(Function<ToolResult,String>)` + `errorStrategy(PipelineErrorStrategy)` builder methods; `of(AgentTool...)` and `of(String, String, AgentTool...)` factory methods; `getSteps()` and `getErrorStrategy()` accessors; overrides package-private `setContext(ToolContext)` to propagate context to nested `AbstractAgentTool` steps
+
+**Design:**
+- The pipeline exposes a single `ToolSpecification` to the LLM; all steps execute inside `doExecute()` with no LLM round-trips between steps
+- Default data handoff: `ToolResult.getOutput()` (String) from step N passed verbatim to step N+1
+- Adapters: optional `Function<ToolResult, String>` transformers attached to any step; receive the full `ToolResult` (including `structuredOutput`); only called when the step succeeds and there is a next step
+- `FAIL_FAST`: short-circuits on first failure, returning the failed step's result immediately
+- `CONTINUE_ON_FAILURE`: forwards error message to next step's input; runs to completion
+- `ToolContext` propagation: `setContext()` override forwards context to all nested `AbstractAgentTool` steps so each gets metrics, logging, executor, and review handler wired correctly
+
+**Tests:**
+- `ToolPipelineTest` (49 unit tests): happy path chaining, both error strategies, adapters (including structured output access), ToolContext propagation, factory method validation, builder validation, empty pipeline pass-through, null input handling
+- `ToolPipelineIntegrationTest` (7 integration tests with mocked LLMs): single-tool LLM call with all steps executing internally, error strategies in ensemble context, ToolContext propagation through full ensemble, adapter in ensemble context, v2 task-first API registration
+
+**Example:**
+- `ToolPipelineExample.java` -- two pipelines using `JsonParserTool` + `CalculatorTool` and chained `JsonParserTool` instances; demonstrates adapters and `getSteps()`/`getErrorStrategy()` inspection
+- `runToolPipeline` Gradle task registered in `agentensemble-examples/build.gradle.kts`
+
+**Documentation:**
+- `docs/design/17-tool-pipeline.md` -- full design specification
+- `docs/guides/tool-pipeline.md` -- user guide with quick start, data flow, error strategies, builder reference, factory methods, metrics, approval gates, common patterns
+- `docs/examples/tool-pipeline.md` -- example page with walk-through and sample output
+- `docs/design/06-tool-system.md` -- "Tool Pipeline" section added
+- `docs/guides/built-in-tools.md` -- "Pipelining Built-in Tools" section added
+- `README.md` -- Tool Pipeline in Core Concepts table; "Option 3: Chain tools with ToolPipeline" in Creating Tools; `runToolPipeline` in Running Examples; design/17 in Design Documentation list
+- `mkdocs.yml` -- Tool Pipeline added to Guides and Examples nav; design/17 added to Design nav
+
+---
+
+## Previous Work
+
+### Issue #130: agentensemble-web module -- Live Execution Dashboard
 
 ### Issue #130: agentensemble-web module -- Live Execution Dashboard
 

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## [Unreleased] - Issue #74: Explicit Tool Pipeline / Chaining -- 2026-03-06
+
+### Added (Issue #74 -- Unix-pipe-style tool composition)
+
+**New types in `agentensemble-core` (`net.agentensemble.tool`):**
+- `PipelineErrorStrategy` enum: `FAIL_FAST` (default), `CONTINUE_ON_FAILURE`
+- `ToolPipeline` (`AbstractAgentTool` subclass): linear chain of `AgentTool` steps executed sequentially inside a single `execute(String)` call with no LLM round-trips between steps
+
+**`ToolPipeline` API:**
+- `ToolPipeline.of(AgentTool first, AgentTool... rest)` -- factory; auto-generates name (step names joined with `_then_`) and description
+- `ToolPipeline.of(String name, String description, AgentTool first, AgentTool... rest)` -- named factory
+- `ToolPipeline.builder()` -- full builder with `name()`, `description()`, `step(AgentTool)`, `adapter(Function<ToolResult,String>)`, `errorStrategy(PipelineErrorStrategy)`
+- `ToolPipeline.getSteps()` -- unmodifiable list of step tools in execution order
+- `ToolPipeline.getErrorStrategy()` -- configured error strategy
+
+**Data handoff:**
+- Default: `ToolResult.getOutput()` (String) passed verbatim from step N to step N+1
+- Adapter: optional `Function<ToolResult, String>` attached to any step via `Builder.adapter()`; transforms the preceding step's result; called only when the step succeeds and there is a next step; receives full `ToolResult` including `getStructuredOutput()`
+
+**Error strategy:**
+- `FAIL_FAST`: returns the first failed step's `ToolResult` immediately; subsequent steps skipped
+- `CONTINUE_ON_FAILURE`: forwards `ToolResult.getErrorMessage()` (or empty string) as the next step's input; runs to completion; final result is the last step's result
+
+**`ToolContext` propagation:**
+- `ToolPipeline.setContext(ToolContext)` (package-private override) propagates the injected context to all nested steps that are `AbstractAgentTool` instances; plain `AgentTool` steps receive no injection
+
+**Registration:**
+- `ToolPipeline implements AgentTool` -- registered on tasks and agents exactly like any other tool; adapted by `LangChain4jToolAdapter` with no special handling; single `ToolSpecification` exposed to LLM
+
+### Tests Added (Issue #74)
+
+**Unit tests -- `ToolPipelineTest` (49 tests):**
+- Happy path: single step, two steps, three steps, empty pipeline, null input
+- FAIL_FAST: first step fails (second never called), middle step fails (remaining skipped), last step fails, default strategy is FAIL_FAST
+- CONTINUE_ON_FAILURE: error message forwarded, all steps run, null error message handled, final result is last step's result
+- Adapters: transforms output before next input, adapter on last step not called, structured output accessible in adapter
+- ToolContext propagation: injected into AbstractAgentTool steps, plain AgentTool steps unaffected
+- Factory methods: auto-name/description, explicit name/description, null first step, null in rest
+- Builder validation: blank name, null name, blank description, null step, adapter before step, null adapter, null errorStrategy
+- Interface compliance: implements AgentTool, extends AbstractAgentTool
+- Opportunistic: adapter not called when preceding step failed (CONTINUE_ON_FAILURE)
+
+**Integration tests -- `ToolPipelineIntegrationTest` (7 tests):**
+- `pipeline_appearsAsSingleToolToLlm_allStepsExecutedWithinOneLlmTurn` -- both steps ran exactly once; LLM made 1 tool call
+- `pipeline_returnsChainedOutputToLlm_singleToolCallResult` -- chained output received by LLM
+- `pipeline_failFast_failedMiddleStep_llmReceivesErrorMessage` -- step 3 never called
+- `pipeline_continueOnFailure_allStepsRun_llmReceivesFinalResult` -- step 3 ran despite step 2 failure
+- `pipeline_toolContextPropagated_metricsRecordedForNestedAbstractAgentToolSteps` -- no exceptions on context injection
+- `pipeline_withAdapter_transformsBetweenSteps_ensembleCompletesSuccessfully` -- step 2 received adapter's output
+- `pipeline_registeredOnTask_autoSynthesizedAgent_executes` -- v2 task-first API works with pipeline
+
+### Example Added (Issue #74)
+
+- `ToolPipelineExample.java`: two pipelines demonstrating `JsonParserTool` + `CalculatorTool` with adapter (10% markup), and chained `JsonParserTool` instances for nested JSON extraction; prints pipeline structure via `getSteps()` and `getErrorStrategy()`
+- `runToolPipeline` Gradle task registered in `agentensemble-examples/build.gradle.kts`
+
+### Documentation Added/Updated (Issue #74)
+
+- `docs/design/17-tool-pipeline.md` -- NEW: full design spec (motivation, classes, data handoff, error strategy, ToolContext propagation, metrics, LLM integration, execution flow diagram, builder API, design decisions)
+- `docs/guides/tool-pipeline.md` -- NEW: user guide (quick start, data flow, error strategies, full builder reference, factory methods, inspecting a pipeline, metrics, approval gates, common patterns, nesting, when to use vs separate tools)
+- `docs/examples/tool-pipeline.md` -- NEW: example page (run command, what it demonstrates, code walk-through, sample output, key concepts)
+- `docs/design/06-tool-system.md` -- "Tool Pipeline" section added (class structure, registration, context propagation, error strategies, step adapters)
+- `docs/guides/built-in-tools.md` -- "Pipelining Built-in Tools" section added at bottom
+- `README.md` -- Tool Pipeline added to Core Concepts table; "Option 3: Chain tools with ToolPipeline" section in Creating Tools; `runToolPipeline` in Running Examples; design/17 in Design Documentation list
+- `mkdocs.yml` -- `Tool Pipeline: guides/tool-pipeline.md` added to Guides nav (after Built-in Tools); `Tool Pipeline: examples/tool-pipeline.md` added to Examples nav; `Tool Pipeline: design/17-tool-pipeline.md` added to Design nav
+
+### Design Decisions (Issue #74)
+
+- `ToolPipeline extends AbstractAgentTool` (not just `implements AgentTool`): gets automatic metrics, exception safety, structured logging, and approval-gate capability for free without additional code
+- Package placement in `net.agentensemble.tool`: same package as `AbstractAgentTool` gives access to the package-private `setContext()` override needed for context propagation; keeps user API consistent with existing tool classes
+- String-based data handoff by default (not typed): consistent with the `AgentTool` interface which uses `String input`; adapters provide the typed escape hatch when needed
+- Adapter attached to preceding step (not following step): semantically the adapter is "how this step's output becomes the next step's input", which reads more naturally in the builder chain: `.step(A).adapter(fn).step(B)` = "A's output is transformed by fn before entering B"
+- Adapter not called on failure or on last step: avoids surprising behavior; on failure the error message is forwarded directly (no transformation); on last step there is no next step to receive the adapted output
+- Empty pipeline returns input as pass-through: safe no-op default; matches Unix pipe behavior of `cat file | cat` = `cat file`
+- Parallel branches (fan-out/fan-in) deferred: the linear model covers the common deterministic transformation case; parallel branches can be added later by composing pipelines with the existing parallel execution infrastructure
+
+---
+
 ## [Unreleased] - Issue #130: agentensemble-web module -- WebSocket server + protocol (v2.1.0) -- 2026-03-05
 
 ### Added (Issue #130 -- agentensemble-web Live Execution Dashboard)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,20 @@
 # Progress
 
+## What Works (as of Issue #74 -- Tool Pipeline / Chaining)
+
+**ToolPipeline (Issue #74):**
+- `ToolPipeline.of(AgentTool...)` -- zero-config factory with auto-generated name and description
+- `ToolPipeline.of(String, String, AgentTool...)` -- named factory
+- `ToolPipeline.builder()` -- full builder with `.step()`, `.adapter()`, `.errorStrategy()`
+- `PipelineErrorStrategy.FAIL_FAST` (default) -- stops on first failed step
+- `PipelineErrorStrategy.CONTINUE_ON_FAILURE` -- forwards error message as next step's input
+- Step adapters (`Function<ToolResult, String>`) -- reshape output between steps; access to `structuredOutput`
+- `ToolContext` propagation -- metrics, logging, executor, and review handler forwarded to all nested `AbstractAgentTool` steps
+- `getSteps()` and `getErrorStrategy()` public accessors
+- Empty pipeline pass-through (returns input unchanged)
+- Pipelines nest -- a pipeline can be a step inside another pipeline
+- 49 unit tests + 7 integration tests; all pass; branch `feature/tool-pipeline-74`
+
 ## What Works (as of Issue #130 -- agentensemble-web Live Execution Dashboard)
 
 **agentensemble-web module (Issue #130):**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - MapReduceEnsemble: guides/map-reduce.md
     - Tools: guides/tools.md
     - Built-in Tools: guides/built-in-tools.md
+    - Tool Pipeline: guides/tool-pipeline.md
     - Remote Tools: guides/remote-tools.md
     - Metrics: guides/metrics.md
     - CaptureMode: guides/capture-mode.md
@@ -109,6 +110,7 @@ nav:
     - Metrics and Traces: examples/metrics.md
     - CaptureMode: examples/capture-mode.md
     - Visualization: examples/visualization.md
+    - Tool Pipeline: examples/tool-pipeline.md
     - Human-in-the-Loop: examples/human-in-the-loop.md
     - Live Dashboard: examples/live-dashboard.md
   - Migration:
@@ -130,3 +132,4 @@ nav:
     - MapReduceEnsemble: design/14-map-reduce.md
     - v2.0.0 Architecture: design/15-v2-architecture.md
     - Live Execution Dashboard: design/16-live-dashboard.md
+    - Tool Pipeline: design/17-tool-pipeline.md


### PR DESCRIPTION
## Summary

Implements issue #74: Unix-pipe-style tool composition that chains multiple `AgentTool` instances into a single compound tool. The LLM calls the pipeline once; all steps execute sequentially inside that single call with no LLM round-trips between steps.

## New API

```java
// Simple factory (auto-generated name/description)
ToolPipeline pipeline = ToolPipeline.of(
    new JsonParserTool(),
    new CalculatorTool()
);

// Full builder with adapter and error strategy
ToolPipeline pipeline = ToolPipeline.builder()
    .name("extract_and_calculate")
    .description("Extracts a price from JSON and applies a 10% markup")
    .step(new JsonParserTool())
    .adapter(result -> result.getOutput() + " * 1.1")
    .step(new CalculatorTool())
    .errorStrategy(PipelineErrorStrategy.FAIL_FAST)
    .build();

// Register on a task (v2 task-first API)
var task = Task.builder()
    .description("Calculate the retail price")
    .tools(List.of(pipeline))
    .build();
```

## New Classes

| Class | Package | Description |
|---|---|---|
| `PipelineErrorStrategy` | `net.agentensemble.tool` | `FAIL_FAST` (default) or `CONTINUE_ON_FAILURE` |
| `ToolPipeline` | `net.agentensemble.tool` | Composite `AbstractAgentTool` that chains steps sequentially |

## Design Decisions

- **Extends `AbstractAgentTool`** for automatic metrics, logging, exception safety, and approval-gate capability
- **Package placement** in `net.agentensemble.tool` gives access to package-private `setContext()` override for `ToolContext` propagation to nested steps
- **String-based handoff** by default (consistent with `AgentTool` interface); adapters provide typed reshaping when needed
- **Zero changes to existing code**: `ToolResolver` and `LangChain4jToolAdapter` adapt `ToolPipeline` exactly like any other `AgentTool`

## Tests

- `ToolPipelineTest`: 49 unit tests (chaining, both error strategies, adapters including structuredOutput access, ToolContext propagation, factory/builder validation, edge cases)
- `ToolPipelineIntegrationTest`: 7 integration tests with Mockito-mocked LLMs (pipeline as single tool call, both error strategies in ensemble context, adapter in ensemble context, v2 task-first API)
- All 49+7 = 56 new tests pass; full `agentensemble-core` build clean including Spotless, ErrorProne, JaCoCo

## Documentation

- `docs/design/17-tool-pipeline.md` -- full design spec
- `docs/guides/tool-pipeline.md` -- user guide
- `docs/examples/tool-pipeline.md` -- example page
- `docs/design/06-tool-system.md` -- Tool Pipeline section added
- `docs/guides/built-in-tools.md` -- Pipelining section added
- `README.md` -- Core Concepts, Creating Tools (Option 3), Running Examples, Design docs
- `mkdocs.yml` -- Guides, Examples, Design nav entries

Closes #74