### PR TITLE
chore: migrate to Javalin 7.0.1

### DIFF
--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
@@ -14,6 +14,7 @@ import net.agentensemble.web.protocol.MessageSerializer;
 import net.agentensemble.web.protocol.PingMessage;
 import net.agentensemble.web.protocol.PongMessage;
 import net.agentensemble.web.protocol.ReviewDecisionMessage;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,46 +89,47 @@ class WebSocketServer {
                     host);
         }
 
+        final String boundHost = host;
         app = Javalin.create(config -> {
-            config.showJavalinBanner = false;
+            config.startup.showJavalinBanner = false;
             // Static files from viz dist embedded in the JAR under /web/
             // config.staticFiles.add("/web", io.javalin.http.staticfiles.Location.CLASSPATH);
-        });
 
-        final String boundHost = host;
-        app.ws("/ws", ws -> {
-            ws.onConnect(ctx -> {
-                String origin = ctx.header("Origin");
-                if (!isOriginAllowed(origin, boundHost)) {
-                    log.warn("Rejected WebSocket connection from origin '{}' (host binding: {})", origin, boundHost);
-                    ctx.session.close(1008, "Origin not allowed");
-                    return;
-                }
-                connectionManager.onConnect(new JavalinWsSession(ctx));
+            config.routes.ws("/ws", ws -> {
+                ws.onConnect(ctx -> {
+                    String origin = ctx.header("Origin");
+                    if (!isOriginAllowed(origin, boundHost)) {
+                        log.warn(
+                                "Rejected WebSocket connection from origin '{}' (host binding: {})", origin, boundHost);
+                        ctx.session.close(1008, "Origin not allowed", Callback.NOOP);
+                        return;
+                    }
+                    connectionManager.onConnect(new JavalinWsSession(ctx));
+                });
+
+                ws.onMessage(ctx -> {
+                    String message = ctx.message();
+                    try {
+                        ClientMessage parsed = serializer.fromJson(message, ClientMessage.class);
+                        handleClientMessage(ctx, parsed);
+                    } catch (Exception e) {
+                        log.warn("Failed to parse client message: {}", message, e);
+                    }
+                });
+
+                ws.onClose(ctx -> connectionManager.onDisconnect(ctx.sessionId()));
             });
 
-            ws.onMessage(ctx -> {
-                String message = ctx.message();
-                try {
-                    ClientMessage parsed = serializer.fromJson(message, ClientMessage.class);
-                    handleClientMessage(ctx, parsed);
-                } catch (Exception e) {
-                    log.warn("Failed to parse client message: {}", message, e);
-                }
-            });
-
-            ws.onClose(ctx -> connectionManager.onDisconnect(ctx.sessionId()));
+            config.routes.get(
+                    "/api/status",
+                    ctx -> ctx.json(Map.of(
+                            "status",
+                            "running",
+                            "clients",
+                            connectionManager.sessionCount(),
+                            "port",
+                            runningPort > 0 ? runningPort : port)));
         });
-
-        app.get(
-                "/api/status",
-                ctx -> ctx.json(Map.of(
-                        "status",
-                        "running",
-                        "clients",
-                        connectionManager.sessionCount(),
-                        "port",
-                        runningPort > 0 ? runningPort : port)));
 
         app.start(host, port);
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ spotless         = "8.3.0"
 errorprone       = "5.1.0"
 errorprone-core  = "2.48.0"
 micrometer       = "1.16.3"
-javalin          = "6.3.0"
+javalin          = "7.0.1"
 
 [libraries]
 langchain4j               = { group = "dev.langchain4j", name = "langchain4j",          version.ref = "langchain4j" }


### PR DESCRIPTION
## Summary

Replaces the Dependabot-only PR #154 with a complete migration to Javalin 7.0.1.

The Dependabot PR bumped the version but did not migrate the code, causing 3 compilation errors in `WebSocketServer.java`. This PR includes both the version bump and the required API migration.

## Breaking changes in Javalin 7

| Change | Before (Javalin 6) | After (Javalin 7) |
|---|---|---|
| Banner config | `config.showJavalinBanner = false` | `config.startup.showJavalinBanner = false` |
| Route registration | `app.ws(...)` / `app.get(...)` after `create()` | `config.routes.ws(...)` / `config.routes.get(...)` inside `Javalin.create()` |
| WebSocket close | `ctx.session.close(code, reason)` | `ctx.session.close(code, reason, Callback.NOOP)` (Jetty 12 API change) |

## Files changed
- `gradle/libs.versions.toml` — bumps `javalin` from 6.3.0 to 7.0.1
- `agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java` — migrates to Javalin 7 API

## Testing
All 204 tasks pass locally including unit tests, integration tests, Spotless formatting checks, JaCoCo coverage verification, and Javadoc generation.

Closes #154