### PR TITLE
feat: enable parallel test class execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,11 @@ subprojects {
 
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
+        systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
+        systemProperties["junit.jupiter.execution.parallel.mode.default"] = "same_thread"
+        systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
+        systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "dynamic"
+        systemProperties["junit.jupiter.execution.parallel.config.dynamic.factor"] = "1"
         testLogging {
             events("passed", "skipped", "failed")
             showStandardStreams = false

--- a/buildSrc/src/main/kotlin/agentensemble.tool-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/agentensemble.tool-conventions.gradle.kts
@@ -48,6 +48,11 @@ tasks.withType<JavaCompile>().configureEach {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
+    systemProperties["junit.jupiter.execution.parallel.mode.default"] = "same_thread"
+    systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
+    systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "dynamic"
+    systemProperties["junit.jupiter.execution.parallel.config.dynamic.factor"] = "1"
     testLogging {
         events("passed", "skipped", "failed")
         showStandardStreams = false


### PR DESCRIPTION
## Summary
- Enable JUnit 5 parallel execution for test classes across all modules
- Classes run concurrently; methods within a class stay sequential (preserves per-instance `@AfterEach` teardown safety)
- Configured in both `build.gradle.kts` (regular subprojects) and `agentensemble.tool-conventions.gradle.kts` (tool subprojects)

## Test plan
- [x] `./gradlew test` — all tests pass with parallel execution enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)