### PR TITLE
fix: CA-002 PMD cleanup, docs update, CodingTools example

### DIFF
--- a/agentensemble-examples/build.gradle.kts
+++ b/agentensemble-examples/build.gradle.kts
@@ -65,6 +65,7 @@ application {
 //   ./gradlew :agentensemble-examples:runDeterministicOnlyPipeline
 //   ./gradlew :agentensemble-examples:runPhases
 //   ./gradlew :agentensemble-examples:runPhaseReview
+//   ./gradlew :agentensemble-examples:runCodingTools --args="/path/to/project"
 //   ./gradlew :agentensemble-examples:runCodingAgent --args="/path/to/project"
 //   ./gradlew :agentensemble-examples:runIsolatedCoding --args="/path/to/git/repo"
 //   ./gradlew :agentensemble-examples:runMcpCoding --args="/path/to/git/project"
@@ -92,6 +93,7 @@ mapOf(
     "runPhaseReview" to "net.agentensemble.examples.PhaseReviewExample",
     "runTypedTools" to "net.agentensemble.examples.TypedToolsExample",
     "runToonFormat" to "net.agentensemble.examples.ToonFormatExample",
+    "runCodingTools" to "net.agentensemble.examples.CodingToolsExample",
     "runCodingAgent" to "net.agentensemble.examples.CodingAgentExample",
     "runIsolatedCoding" to "net.agentensemble.examples.IsolatedCodingExample",
     "runMcpCoding" to "net.agentensemble.examples.McpCodingExample",

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/CodingToolsExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/CodingToolsExample.java
@@ -1,0 +1,85 @@
+package net.agentensemble.examples;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.tools.coding.BuildRunnerTool;
+import net.agentensemble.tools.coding.CodeEditTool;
+import net.agentensemble.tools.coding.CodeSearchTool;
+import net.agentensemble.tools.coding.GitTool;
+import net.agentensemble.tools.coding.GlobTool;
+import net.agentensemble.tools.coding.ShellTool;
+import net.agentensemble.tools.coding.TestRunnerTool;
+
+/**
+ * Demonstrates assembling all 7 coding tools directly without the CodingAgent factory.
+ *
+ * <p>This gives full control over tool configuration: approval gates, timeouts,
+ * and which tools to include. Compare with {@link CodingAgentExample} which uses
+ * the higher-level {@code CodingEnsemble.run()} API.
+ *
+ * <p>Run with:
+ * <pre>
+ *   export OPENAI_API_KEY=sk-...
+ *   ./gradlew :agentensemble-examples:runCodingTools --args="/path/to/project"
+ * </pre>
+ *
+ * <p>The first argument is the path to the project directory. If omitted, the current
+ * directory is used.
+ */
+public final class CodingToolsExample {
+
+    public static void main(String[] args) {
+        Path workspace = args.length > 0 ? Path.of(args[0]) : Path.of(".");
+
+        ChatModel model = OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName("gpt-4o")
+                .build();
+
+        System.out.println("=".repeat(70));
+        System.out.println("AgentEnsemble: Coding Tools (Raw Assembly) Example");
+        System.out.println("=".repeat(70));
+        System.out.println("Workspace: " + workspace.toAbsolutePath());
+        System.out.println();
+
+        // Assemble all 7 coding tools with explicit configuration
+        List<Object> tools = List.of(
+                GlobTool.of(workspace),
+                CodeSearchTool.of(workspace),
+                CodeEditTool.builder(workspace).requireApproval(true).build(),
+                ShellTool.builder(workspace)
+                        .requireApproval(true)
+                        .timeout(Duration.ofSeconds(60))
+                        .build(),
+                GitTool.builder(workspace).requireApproval(true).build(),
+                BuildRunnerTool.of(workspace),
+                TestRunnerTool.of(workspace));
+
+        Agent agent = Agent.builder()
+                .role("Senior Software Engineer")
+                .goal("Fix bugs and implement features in the codebase")
+                .tools(tools)
+                .llm(model)
+                .maxIterations(75)
+                .build();
+
+        Task task = Task.builder()
+                .description("Explore the project structure, identify any compilation errors "
+                        + "or obvious bugs, and fix them. Run the build to verify your fixes.")
+                .expectedOutput("A summary of the issues found and fixed, with build verification.")
+                .agent(agent)
+                .build();
+
+        EnsembleOutput output = Ensemble.run(model, task);
+
+        System.out.println("\n--- Result ---");
+        System.out.println(output.getRaw());
+    }
+}

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/BuildRunnerTool.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/BuildRunnerTool.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,7 +44,7 @@ public final class BuildRunnerTool extends AbstractTypedAgentTool<BuildRunnerInp
     private BuildRunnerTool(SandboxValidator sandbox, Duration timeout) {
         this.sandbox = sandbox;
         this.timeout = timeout;
-        String os = System.getProperty("os.name", "").toLowerCase();
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         this.shellPrefix = os.contains("win") ? List.of("cmd", "/c") : List.of("sh", "-c");
     }
 

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/CodeSearchTool.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/CodeSearchTool.java
@@ -231,10 +231,10 @@ public final class CodeSearchTool extends AbstractTypedAgentTool<CodeSearchInput
         if (lines.length <= MAX_MATCHES) {
             return output;
         }
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(MAX_MATCHES * 80);
         for (int i = 0; i < MAX_MATCHES; i++) {
             if (i > 0) {
-                sb.append("\n");
+                sb.append('\n');
             }
             sb.append(lines[i]);
         }
@@ -270,7 +270,7 @@ public final class CodeSearchTool extends AbstractTypedAgentTool<CodeSearchInput
                     }
                     searchFile(file, regex, contextSize, results);
                 } catch (IOException e) {
-                    // Skip unreadable files
+                    log().trace("Skipping unreadable file: {}", file, e);
                 }
                 return results.size() >= MAX_MATCHES ? FileVisitResult.TERMINATE : FileVisitResult.CONTINUE;
             }

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/GitTool.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/GitTool.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import net.agentensemble.exception.ToolConfigurationException;
@@ -105,7 +106,7 @@ public final class GitTool extends AbstractTypedAgentTool<GitInput> {
             return ToolResult.failure("Git command must not be blank");
         }
 
-        String command = input.command().trim().toLowerCase();
+        String command = input.command().trim().toLowerCase(Locale.ROOT);
         if (!ALLOWED_COMMANDS.contains(command)) {
             return ToolResult.failure("Unknown git command: " + command + ". Allowed: "
                     + String.join(", ", ALLOWED_COMMANDS.stream().sorted().toList()));

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/GlobTool.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/GlobTool.java
@@ -69,6 +69,7 @@ public final class GlobTool extends AbstractTypedAgentTool<GlobInput> {
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource") // Default FileSystem must not be closed
     public ToolResult execute(GlobInput input) {
         String pattern = input.pattern();
         if (pattern == null || pattern.isBlank()) {

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/ShellTool.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/ShellTool.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import net.agentensemble.exception.ToolConfigurationException;
 import net.agentensemble.review.ReviewDecision;
@@ -46,7 +47,7 @@ public final class ShellTool extends AbstractTypedAgentTool<ShellInput> {
     }
 
     private static List<String> detectShellPrefix() {
-        String os = System.getProperty("os.name", "").toLowerCase();
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         if (os.contains("win")) {
             return List.of("cmd", "/c");
         }

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/SubprocessRunner.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/SubprocessRunner.java
@@ -3,7 +3,6 @@ package net.agentensemble.tools.coding;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -47,8 +46,8 @@ final class SubprocessRunner {
         Process process = pb.start();
 
         // Close stdin immediately -- coding tools do not send input to subprocesses.
-        try (OutputStream stdin = process.getOutputStream()) {
-            // no-op; just close stdin
+        try {
+            process.getOutputStream().close();
         } catch (IOException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Process stdin closed early: {}", e.getMessage());
@@ -97,6 +96,7 @@ final class SubprocessRunner {
      * Drain an input stream into the output buffer up to maxBytes, then discard the rest.
      * This prevents OOM when a subprocess produces very large output.
      */
+    @SuppressWarnings("PMD.AssignmentInOperand") // Standard stream-draining idiom
     private static void drainBounded(InputStream in, ByteArrayOutputStream out, int maxBytes) throws IOException {
         byte[] buf = new byte[8192];
         int totalRead = 0;

--- a/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/TestRunnerTool.java
+++ b/agentensemble-tools/coding/src/main/java/net/agentensemble/tools/coding/TestRunnerTool.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,6 +30,7 @@ import net.agentensemble.tool.ToolResult;
  * TestRunnerTool tool = TestRunnerTool.of(Path.of("/workspace/project"));
  * </pre>
  */
+@SuppressWarnings("PMD.TestClassWithoutTestCases") // Not a test class; 'Test' refers to test-runner functionality
 public final class TestRunnerTool extends AbstractTypedAgentTool<TestRunnerInput> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -55,7 +57,7 @@ public final class TestRunnerTool extends AbstractTypedAgentTool<TestRunnerInput
     private TestRunnerTool(SandboxValidator sandbox, Duration timeout) {
         this.sandbox = sandbox;
         this.timeout = timeout;
-        String os = System.getProperty("os.name", "").toLowerCase();
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         this.shellPrefix = os.contains("win") ? List.of("cmd", "/c") : List.of("sh", "-c");
     }
 
@@ -190,6 +192,7 @@ public final class TestRunnerTool extends AbstractTypedAgentTool<TestRunnerInput
         return new TestResult(exitSuccess, 0, exitSuccess ? 0 : 1, 0, failures);
     }
 
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // Each failure is a distinct result object
     private List<TestFailure> extractFailures(String output) {
         List<TestFailure> failures = new ArrayList<>();
         String[] lines = output.split("\n");
@@ -205,10 +208,10 @@ public final class TestRunnerTool extends AbstractTypedAgentTool<TestRunnerInput
                     message = lines[i + 1].trim();
                 }
                 if (i + 2 < lines.length && lines[i + 2].trim().startsWith("at ")) {
-                    StringBuilder sb = new StringBuilder();
+                    StringBuilder sb = new StringBuilder(256);
                     for (int j = i + 2; j < Math.min(i + 7, lines.length); j++) {
                         if (lines[j].trim().startsWith("at ") || lines[j].trim().startsWith("Caused by:")) {
-                            sb.append(lines[j].trim()).append("\n");
+                            sb.append(lines[j].trim()).append('\n');
                         }
                     }
                     stackTrace = sb.toString().trim();
@@ -223,7 +226,7 @@ public final class TestRunnerTool extends AbstractTypedAgentTool<TestRunnerInput
     private static final int MAX_RAW_OUTPUT_LENGTH = 10_000;
 
     private String buildSummary(TestResult testResult, String rawOutput) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(256);
         sb.append("Tests: ")
                 .append(testResult.passed())
                 .append(" passed, ")
@@ -247,8 +250,8 @@ public final class TestRunnerTool extends AbstractTypedAgentTool<TestRunnerInput
         // Append raw output for context, truncated to prevent overwhelming the LLM
         sb.append("\n\n--- Raw Output ---\n");
         if (rawOutput.length() > MAX_RAW_OUTPUT_LENGTH) {
-            sb.append(rawOutput, 0, MAX_RAW_OUTPUT_LENGTH);
-            sb.append("\n... (output truncated at ")
+            sb.append(rawOutput, 0, MAX_RAW_OUTPUT_LENGTH)
+                    .append("\n... (output truncated at ")
                     .append(MAX_RAW_OUTPUT_LENGTH)
                     .append(" characters)");
         } else {

--- a/docs/examples/coding-tools.md
+++ b/docs/examples/coding-tools.md
@@ -96,8 +96,8 @@ var ensemble = Ensemble.builder()
 ## Workspace Scoping
 
 All coding tools accept a `Path baseDir` at construction time. When combined
-with workspace isolation (coming in a future module), all tools are automatically
-scoped to the isolated working directory:
+with the `agentensemble-workspace` module (see [Workspace Isolation](../guides/workspace-isolation.md)),
+all tools are automatically scoped to the isolated working directory:
 
 ```java
 Path isolatedDir = workspace; // or a git worktree path


### PR DESCRIPTION
## Summary
- Resolve all 15 PMD warnings in `agentensemble-tools/coding` (11 direct fixes, 4 suppressions for false positives)
- Update stale "coming in a future module" reference in `docs/examples/coding-tools.md` to point to `agentensemble-workspace`
- Add `CodingToolsExample.java` demonstrating raw tool assembly without the CodingAgent factory

Closes #254
Progresses #252

## Test plan
- [x] `./gradlew :agentensemble-tools:coding:check` passes (tests, PMD, coverage)
- [x] `./gradlew :agentensemble-examples:compileJava` compiles new example
- [x] PMD report shows 0 warnings for coding module
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)