### PR TITLE
feat(#299): Ensemble Control API Phase 1 -- catalogs, RunManager, REST endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+.claude/

--- a/agentensemble-web/src/main/java/net/agentensemble/web/ModelCatalog.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/ModelCatalog.java
@@ -1,0 +1,209 @@
+package net.agentensemble.web;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Registry mapping model aliases to {@link ChatModel} instances for the Ensemble Control API.
+ *
+ * <p>Models registered here form the server-side allowlist for API-submitted runs. Clients
+ * reference models by alias in API requests; only registered models can be used. This prevents
+ * references to arbitrary or unconfigured LLM providers.
+ *
+ * <pre>
+ * ModelCatalog catalog = ModelCatalog.builder()
+ *     .model("sonnet", sonnetModel)
+ *     .model("opus", opusModel)
+ *     .model("haiku", haikuModel, haikuStreamingModel)
+ *     .build();
+ * </pre>
+ *
+ * <p>Registered via {@link WebDashboard.Builder#modelCatalog(ModelCatalog)}:
+ *
+ * <pre>
+ * WebDashboard dashboard = WebDashboard.builder()
+ *     .port(7329)
+ *     .modelCatalog(catalog)
+ *     .build();
+ * </pre>
+ */
+public final class ModelCatalog {
+
+    private final Map<String, ChatModel> models;
+    private final Map<String, StreamingChatModel> streamingModels;
+
+    private ModelCatalog(Builder builder) {
+        this.models = Collections.unmodifiableMap(new LinkedHashMap<>(builder.models));
+        this.streamingModels = Collections.unmodifiableMap(new LinkedHashMap<>(builder.streamingModels));
+    }
+
+    /**
+     * Returns a new builder for constructing a {@link ModelCatalog}.
+     *
+     * @return a new Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Resolves the chat model with the given alias.
+     *
+     * @param alias the model alias; must not be null
+     * @return the registered {@link ChatModel}
+     * @throws NoSuchElementException if no model is registered with the given alias
+     */
+    public ChatModel resolve(String alias) {
+        ChatModel model = models.get(alias);
+        if (model == null) {
+            List<String> available = models.keySet().stream().sorted().toList();
+            throw new NoSuchElementException("Unknown model '" + alias + "'. Available: " + available);
+        }
+        return model;
+    }
+
+    /**
+     * Returns the chat model with the given alias, or empty if not found.
+     *
+     * @param alias the model alias
+     * @return an Optional containing the model, or empty
+     */
+    public Optional<ChatModel> find(String alias) {
+        return Optional.ofNullable(models.get(alias));
+    }
+
+    /**
+     * Returns the streaming model registered under the given alias, or {@code null} if no
+     * streaming variant was registered for that alias.
+     *
+     * @param alias the model alias
+     * @return the streaming model, or null if not registered
+     */
+    public StreamingChatModel resolveStreaming(String alias) {
+        return streamingModels.get(alias);
+    }
+
+    /**
+     * Returns a list of all registered model descriptions, in registration order.
+     *
+     * @return unmodifiable list of {@link ModelInfo} records
+     */
+    public List<ModelInfo> list() {
+        return models.entrySet().stream()
+                .map(e -> new ModelInfo(e.getKey(), deriveProvider(e.getValue())))
+                .toList();
+    }
+
+    /**
+     * Returns the number of registered models.
+     *
+     * @return model count
+     */
+    public int size() {
+        return models.size();
+    }
+
+    /**
+     * Derives a human-readable provider name from the model's class name.
+     *
+     * <p>For example, a class named {@code OpenAiChatModel} returns {@code "openai"},
+     * {@code AnthropicChatModel} returns {@code "anthropic"}.
+     *
+     * @param model the chat model instance
+     * @return a lowercase provider name, or {@code "unknown"} if not recognized
+     */
+    static String deriveProvider(ChatModel model) {
+        String className = model.getClass().getSimpleName().toLowerCase(Locale.ROOT);
+        if (className.contains("openai")) return "openai";
+        if (className.contains("anthropic")) return "anthropic";
+        if (className.contains("gemini") || className.contains("vertexai")) return "google";
+        if (className.contains("google")) return "google";
+        if (className.contains("mistral")) return "mistral";
+        if (className.contains("ollama")) return "ollama";
+        if (className.contains("cohere")) return "cohere";
+        if (className.contains("azure")) return "azure";
+        if (className.contains("bedrock")) return "bedrock";
+        if (className.contains("huggingface")) return "huggingface";
+        return "unknown";
+    }
+
+    /**
+     * Descriptive snapshot of a registered model returned by {@link #list()}.
+     *
+     * @param alias    the model alias clients use in API requests
+     * @param provider the inferred provider name (e.g. {@code "anthropic"}, {@code "openai"})
+     */
+    public record ModelInfo(String alias, String provider) {}
+
+    /**
+     * Fluent builder for {@link ModelCatalog}.
+     *
+     * <p>Models are stored in insertion order. Attempting to register the same alias twice
+     * throws {@link IllegalArgumentException} at builder time (fail-fast).
+     */
+    public static final class Builder {
+
+        private final Map<String, ChatModel> models = new LinkedHashMap<>();
+        private final Map<String, StreamingChatModel> streamingModels = new LinkedHashMap<>();
+
+        private Builder() {}
+
+        /**
+         * Registers a chat model under the given alias.
+         *
+         * @param alias the alias clients use to reference this model; must not be null or blank
+         * @param model the chat model implementation; must not be null
+         * @return this builder
+         * @throws IllegalArgumentException if the alias is null/blank or already registered,
+         *                                  or if the model is null
+         */
+        public Builder model(String alias, ChatModel model) {
+            if (alias == null || alias.isBlank()) {
+                throw new IllegalArgumentException("model alias must not be null or blank");
+            }
+            if (model == null) {
+                throw new IllegalArgumentException("model must not be null (alias: '" + alias + "')");
+            }
+            if (models.containsKey(alias)) {
+                throw new IllegalArgumentException("duplicate model alias: '" + alias + "'");
+            }
+            models.put(alias, model);
+            return this;
+        }
+
+        /**
+         * Registers a chat model and its streaming counterpart under the given alias.
+         *
+         * @param alias          the alias clients use to reference this model
+         * @param model          the chat model implementation; must not be null
+         * @param streamingModel the streaming variant; must not be null
+         * @return this builder
+         * @throws IllegalArgumentException if any argument is invalid or the alias is already registered
+         */
+        public Builder model(String alias, ChatModel model, StreamingChatModel streamingModel) {
+            if (streamingModel == null) {
+                throw new IllegalArgumentException(
+                        "streamingModel must not be null when provided (alias: '" + alias + "')");
+            }
+            model(alias, model);
+            streamingModels.put(alias, streamingModel);
+            return this;
+        }
+
+        /**
+         * Builds and returns the {@link ModelCatalog}.
+         *
+         * @return a new, immutable ModelCatalog
+         */
+        public ModelCatalog build() {
+            return new ModelCatalog(this);
+        }
+    }
+}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunManager.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunManager.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -101,6 +102,8 @@ public final class RunManager {
             RunOptions options,
             String originSessionId,
             Consumer<RunResultMessage> onComplete) {
+
+        Objects.requireNonNull(template, "template must not be null");
 
         String runId = generateRunId();
 
@@ -303,13 +306,17 @@ public final class RunManager {
         }
     }
 
-    private void evictCompletedRunsIfNeeded() {
+    private synchronized void evictCompletedRunsIfNeeded() {
+        // Synchronized to prevent concurrent completions from computing stale snapshots
+        // and collectively evicting more runs than intended.
+        // Secondary sort by runId provides a deterministic tie-breaker when timestamps match.
         List<RunState> terminal = runs.values().stream()
                 .filter(s -> {
                     Status st = s.getStatus();
                     return st == Status.COMPLETED || st == Status.FAILED || st == Status.CANCELLED;
                 })
-                .sorted(Comparator.comparing(RunState::getCompletedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .sorted(Comparator.comparing(RunState::getCompletedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(RunState::getRunId))
                 .toList();
 
         int excess = terminal.size() - maxRetainedRuns;

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunManager.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunManager.java
@@ -1,0 +1,328 @@
+package net.agentensemble.web;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import net.agentensemble.Ensemble;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.execution.RunOptions;
+import net.agentensemble.metrics.ExecutionMetrics;
+import net.agentensemble.task.TaskOutput;
+import net.agentensemble.web.RunState.Status;
+import net.agentensemble.web.RunState.TaskOutputSnapshot;
+import net.agentensemble.web.protocol.RunResultMessage;
+import net.agentensemble.web.protocol.RunResultMessage.MetricsDto;
+import net.agentensemble.web.protocol.RunResultMessage.TaskOutputDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Coordinates the lifecycle of API-submitted ensemble runs.
+ *
+ * <p>RunManager handles:
+ * <ul>
+ *   <li>Concurrency limiting via a fair {@link Semaphore} (configurable max concurrent runs)</li>
+ *   <li>Asynchronous execution on virtual threads</li>
+ *   <li>Run state tracking in a {@link ConcurrentHashMap}</li>
+ *   <li>Eviction of oldest completed runs when {@code maxRetainedRuns} is exceeded</li>
+ *   <li>Completion notification via an optional callback</li>
+ * </ul>
+ *
+ * <p>Thread safety: all public methods are safe for concurrent use. Run state transitions
+ * use atomic operations and volatile fields.
+ *
+ * <p>Instances should be shut down via {@link #shutdown()} when the dashboard stops.
+ */
+public final class RunManager {
+
+    private static final Logger log = LoggerFactory.getLogger(RunManager.class);
+
+    private final ConcurrentHashMap<String, RunState> runs = new ConcurrentHashMap<>();
+    private final Semaphore concurrencyLimit;
+    private final ExecutorService executor;
+    private final int maxConcurrentRuns;
+    private final int maxRetainedRuns;
+
+    /**
+     * Creates a RunManager with the given concurrency and retention limits.
+     *
+     * @param maxConcurrentRuns the maximum number of runs that may execute simultaneously;
+     *                          must be &ge; 1
+     * @param maxRetainedRuns   the maximum number of completed (and failed/cancelled) runs
+     *                          to keep in memory for state queries; must be &ge; 1
+     * @throws IllegalArgumentException if either limit is less than 1
+     */
+    public RunManager(int maxConcurrentRuns, int maxRetainedRuns) {
+        if (maxConcurrentRuns < 1) {
+            throw new IllegalArgumentException("maxConcurrentRuns must be >= 1; got: " + maxConcurrentRuns);
+        }
+        if (maxRetainedRuns < 1) {
+            throw new IllegalArgumentException("maxRetainedRuns must be >= 1; got: " + maxRetainedRuns);
+        }
+        this.maxConcurrentRuns = maxConcurrentRuns;
+        this.maxRetainedRuns = maxRetainedRuns;
+        this.concurrencyLimit = new Semaphore(maxConcurrentRuns, /* fair= */ true);
+        this.executor = Executors.newVirtualThreadPerTaskExecutor();
+    }
+
+    /**
+     * Submits a run for asynchronous execution.
+     *
+     * <p>If the concurrency limit is reached, returns a {@link RunState} with status
+     * {@link Status#REJECTED} immediately (no execution scheduled). The rejected state is
+     * not retained in the run map.
+     *
+     * <p>Otherwise, returns a state with status {@link Status#ACCEPTED} and schedules
+     * execution on a virtual thread. The callback (if provided) is invoked from the
+     * execution thread once the run completes.
+     *
+     * @param template        the template ensemble to run; must not be null
+     * @param inputs          the input variables for template substitution; may be null
+     * @param tags            metadata tags for filtering and querying; may be null
+     * @param options         per-run execution options; may be null (uses defaults)
+     * @param originSessionId the WebSocket session ID that submitted the run; null for HTTP
+     * @param onComplete      callback invoked with the final result message; may be null
+     * @return the initial {@link RunState} (ACCEPTED or REJECTED)
+     */
+    public RunState submitRun(
+            Ensemble template,
+            Map<String, String> inputs,
+            Map<String, Object> tags,
+            RunOptions options,
+            String originSessionId,
+            Consumer<RunResultMessage> onComplete) {
+
+        String runId = generateRunId();
+
+        if (!concurrencyLimit.tryAcquire()) {
+            log.debug("Run {} rejected: concurrency limit ({}) reached", runId, maxConcurrentRuns);
+            return new RunState(runId, Status.REJECTED, Instant.now(), inputs, tags, 0, null, originSessionId);
+        }
+
+        int taskCount = (template.getTasks() != null) ? template.getTasks().size() : 0;
+        RunState state =
+                new RunState(runId, Status.ACCEPTED, Instant.now(), inputs, tags, taskCount, null, originSessionId);
+        runs.put(runId, state);
+
+        Map<String, String> effectiveInputs = inputs != null ? Map.copyOf(inputs) : Map.of();
+        RunOptions effectiveOptions = options != null ? options : RunOptions.DEFAULT;
+
+        executor.submit(() -> executeRun(state, template, effectiveInputs, effectiveOptions, onComplete));
+
+        log.debug("Run {} accepted ({} task(s))", runId, taskCount);
+        return state;
+    }
+
+    /**
+     * Returns the {@link RunState} for the given run ID, or empty if not found.
+     *
+     * @param runId the run identifier
+     * @return the state, or empty
+     */
+    public Optional<RunState> getRun(String runId) {
+        return Optional.ofNullable(runs.get(runId));
+    }
+
+    /**
+     * Returns all retained runs matching the given filter criteria, ordered by start time
+     * descending (most recent first).
+     *
+     * @param statusFilter if non-null, only runs with this status are returned
+     * @param tagKey       if non-null, only runs with this tag key are returned
+     * @param tagValue     if non-null (along with {@code tagKey}), only runs where the tag
+     *                     value equals this string are returned
+     * @return a list of matching {@link RunState} records
+     */
+    public List<RunState> listRuns(Status statusFilter, String tagKey, String tagValue) {
+        return runs.values().stream()
+                .filter(s -> statusFilter == null || s.getStatus() == statusFilter)
+                .filter(s -> {
+                    if (tagKey == null) return true;
+                    Object val = s.getTags().get(tagKey);
+                    return val != null && (tagValue == null || tagValue.equals(val.toString()));
+                })
+                .sorted(Comparator.comparing(RunState::getStartedAt).reversed())
+                .toList();
+    }
+
+    /**
+     * Returns all retained runs, ordered by start time descending.
+     *
+     * @return all retained run states
+     */
+    public List<RunState> listAllRuns() {
+        return listRuns(null, null, null);
+    }
+
+    /**
+     * Returns the number of currently active (ACCEPTED or RUNNING) runs.
+     *
+     * @return count of active runs
+     */
+    public int getActiveCount() {
+        return maxConcurrentRuns - concurrencyLimit.availablePermits();
+    }
+
+    /**
+     * Returns the configured maximum concurrent runs limit.
+     *
+     * @return max concurrent runs
+     */
+    public int getMaxConcurrentRuns() {
+        return maxConcurrentRuns;
+    }
+
+    /**
+     * Shuts down the internal virtual-thread executor, waiting up to 2 seconds for
+     * in-progress work to finish. Should be called when the dashboard stops.
+     */
+    public void shutdown() {
+        executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
+                log.warn("RunManager executor did not terminate within 2 seconds");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    // ========================
+    // Private execution logic
+    // ========================
+
+    private void executeRun(
+            RunState state,
+            Ensemble template,
+            Map<String, String> inputs,
+            RunOptions options,
+            Consumer<RunResultMessage> onComplete) {
+
+        state.setEnsemble(template);
+        state.transitionTo(Status.RUNNING);
+        log.debug("Run {} started", state.getRunId());
+
+        EnsembleOutput output = null;
+        Exception runException = null;
+        try {
+            output = template.run(inputs, options);
+        } catch (Exception e) {
+            runException = e;
+            log.warn("Run {} failed with exception: {}", state.getRunId(), e.getMessage(), e);
+        } finally {
+            concurrencyLimit.release();
+        }
+
+        Instant completedAt = Instant.now();
+        state.setCompletedAt(completedAt);
+        long durationMs = completedAt.toEpochMilli() - state.getStartedAt().toEpochMilli();
+
+        RunResultMessage resultMessage;
+
+        if (runException != null) {
+            state.transitionTo(Status.FAILED);
+            state.setError(runException.getMessage());
+            resultMessage = new RunResultMessage(
+                    state.getRunId(), Status.FAILED.name(), List.of(), durationMs, null, runException.getMessage());
+        } else {
+            Status finalStatus = state.isCancelled() ? Status.CANCELLED : Status.COMPLETED;
+            state.transitionTo(finalStatus);
+
+            List<TaskOutputDto> taskDtos = buildTaskOutputDtos(output);
+            MetricsDto metricsDto = buildMetricsDto(output);
+
+            if (output != null) {
+                state.setMetrics(output.getMetrics());
+                populateTaskOutputSnapshots(state, output);
+            }
+
+            resultMessage =
+                    new RunResultMessage(state.getRunId(), finalStatus.name(), taskDtos, durationMs, metricsDto, null);
+        }
+
+        log.debug("Run {} finished with status {}", state.getRunId(), state.getStatus());
+
+        // Evict before notifying so the map is already clean when the callback fires.
+        evictCompletedRunsIfNeeded();
+
+        if (onComplete != null) {
+            try {
+                onComplete.accept(resultMessage);
+            } catch (Exception e) {
+                log.warn("Run completion callback threw for runId={}", state.getRunId(), e);
+            }
+        }
+    }
+
+    private List<TaskOutputDto> buildTaskOutputDtos(EnsembleOutput output) {
+        if (output == null
+                || output.getTaskOutputs() == null
+                || output.getTaskOutputs().isEmpty()) {
+            return List.of();
+        }
+        List<TaskOutputDto> dtos = new ArrayList<>();
+        for (TaskOutput taskOutput : output.getTaskOutputs()) {
+            Long durationMs =
+                    taskOutput.getDuration() != null ? taskOutput.getDuration().toMillis() : null;
+            dtos.add(new TaskOutputDto(taskOutput.getTaskDescription(), taskOutput.getRaw(), durationMs));
+        }
+        return List.copyOf(dtos);
+    }
+
+    private MetricsDto buildMetricsDto(EnsembleOutput output) {
+        if (output == null) return null;
+        ExecutionMetrics m = output.getMetrics();
+        if (m == null) return null;
+        return new MetricsDto(m.getTotalTokens(), m.getTotalToolCalls());
+    }
+
+    private void populateTaskOutputSnapshots(RunState state, EnsembleOutput output) {
+        if (output == null || output.getTaskOutputs() == null) return;
+        for (TaskOutput taskOutput : output.getTaskOutputs()) {
+            Long durationMs =
+                    taskOutput.getDuration() != null ? taskOutput.getDuration().toMillis() : null;
+            long tokenCount =
+                    taskOutput.getMetrics() != null ? taskOutput.getMetrics().getTotalTokens() : -1L;
+            state.addTaskOutput(new TaskOutputSnapshot(
+                    null,
+                    taskOutput.getTaskDescription(),
+                    taskOutput.getRaw(),
+                    durationMs,
+                    tokenCount,
+                    taskOutput.getToolCallCount()));
+        }
+    }
+
+    private void evictCompletedRunsIfNeeded() {
+        List<RunState> terminal = runs.values().stream()
+                .filter(s -> {
+                    Status st = s.getStatus();
+                    return st == Status.COMPLETED || st == Status.FAILED || st == Status.CANCELLED;
+                })
+                .sorted(Comparator.comparing(RunState::getCompletedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+
+        int excess = terminal.size() - maxRetainedRuns;
+        if (excess > 0) {
+            terminal.subList(0, excess).forEach(evicted -> {
+                runs.remove(evicted.getRunId());
+                log.debug("Evicted completed run {} from state map", evicted.getRunId());
+            });
+        }
+    }
+
+    private static String generateRunId() {
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        return "run-" + uuid.substring(0, 8);
+    }
+}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunRequestParser.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunRequestParser.java
@@ -1,0 +1,85 @@
+package net.agentensemble.web;
+
+import java.util.Map;
+import java.util.Objects;
+import net.agentensemble.Ensemble;
+import net.agentensemble.execution.RunOptions;
+
+/**
+ * Converts API run requests into {@link RunConfiguration} values ready for execution.
+ *
+ * <p>In Phase 1 (this implementation), only <strong>Level 1</strong> is supported:
+ * run the pre-configured template ensemble with input variable substitution. The
+ * template ensemble's tasks run as-is; {@code {variable}} placeholders in task
+ * descriptions are resolved by the {@code TemplateResolver} inside
+ * {@code Ensemble.run(inputs, options)}.
+ *
+ * <p>Future phases will add:
+ * <ul>
+ *   <li>Level 2 -- per-task overrides (description, model, tool add/remove)</li>
+ *   <li>Level 3 -- fully dynamic task creation from a JSON task list</li>
+ * </ul>
+ *
+ * <p>Instances are stateless and safe for concurrent use.
+ */
+public final class RunRequestParser {
+
+    private final ToolCatalog toolCatalog;
+    private final ModelCatalog modelCatalog;
+
+    /**
+     * Creates a parser with the given catalog references.
+     *
+     * <p>Catalogs may be {@code null} in Phase 1 (Level 1 parsing does not resolve
+     * tools or models from catalogs). They are retained here for Phase 2+ use.
+     *
+     * @param toolCatalog  the registered tool allowlist; may be null
+     * @param modelCatalog the registered model allowlist; may be null
+     */
+    public RunRequestParser(ToolCatalog toolCatalog, ModelCatalog modelCatalog) {
+        this.toolCatalog = toolCatalog;
+        this.modelCatalog = modelCatalog;
+    }
+
+    /**
+     * Level 1: builds a run configuration from a template ensemble and input variables.
+     *
+     * <p>The template's tasks are run unchanged; {@code {variable}} placeholders are
+     * resolved by the ensemble's own {@code TemplateResolver} at run time.
+     *
+     * @param template the pre-configured template ensemble; must not be null
+     * @param inputs   the input variables to substitute; may be null (treated as empty)
+     * @param options  per-run execution overrides; may be null (uses ensemble defaults)
+     * @return a {@link RunConfiguration} ready for execution via {@link RunManager}
+     * @throws NullPointerException if {@code template} is null
+     */
+    public RunConfiguration buildFromTemplate(Ensemble template, Map<String, String> inputs, RunOptions options) {
+        Objects.requireNonNull(template, "template ensemble must not be null");
+        Map<String, String> effectiveInputs = inputs != null ? Map.copyOf(inputs) : Map.of();
+        RunOptions effectiveOptions = options != null ? options : RunOptions.DEFAULT;
+        return new RunConfiguration(template, effectiveInputs, effectiveOptions);
+    }
+
+    /**
+     * Returns the tool catalog, or {@code null} if not configured.
+     */
+    public ToolCatalog getToolCatalog() {
+        return toolCatalog;
+    }
+
+    /**
+     * Returns the model catalog, or {@code null} if not configured.
+     */
+    public ModelCatalog getModelCatalog() {
+        return modelCatalog;
+    }
+
+    /**
+     * A validated, ready-to-execute run configuration produced by {@link RunRequestParser}.
+     *
+     * @param template the template ensemble to run
+     * @param inputs   the resolved input variables (never null, may be empty)
+     * @param options  the effective run options (never null)
+     */
+    public record RunConfiguration(Ensemble template, Map<String, String> inputs, RunOptions options) {}
+}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunState.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunState.java
@@ -185,10 +185,12 @@ public final class RunState {
     }
 
     /**
-     * Returns a snapshot list of task outputs accumulated so far, in execution order.
+     * Returns an immutable snapshot of task outputs accumulated so far, in execution order.
+     *
+     * <p>Returns a copy so callers can iterate safely without holding the list's intrinsic lock.
      */
     public List<TaskOutputSnapshot> getTaskOutputs() {
-        return Collections.unmodifiableList(taskOutputs);
+        return List.copyOf(taskOutputs);
     }
 
     /**

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunState.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunState.java
@@ -1,0 +1,290 @@
+package net.agentensemble.web;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import net.agentensemble.Ensemble;
+import net.agentensemble.metrics.ExecutionMetrics;
+
+/**
+ * Mutable per-run state record tracked by {@link RunManager}.
+ *
+ * <p>Instances are created by {@link RunManager} when a run is submitted and are updated
+ * as the run transitions through its lifecycle. Thread safety is maintained via
+ * {@link AtomicReference} for status, {@link AtomicInteger} for task counts, and
+ * {@code volatile} for other mutable fields.
+ *
+ * <p>Callers outside the {@code net.agentensemble.web} package should treat instances as
+ * read-only; mutators are package-private.
+ */
+public final class RunState {
+
+    /**
+     * Status values for an API-submitted run's lifecycle.
+     */
+    public enum Status {
+        /**
+         * Run has been accepted and is queued for execution. The concurrency permit has been
+         * acquired; execution has not yet started.
+         */
+        ACCEPTED,
+
+        /**
+         * Run is currently executing on a virtual thread.
+         */
+        RUNNING,
+
+        /**
+         * Run completed successfully (all tasks finished without error).
+         */
+        COMPLETED,
+
+        /**
+         * Run completed with an unhandled exception.
+         */
+        FAILED,
+
+        /**
+         * Run was cancelled cooperatively (flagged before or during execution).
+         */
+        CANCELLED,
+
+        /**
+         * Run was rejected because the maximum concurrent run limit was reached.
+         * No concurrency permit was acquired; the run never executed.
+         */
+        REJECTED
+    }
+
+    // ========================
+    // Immutable fields
+    // ========================
+
+    private final String runId;
+    private final Instant startedAt;
+    private final Map<String, String> inputs;
+    private final Map<String, Object> tags;
+    private final int taskCount;
+    private final String originSessionId;
+
+    // ========================
+    // Mutable fields (thread-safe)
+    // ========================
+
+    private final AtomicReference<Status> status;
+    private final AtomicInteger completedTasks = new AtomicInteger(0);
+    private final List<TaskOutputSnapshot> taskOutputs;
+
+    private volatile Instant completedAt;
+    private volatile String workflow;
+    private volatile ExecutionMetrics metrics;
+    private volatile Ensemble ensemble;
+    private volatile boolean cancelled = false;
+    private volatile String error;
+
+    RunState(
+            String runId,
+            Status initialStatus,
+            Instant startedAt,
+            Map<String, String> inputs,
+            Map<String, Object> tags,
+            int taskCount,
+            String workflow,
+            String originSessionId) {
+        this.runId = runId;
+        this.status = new AtomicReference<>(initialStatus);
+        this.startedAt = startedAt;
+        this.inputs = inputs != null ? Map.copyOf(inputs) : Map.of();
+        this.tags = tags != null ? Map.copyOf(tags) : Map.of();
+        this.taskCount = taskCount;
+        this.workflow = workflow;
+        this.originSessionId = originSessionId;
+        this.taskOutputs = Collections.synchronizedList(new ArrayList<>());
+    }
+
+    // ========================
+    // Public accessors
+    // ========================
+
+    /**
+     * Returns the unique run identifier (e.g. {@code run-7f3a2b}).
+     */
+    public String getRunId() {
+        return runId;
+    }
+
+    /**
+     * Returns the current run status.
+     */
+    public Status getStatus() {
+        return status.get();
+    }
+
+    /**
+     * Returns the instant when the run was submitted (not when execution started).
+     */
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    /**
+     * Returns the instant when the run completed, or {@code null} if still in progress.
+     */
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    /**
+     * Returns the input variables supplied for this run (for template substitution).
+     * May be empty but never null.
+     */
+    public Map<String, String> getInputs() {
+        return inputs;
+    }
+
+    /**
+     * Returns the metadata tags attached to this run for filtering and querying.
+     * May be empty but never null.
+     */
+    public Map<String, Object> getTags() {
+        return tags;
+    }
+
+    /**
+     * Returns the number of tasks in this run (as determined at submission time).
+     */
+    public int getTaskCount() {
+        return taskCount;
+    }
+
+    /**
+     * Returns the number of tasks that have completed so far.
+     */
+    public int getCompletedTasks() {
+        return completedTasks.get();
+    }
+
+    /**
+     * Returns the workflow type (e.g. {@code "SEQUENTIAL"}, {@code "PARALLEL"}),
+     * or {@code null} if not yet determined.
+     */
+    public String getWorkflow() {
+        return workflow;
+    }
+
+    /**
+     * Returns the WebSocket session ID that submitted this run, or {@code null} if
+     * the run was submitted via HTTP (not WebSocket).
+     */
+    public String getOriginSessionId() {
+        return originSessionId;
+    }
+
+    /**
+     * Returns a snapshot list of task outputs accumulated so far, in execution order.
+     */
+    public List<TaskOutputSnapshot> getTaskOutputs() {
+        return Collections.unmodifiableList(taskOutputs);
+    }
+
+    /**
+     * Returns the aggregated execution metrics for this run, or {@code null} if not yet
+     * available (run is still in progress or metrics collection was not enabled).
+     */
+    public ExecutionMetrics getMetrics() {
+        return metrics;
+    }
+
+    /**
+     * Returns the live {@link Ensemble} reference for control operations (e.g. model switching).
+     * May be {@code null} before execution starts.
+     */
+    public Ensemble getEnsemble() {
+        return ensemble;
+    }
+
+    /**
+     * Returns {@code true} if this run has been flagged for cooperative cancellation.
+     * The run will stop at the next task boundary.
+     */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Returns the error message if the run failed, or {@code null} otherwise.
+     */
+    public String getError() {
+        return error;
+    }
+
+    // ========================
+    // Package-private mutators (called exclusively by RunManager)
+    // ========================
+
+    void transitionTo(Status newStatus) {
+        status.set(newStatus);
+    }
+
+    boolean compareAndSetStatus(Status expected, Status update) {
+        return status.compareAndSet(expected, update);
+    }
+
+    void setCompletedAt(Instant time) {
+        this.completedAt = time;
+    }
+
+    void setWorkflow(String workflow) {
+        this.workflow = workflow;
+    }
+
+    void incrementCompletedTasks() {
+        completedTasks.incrementAndGet();
+    }
+
+    void setMetrics(ExecutionMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    void setEnsemble(Ensemble ensemble) {
+        this.ensemble = ensemble;
+    }
+
+    void cancel() {
+        this.cancelled = true;
+    }
+
+    void setError(String error) {
+        this.error = error;
+    }
+
+    void addTaskOutput(TaskOutputSnapshot snapshot) {
+        taskOutputs.add(snapshot);
+    }
+
+    // ========================
+    // Nested types
+    // ========================
+
+    /**
+     * Immutable snapshot of a single completed task's output, for API responses.
+     *
+     * @param taskName       the task name (if set) or description prefix
+     * @param taskDescription the full task description
+     * @param output         the raw text output from the agent
+     * @param durationMs     how long the task took in milliseconds
+     * @param tokenCount     total tokens consumed ({@code -1} if unknown)
+     * @param toolCallCount  number of tool invocations during execution
+     */
+    public record TaskOutputSnapshot(
+            String taskName,
+            String taskDescription,
+            String output,
+            Long durationMs,
+            Long tokenCount,
+            int toolCallCount) {}
+}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/ToolCatalog.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/ToolCatalog.java
@@ -1,0 +1,159 @@
+package net.agentensemble.web;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import net.agentensemble.tool.AgentTool;
+
+/**
+ * Registry mapping tool names to {@link AgentTool} instances for the Ensemble Control API.
+ *
+ * <p>Tools registered here form the server-side allowlist for API-submitted runs. Clients
+ * reference tools by name in API requests; only registered tools can be used. This prevents
+ * arbitrary tool invocation from external callers.
+ *
+ * <pre>
+ * ToolCatalog catalog = ToolCatalog.builder()
+ *     .tool("web_search", webSearchTool)
+ *     .tool("calculator", calculatorTool)
+ *     .build();
+ * </pre>
+ *
+ * <p>Registered via {@link WebDashboard.Builder#toolCatalog(ToolCatalog)}:
+ *
+ * <pre>
+ * WebDashboard dashboard = WebDashboard.builder()
+ *     .port(7329)
+ *     .toolCatalog(catalog)
+ *     .build();
+ * </pre>
+ */
+public final class ToolCatalog {
+
+    private final Map<String, AgentTool> tools;
+
+    private ToolCatalog(Builder builder) {
+        this.tools = Collections.unmodifiableMap(new LinkedHashMap<>(builder.tools));
+    }
+
+    /**
+     * Returns a new builder for constructing a {@link ToolCatalog}.
+     *
+     * @return a new Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Resolves the tool with the given name.
+     *
+     * @param name the tool name; must not be null
+     * @return the registered {@link AgentTool}
+     * @throws NoSuchElementException if no tool is registered with the given name
+     */
+    public AgentTool resolve(String name) {
+        AgentTool tool = tools.get(name);
+        if (tool == null) {
+            List<String> available = tools.keySet().stream().sorted().toList();
+            throw new NoSuchElementException("Unknown tool '" + name + "'. Available: " + available);
+        }
+        return tool;
+    }
+
+    /**
+     * Returns the tool with the given name, or empty if not found.
+     *
+     * @param name the tool name
+     * @return an Optional containing the tool, or empty
+     */
+    public Optional<AgentTool> find(String name) {
+        return Optional.ofNullable(tools.get(name));
+    }
+
+    /**
+     * Returns a list of all registered tool descriptions, in registration order.
+     *
+     * @return unmodifiable list of {@link ToolInfo} records
+     */
+    public List<ToolInfo> list() {
+        return tools.entrySet().stream()
+                .map(e -> new ToolInfo(e.getKey(), e.getValue().description()))
+                .toList();
+    }
+
+    /**
+     * Returns {@code true} if a tool with the given name is registered.
+     *
+     * @param name the tool name
+     * @return true if registered
+     */
+    public boolean contains(String name) {
+        return tools.containsKey(name);
+    }
+
+    /**
+     * Returns the number of registered tools.
+     *
+     * @return tool count
+     */
+    public int size() {
+        return tools.size();
+    }
+
+    /**
+     * Descriptive snapshot of a registered tool returned by {@link #list()}.
+     *
+     * @param name        the tool name clients use in API requests
+     * @param description the tool's description as returned by {@link AgentTool#description()}
+     */
+    public record ToolInfo(String name, String description) {}
+
+    /**
+     * Fluent builder for {@link ToolCatalog}.
+     *
+     * <p>Tools are stored in insertion order. Attempting to register the same name twice
+     * throws {@link IllegalArgumentException} at builder time (fail-fast).
+     */
+    public static final class Builder {
+
+        private final Map<String, AgentTool> tools = new LinkedHashMap<>();
+
+        private Builder() {}
+
+        /**
+         * Registers a tool under the given name.
+         *
+         * @param name the name clients use to reference this tool; must not be null or blank
+         * @param tool the tool implementation; must not be null
+         * @return this builder
+         * @throws IllegalArgumentException if the name is null/blank or already registered,
+         *                                  or if the tool is null
+         */
+        public Builder tool(String name, AgentTool tool) {
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("tool name must not be null or blank");
+            }
+            if (tool == null) {
+                throw new IllegalArgumentException("tool must not be null (name: '" + name + "')");
+            }
+            if (tools.containsKey(name)) {
+                throw new IllegalArgumentException("duplicate tool name: '" + name + "'");
+            }
+            tools.put(name, tool);
+            return this;
+        }
+
+        /**
+         * Builds and returns the {@link ToolCatalog}.
+         *
+         * @return a new, immutable ToolCatalog
+         */
+        public ToolCatalog build() {
+            return new ToolCatalog(this);
+        }
+    }
+}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
@@ -190,7 +190,8 @@ public final class WebDashboard implements EnsembleDashboard {
 
     /**
      * Manages async run lifecycle: concurrency limiting, state tracking, eviction.
-     * Null when the Control API is not configured (no toolCatalog or modelCatalog set).
+     * Always created (never null); the Control API endpoints use it regardless of whether
+     * optional catalogs (toolCatalog/modelCatalog) are configured.
      */
     private final RunManager runManager;
 

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
@@ -169,6 +169,31 @@ public final class WebDashboard implements EnsembleDashboard {
     /** Virtual-thread executor for processing incoming work requests asynchronously. */
     private final ExecutorService requestExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
+    // ========================
+    // Ensemble Control API fields (Phase 1)
+    // ========================
+
+    /**
+     * Optional tool registry for API-submitted runs. Null when the Control API is not
+     * configured; REST endpoints return 503 in that case.
+     */
+    private final ToolCatalog toolCatalog;
+
+    /**
+     * Optional model registry for API-submitted runs. Null when the Control API is not
+     * configured.
+     */
+    private final ModelCatalog modelCatalog;
+
+    /** Parses API run requests into executable ensemble configurations. */
+    private final RunRequestParser runRequestParser;
+
+    /**
+     * Manages async run lifecycle: concurrency limiting, state tracking, eviction.
+     * Null when the Control API is not configured (no toolCatalog or modelCatalog set).
+     */
+    private final RunManager runManager;
+
     private WebDashboard(Builder builder) {
         this.port = builder.port;
         this.host = builder.host;
@@ -180,6 +205,10 @@ public final class WebDashboard implements EnsembleDashboard {
         this.configuredTraceExporter = traceExportDir != null ? new JsonTraceExporter(traceExportDir) : null;
 
         this.maxSnapshotIterations = builder.maxSnapshotIterations;
+        this.toolCatalog = builder.toolCatalog;
+        this.modelCatalog = builder.modelCatalog;
+        this.runRequestParser = new RunRequestParser(toolCatalog, modelCatalog);
+        this.runManager = new RunManager(builder.maxConcurrentRuns, builder.maxRetainedCompletedRuns);
 
         this.serializer = new MessageSerializer();
         this.connectionManager = new ConnectionManager(serializer, maxRetainedRuns, maxSnapshotIterations);
@@ -192,6 +221,12 @@ public final class WebDashboard implements EnsembleDashboard {
         if (workspacePath != null) {
             this.server.setWorkspacePath(workspacePath);
         }
+        this.server.setRunManager(runManager);
+        this.server.setRunRequestParser(runRequestParser);
+        this.server.setToolCatalog(toolCatalog);
+        this.server.setModelCatalog(modelCatalog);
+        // Provide a supplier so routes can access the template ensemble set via setEnsemble()
+        this.server.setEnsembleSupplier(() -> this.ensemble);
         this.streamingListener = new WebSocketStreamingListener(connectionManager, serializer);
         this.reviewHandler = new WebReviewHandler(connectionManager, serializer, reviewTimeout, onTimeout);
     }
@@ -285,6 +320,7 @@ public final class WebDashboard implements EnsembleDashboard {
         if (wasRunning) {
             heartbeatScheduler.shutdownNow();
             requestExecutor.shutdownNow();
+            runManager.shutdown();
             try {
                 if (!heartbeatScheduler.awaitTermination(2, TimeUnit.SECONDS)) {
                     log.warn("Heartbeat scheduler did not terminate within 2 seconds");
@@ -747,6 +783,12 @@ public final class WebDashboard implements EnsembleDashboard {
         private int maxSnapshotIterations = 5;
         private Path workspacePath = null;
 
+        // Ensemble Control API (Phase 1)
+        private ToolCatalog toolCatalog = null;
+        private ModelCatalog modelCatalog = null;
+        private int maxConcurrentRuns = 5;
+        private int maxRetainedCompletedRuns = 100;
+
         private Builder() {}
 
         /**
@@ -895,6 +937,72 @@ public final class WebDashboard implements EnsembleDashboard {
         }
 
         /**
+         * Sets the tool registry for the Ensemble Control API.
+         *
+         * <p>When set, external callers can reference tools by name in {@code POST /api/runs}
+         * requests (Level 2+ parameterization). In Phase 1 (Level 1), the catalog is used
+         * for capability discovery via {@code GET /api/capabilities}.
+         *
+         * @param toolCatalog the tool registry; may be {@code null} to disable tool catalog
+         *                    (Level 2+ tool references will fail with 503)
+         * @return this builder
+         */
+        public Builder toolCatalog(ToolCatalog toolCatalog) {
+            this.toolCatalog = toolCatalog;
+            return this;
+        }
+
+        /**
+         * Sets the model registry for the Ensemble Control API.
+         *
+         * <p>When set, external callers can reference models by alias in {@code POST /api/runs}
+         * requests (Level 2+ parameterization). In Phase 1 (Level 1), the catalog is used
+         * for capability discovery via {@code GET /api/capabilities}.
+         *
+         * @param modelCatalog the model registry; may be {@code null} to disable model catalog
+         * @return this builder
+         */
+        public Builder modelCatalog(ModelCatalog modelCatalog) {
+            this.modelCatalog = modelCatalog;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of ensemble runs that may execute concurrently via the
+         * {@code POST /api/runs} endpoint.
+         *
+         * <p>When this limit is reached, new run submissions are rejected with HTTP 429.
+         * Default: {@code 5}.
+         *
+         * @param maxConcurrentRuns the concurrency cap; must be &ge; 1
+         * @return this builder
+         * @throws IllegalArgumentException when {@code maxConcurrentRuns} is less than 1
+         *                                  (validated at {@link #build()} time)
+         */
+        public Builder maxConcurrentRuns(int maxConcurrentRuns) {
+            this.maxConcurrentRuns = maxConcurrentRuns;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of completed (and failed/cancelled) runs retained in
+         * memory for state queries via {@code GET /api/runs}.
+         *
+         * <p>When a run completes and the total number of terminal runs exceeds this cap,
+         * the oldest completed run is evicted. Active runs (ACCEPTED/RUNNING) are never
+         * evicted. Default: {@code 100}.
+         *
+         * @param maxRetainedCompletedRuns the retention cap for completed runs; must be &ge; 1
+         * @return this builder
+         * @throws IllegalArgumentException when {@code maxRetainedCompletedRuns} is less
+         *                                  than 1 (validated at {@link #build()} time)
+         */
+        public Builder maxRetainedCompletedRuns(int maxRetainedCompletedRuns) {
+            this.maxRetainedCompletedRuns = maxRetainedCompletedRuns;
+            return this;
+        }
+
+        /**
          * Validates configuration and constructs the {@link WebDashboard}.
          *
          * <p>The returned dashboard is not yet started; call {@link WebDashboard#start()}
@@ -925,6 +1033,13 @@ public final class WebDashboard implements EnsembleDashboard {
                 throw new IllegalArgumentException(
                         "maxSnapshotIterations must be >= 0 (0 disables iteration snapshots); got: "
                                 + maxSnapshotIterations);
+            }
+            if (maxConcurrentRuns < 1) {
+                throw new IllegalArgumentException("maxConcurrentRuns must be >= 1; got: " + maxConcurrentRuns);
+            }
+            if (maxRetainedCompletedRuns < 1) {
+                throw new IllegalArgumentException(
+                        "maxRetainedCompletedRuns must be >= 1; got: " + maxRetainedCompletedRuns);
             }
             return new WebDashboard(this);
         }

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
@@ -75,6 +75,28 @@ class WebSocketServer {
     /** Optional workspace root path for file browsing endpoints. Null if not configured. */
     private volatile java.nio.file.Path workspacePath;
 
+    // ========================
+    // Ensemble Control API fields (Phase 1)
+    // ========================
+
+    /** RunManager for tracking and executing API-submitted runs. */
+    private volatile RunManager runManager;
+
+    /** Parser for converting API request bodies into run configurations. */
+    private volatile RunRequestParser runRequestParser;
+
+    /** Tool registry for the capabilities endpoint. Null when not configured. */
+    private volatile ToolCatalog toolCatalog;
+
+    /** Model registry for the capabilities endpoint. Null when not configured. */
+    private volatile ModelCatalog modelCatalog;
+
+    /**
+     * Supplier for the template ensemble (set via WebDashboard.setEnsemble()).
+     * Used by POST /api/runs to obtain the ensemble to run.
+     */
+    private volatile java.util.function.Supplier<net.agentensemble.Ensemble> ensembleSupplier;
+
     WebSocketServer(
             ConnectionManager connectionManager,
             MessageSerializer serializer,
@@ -314,6 +336,270 @@ class WebSocketServer {
                     ctx.json(Map.of("error", "Failed to read file"));
                 }
             });
+
+            // ========================
+            // Ensemble Control API endpoints (Phase 1)
+            // ========================
+
+            // POST /api/runs -- submit a Level 1 run (template + variable inputs)
+            config.routes.post("/api/runs", ctx -> {
+                RunManager rm = runManager;
+                if (rm == null) {
+                    ctx.status(503);
+                    ctx.json(
+                            Map.of(
+                                    "error",
+                                    "NOT_CONFIGURED",
+                                    "message",
+                                    "Ensemble Control API not configured. Set toolCatalog/modelCatalog on WebDashboard.builder()."));
+                    return;
+                }
+
+                java.util.function.Supplier<net.agentensemble.Ensemble> supplier = ensembleSupplier;
+                net.agentensemble.Ensemble template = supplier != null ? supplier.get() : null;
+                if (template == null) {
+                    ctx.status(503);
+                    ctx.json(
+                            Map.of(
+                                    "error",
+                                    "NOT_CONFIGURED",
+                                    "message",
+                                    "No template ensemble configured. Wire an Ensemble via Ensemble.builder().webDashboard(dashboard)."));
+                    return;
+                }
+
+                com.fasterxml.jackson.databind.JsonNode body;
+                try {
+                    String bodyStr = ctx.body();
+                    if (bodyStr == null || bodyStr.isBlank()) {
+                        body = serializer.toJsonNode("{}");
+                    } else {
+                        body = serializer.toJsonNode(bodyStr);
+                    }
+                } catch (Exception e) {
+                    ctx.status(400);
+                    ctx.json(Map.of("error", "BAD_REQUEST", "message", "Invalid JSON body: " + e.getMessage()));
+                    return;
+                }
+                // toJsonNode returns null for invalid JSON (does not throw)
+                if (body == null) {
+                    ctx.status(400);
+                    ctx.json(Map.of("error", "BAD_REQUEST", "message", "Invalid or unparseable JSON body"));
+                    return;
+                }
+
+                Map<String, String> inputs = new java.util.LinkedHashMap<>();
+                com.fasterxml.jackson.databind.JsonNode inputsNode = body.get("inputs");
+                if (inputsNode != null && inputsNode.isObject()) {
+                    inputsNode.fields().forEachRemaining(entry -> {
+                        if (entry.getValue().isTextual()) {
+                            inputs.put(entry.getKey(), entry.getValue().asText());
+                        }
+                    });
+                }
+
+                Map<String, Object> tags = new java.util.LinkedHashMap<>();
+                com.fasterxml.jackson.databind.JsonNode tagsNode = body.get("tags");
+                if (tagsNode != null && tagsNode.isObject()) {
+                    tagsNode.fields()
+                            .forEachRemaining(entry ->
+                                    tags.put(entry.getKey(), entry.getValue().asText()));
+                }
+
+                RunState state = rm.submitRun(template, inputs, tags, null, null, null);
+
+                if (state.getStatus() == RunState.Status.REJECTED) {
+                    ctx.status(429);
+                    ctx.json(Map.of(
+                            "error",
+                            "CONCURRENCY_LIMIT",
+                            "message",
+                            "Maximum concurrent runs (" + rm.getMaxConcurrentRuns() + ") reached. Retry later.",
+                            "retryAfterMs",
+                            5000));
+                    return;
+                }
+
+                ctx.status(202);
+                ctx.json(Map.of(
+                        "runId", state.getRunId(),
+                        "status", state.getStatus().name(),
+                        "tasks", state.getTaskCount(),
+                        "workflow", state.getWorkflow() != null ? state.getWorkflow() : "SEQUENTIAL"));
+            });
+
+            // GET /api/runs -- list retained runs with optional status/tag filtering
+            config.routes.get("/api/runs", ctx -> {
+                RunManager rm = runManager;
+                if (rm == null) {
+                    ctx.status(503);
+                    ctx.json(Map.of("error", "NOT_CONFIGURED", "message", "Ensemble Control API not configured."));
+                    return;
+                }
+
+                String statusParam = ctx.queryParam("status");
+                RunState.Status statusFilter = null;
+                if (statusParam != null && !statusParam.isBlank()) {
+                    try {
+                        statusFilter = RunState.Status.valueOf(statusParam.toUpperCase(java.util.Locale.ROOT));
+                    } catch (IllegalArgumentException e) {
+                        ctx.status(400);
+                        ctx.json(Map.of("error", "BAD_REQUEST", "message", "Unknown status: " + statusParam));
+                        return;
+                    }
+                }
+
+                String tagParam = ctx.queryParam("tag");
+                String tagKey = null;
+                String tagValue = null;
+                if (tagParam != null && !tagParam.isBlank()) {
+                    int colonIdx = tagParam.indexOf(':');
+                    if (colonIdx > 0) {
+                        tagKey = tagParam.substring(0, colonIdx);
+                        tagValue = tagParam.substring(colonIdx + 1);
+                    } else {
+                        tagKey = tagParam;
+                    }
+                }
+
+                java.util.List<RunState> runs = rm.listRuns(statusFilter, tagKey, tagValue);
+                java.util.List<Map<String, Object>> runList = new java.util.ArrayList<>();
+                for (RunState rs : runs) {
+                    Map<String, Object> summary = new java.util.LinkedHashMap<>();
+                    summary.put("runId", rs.getRunId());
+                    summary.put("status", rs.getStatus().name());
+                    summary.put("startedAt", rs.getStartedAt().toString());
+                    if (rs.getCompletedAt() != null) {
+                        summary.put(
+                                "durationMs",
+                                rs.getCompletedAt().toEpochMilli()
+                                        - rs.getStartedAt().toEpochMilli());
+                    } else {
+                        summary.put("durationMs", null);
+                    }
+                    summary.put("taskCount", rs.getTaskCount());
+                    summary.put("completedTasks", rs.getCompletedTasks());
+                    if (rs.getWorkflow() != null) {
+                        summary.put("workflow", rs.getWorkflow());
+                    }
+                    summary.put("tags", rs.getTags());
+                    runList.add(summary);
+                }
+
+                Map<String, Object> response = new java.util.LinkedHashMap<>();
+                response.put("runs", runList);
+                response.put("total", runList.size());
+                ctx.json(response);
+            });
+
+            // GET /api/runs/{runId} -- get full detail for a specific run
+            config.routes.get("/api/runs/{runId}", ctx -> {
+                RunManager rm = runManager;
+                if (rm == null) {
+                    ctx.status(503);
+                    ctx.json(Map.of("error", "NOT_CONFIGURED", "message", "Ensemble Control API not configured."));
+                    return;
+                }
+
+                String runId = ctx.pathParam("runId");
+                java.util.Optional<RunState> found = rm.getRun(runId);
+                if (found.isEmpty()) {
+                    ctx.status(404);
+                    ctx.json(Map.of("error", "RUN_NOT_FOUND", "message", "No run with ID " + runId));
+                    return;
+                }
+
+                RunState rs = found.get();
+                Map<String, Object> detail = new java.util.LinkedHashMap<>();
+                detail.put("runId", rs.getRunId());
+                detail.put("status", rs.getStatus().name());
+                detail.put("startedAt", rs.getStartedAt().toString());
+                if (rs.getCompletedAt() != null) {
+                    detail.put("completedAt", rs.getCompletedAt().toString());
+                    detail.put(
+                            "durationMs",
+                            rs.getCompletedAt().toEpochMilli()
+                                    - rs.getStartedAt().toEpochMilli());
+                }
+                if (rs.getWorkflow() != null) {
+                    detail.put("workflow", rs.getWorkflow());
+                }
+                detail.put("inputs", rs.getInputs());
+                detail.put("tags", rs.getTags());
+
+                // Task output snapshots
+                java.util.List<Map<String, Object>> tasksList = new java.util.ArrayList<>();
+                for (RunState.TaskOutputSnapshot snap : rs.getTaskOutputs()) {
+                    Map<String, Object> taskDetail = new java.util.LinkedHashMap<>();
+                    taskDetail.put("taskDescription", snap.taskDescription());
+                    taskDetail.put("output", snap.output());
+                    if (snap.durationMs() != null) taskDetail.put("durationMs", snap.durationMs());
+                    if (snap.tokenCount() != null && snap.tokenCount() != -1L)
+                        taskDetail.put("tokenCount", snap.tokenCount());
+                    taskDetail.put("toolCallCount", snap.toolCallCount());
+                    tasksList.add(taskDetail);
+                }
+                detail.put("tasks", tasksList);
+
+                if (rs.getMetrics() != null) {
+                    Map<String, Object> metricsMap = new java.util.LinkedHashMap<>();
+                    metricsMap.put("totalTokens", rs.getMetrics().getTotalTokens());
+                    metricsMap.put("totalToolCalls", rs.getMetrics().getTotalToolCalls());
+                    detail.put("metrics", metricsMap);
+                }
+
+                if (rs.getError() != null) {
+                    detail.put("error", rs.getError());
+                }
+
+                ctx.json(detail);
+            });
+
+            // GET /api/capabilities -- list registered tools, models, and preconfigured tasks
+            config.routes.get("/api/capabilities", ctx -> {
+                Map<String, Object> capabilities = new java.util.LinkedHashMap<>();
+
+                // Tools
+                ToolCatalog tc = toolCatalog;
+                if (tc != null) {
+                    java.util.List<Map<String, String>> toolsList = new java.util.ArrayList<>();
+                    for (ToolCatalog.ToolInfo info : tc.list()) {
+                        toolsList.add(Map.of("name", info.name(), "description", info.description()));
+                    }
+                    capabilities.put("tools", toolsList);
+                } else {
+                    capabilities.put("tools", java.util.List.of());
+                }
+
+                // Models
+                ModelCatalog mc = modelCatalog;
+                if (mc != null) {
+                    java.util.List<Map<String, String>> modelsList = new java.util.ArrayList<>();
+                    for (ModelCatalog.ModelInfo info : mc.list()) {
+                        modelsList.add(Map.of("alias", info.alias(), "provider", info.provider()));
+                    }
+                    capabilities.put("models", modelsList);
+                } else {
+                    capabilities.put("models", java.util.List.of());
+                }
+
+                // Preconfigured tasks from the template ensemble
+                java.util.function.Supplier<net.agentensemble.Ensemble> supplier = ensembleSupplier;
+                net.agentensemble.Ensemble template = supplier != null ? supplier.get() : null;
+                if (template != null && template.getTasks() != null) {
+                    java.util.List<Map<String, Object>> tasksList = new java.util.ArrayList<>();
+                    for (net.agentensemble.Task t : template.getTasks()) {
+                        Map<String, Object> taskInfo = new java.util.LinkedHashMap<>();
+                        taskInfo.put("description", t.getDescription());
+                        tasksList.add(taskInfo);
+                    }
+                    capabilities.put("preconfiguredTasks", tasksList);
+                } else {
+                    capabilities.put("preconfiguredTasks", java.util.List.of());
+                }
+
+                ctx.json(capabilities);
+            });
         });
 
         app.start(host, port);
@@ -423,6 +709,56 @@ class WebSocketServer {
      */
     void setWorkspacePath(java.nio.file.Path path) {
         this.workspacePath = path;
+    }
+
+    // ========================
+    // Ensemble Control API setters (Phase 1)
+    // ========================
+
+    /**
+     * Sets the {@link RunManager} for the {@code POST /api/runs} and {@code GET /api/runs}
+     * endpoints.
+     *
+     * @param runManager the run manager; may be null to disable the Control API endpoints
+     */
+    void setRunManager(RunManager runManager) {
+        this.runManager = runManager;
+    }
+
+    /**
+     * Sets the {@link RunRequestParser} for parsing API run request bodies.
+     *
+     * @param runRequestParser the parser; may be null
+     */
+    void setRunRequestParser(RunRequestParser runRequestParser) {
+        this.runRequestParser = runRequestParser;
+    }
+
+    /**
+     * Sets the {@link ToolCatalog} for the {@code GET /api/capabilities} endpoint.
+     *
+     * @param toolCatalog the catalog; may be null
+     */
+    void setToolCatalog(ToolCatalog toolCatalog) {
+        this.toolCatalog = toolCatalog;
+    }
+
+    /**
+     * Sets the {@link ModelCatalog} for the {@code GET /api/capabilities} endpoint.
+     *
+     * @param modelCatalog the catalog; may be null
+     */
+    void setModelCatalog(ModelCatalog modelCatalog) {
+        this.modelCatalog = modelCatalog;
+    }
+
+    /**
+     * Sets the supplier that provides the template ensemble for API-submitted runs.
+     *
+     * @param supplier a supplier returning the current template ensemble; may be null
+     */
+    void setEnsembleSupplier(java.util.function.Supplier<net.agentensemble.Ensemble> supplier) {
+        this.ensembleSupplier = supplier;
     }
 
     // ========================

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
@@ -82,7 +82,11 @@ class WebSocketServer {
     /** RunManager for tracking and executing API-submitted runs. */
     private volatile RunManager runManager;
 
-    /** Parser for converting API request bodies into run configurations. */
+    /**
+     * Parser configuration retained for Phase 2+ use; request parsing is currently
+     * performed inline in the route handlers.
+     */
+    @SuppressWarnings("unused")
     private volatile RunRequestParser runRequestParser;
 
     /** Tool registry for the capabilities endpoint. Null when not configured. */
@@ -343,17 +347,8 @@ class WebSocketServer {
 
             // POST /api/runs -- submit a Level 1 run (template + variable inputs)
             config.routes.post("/api/runs", ctx -> {
+                // RunManager is always created by WebDashboard; use it directly.
                 RunManager rm = runManager;
-                if (rm == null) {
-                    ctx.status(503);
-                    ctx.json(
-                            Map.of(
-                                    "error",
-                                    "NOT_CONFIGURED",
-                                    "message",
-                                    "Ensemble Control API not configured. Set toolCatalog/modelCatalog on WebDashboard.builder()."));
-                    return;
-                }
 
                 java.util.function.Supplier<net.agentensemble.Ensemble> supplier = ensembleSupplier;
                 net.agentensemble.Ensemble template = supplier != null ? supplier.get() : null;

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
@@ -418,7 +418,7 @@ class WebSocketServer {
                 ctx.status(202);
                 ctx.json(Map.of(
                         "runId", state.getRunId(),
-                        "status", state.getStatus().name(),
+                        "status", RunState.Status.ACCEPTED.name(),
                         "tasks", state.getTaskCount(),
                         "workflow", state.getWorkflow() != null ? state.getWorkflow() : "SEQUENTIAL"));
             });

--- a/agentensemble-web/src/main/java/net/agentensemble/web/protocol/RunAckMessage.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/protocol/RunAckMessage.java
@@ -1,0 +1,21 @@
+package net.agentensemble.web.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Server-to-client message acknowledging a submitted ensemble run.
+ *
+ * <p>Sent immediately when a run is accepted (before execution begins) or rejected (when
+ * the concurrency limit is reached).
+ *
+ * @param requestId the client-provided request identifier; may be {@code null} for REST
+ *                  submissions that do not supply one
+ * @param runId     the server-assigned unique run identifier (e.g. {@code "run-7f3a2b"})
+ * @param status    the initial run status: {@code "ACCEPTED"} or {@code "REJECTED"}
+ * @param tasks     the number of tasks in the run (0 when rejected)
+ * @param workflow  the inferred workflow type (e.g. {@code "SEQUENTIAL"}), or {@code null}
+ *                  when not yet determined
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RunAckMessage(String requestId, String runId, String status, int tasks, String workflow)
+        implements ServerMessage {}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/protocol/RunResultMessage.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/protocol/RunResultMessage.java
@@ -1,0 +1,45 @@
+package net.agentensemble.web.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * Server-to-client message containing the final result of a completed ensemble run.
+ *
+ * <p>Sent to the originating session when a run finishes — whether successfully,
+ * with an error, or cancelled. The existing {@link EnsembleCompletedMessage} continues
+ * to broadcast to <em>all</em> connected sessions (for viz compatibility); this message
+ * carries the full task outputs and is targeted only at the submitting session.
+ *
+ * @param runId      the unique run identifier
+ * @param status     the final status: {@code "COMPLETED"}, {@code "FAILED"}, or
+ *                   {@code "CANCELLED"}
+ * @param outputs    the task outputs in execution order; may be empty on failure
+ * @param durationMs total run duration in milliseconds
+ * @param metrics    aggregated execution metrics, or {@code null} if not collected
+ * @param error      error message if the run failed, or {@code null}
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RunResultMessage(
+        String runId, String status, List<TaskOutputDto> outputs, Long durationMs, MetricsDto metrics, String error)
+        implements ServerMessage {
+
+    /**
+     * Snapshot of a single task's output within a run result.
+     *
+     * @param taskName   the task description (used as the name in Phase 1 before
+     *                   the optional {@code name} field is added to {@code Task})
+     * @param output     the raw text output from the agent
+     * @param durationMs how long the task took in milliseconds
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record TaskOutputDto(String taskName, String output, Long durationMs) {}
+
+    /**
+     * Aggregated execution metrics for an entire run.
+     *
+     * @param totalTokens    total tokens consumed across all tasks ({@code -1} if unknown)
+     * @param totalToolCalls total tool invocations across all tasks
+     */
+    public record MetricsDto(long totalTokens, long totalToolCalls) {}
+}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/protocol/ServerMessage.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/protocol/ServerMessage.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  *   <li>{@link TokenMessage} -- sent for each token during streaming final response generation</li>
  *   <li>{@link FileChangedMessage} -- sent when a coding tool modifies a file</li>
  *   <li>{@link MetricsSnapshotMessage} -- sent with cumulative agent metrics after each LLM iteration</li>
+ *   <li>{@link RunAckMessage} -- acknowledges a submitted API run (ACCEPTED or REJECTED)</li>
+ *   <li>{@link RunResultMessage} -- final result of a completed API run, targeted at originator</li>
  * </ul>
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.PROPERTY)
@@ -62,6 +64,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = LlmIterationCompletedMessage.class, name = "llm_iteration_completed"),
     @JsonSubTypes.Type(value = FileChangedMessage.class, name = "file_changed"),
     @JsonSubTypes.Type(value = MetricsSnapshotMessage.class, name = "metrics_snapshot"),
+    @JsonSubTypes.Type(value = RunAckMessage.class, name = "run_ack"),
+    @JsonSubTypes.Type(value = RunResultMessage.class, name = "run_result"),
 })
 public sealed interface ServerMessage
         permits HelloMessage,
@@ -92,4 +96,6 @@ public sealed interface ServerMessage
                 LlmIterationStartedMessage,
                 LlmIterationCompletedMessage,
                 FileChangedMessage,
-                MetricsSnapshotMessage {}
+                MetricsSnapshotMessage,
+                RunAckMessage,
+                RunResultMessage {}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/ModelCatalogTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/ModelCatalogTest.java
@@ -1,0 +1,286 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ModelCatalog}: builder validation, resolution, streaming, listing.
+ */
+class ModelCatalogTest {
+
+    private ChatModel sonnetModel;
+    private ChatModel opusModel;
+    private StreamingChatModel streamingSonnet;
+
+    @BeforeEach
+    void setUp() {
+        sonnetModel = mock(ChatModel.class);
+        opusModel = mock(ChatModel.class);
+        streamingSonnet = mock(StreamingChatModel.class);
+    }
+
+    // ========================
+    // Builder validation
+    // ========================
+
+    @Test
+    void builder_nullAlias_throws() {
+        assertThatThrownBy(() -> ModelCatalog.builder().model(null, sonnetModel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("model alias must not be null or blank");
+    }
+
+    @Test
+    void builder_blankAlias_throws() {
+        assertThatThrownBy(() -> ModelCatalog.builder().model("", sonnetModel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("model alias must not be null or blank");
+    }
+
+    @Test
+    void builder_nullModel_throws() {
+        assertThatThrownBy(() -> ModelCatalog.builder().model("sonnet", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("model must not be null");
+    }
+
+    @Test
+    void builder_duplicateAlias_throws() {
+        assertThatThrownBy(() ->
+                        ModelCatalog.builder().model("sonnet", sonnetModel).model("sonnet", opusModel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate model alias: 'sonnet'");
+    }
+
+    @Test
+    void builder_nullStreamingModel_throws() {
+        assertThatThrownBy(() -> ModelCatalog.builder().model("sonnet", sonnetModel, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("streamingModel must not be null");
+    }
+
+    @Test
+    void builder_emptyBuild_producesEmptyCatalog() {
+        ModelCatalog catalog = ModelCatalog.builder().build();
+        assertThat(catalog.size()).isZero();
+        assertThat(catalog.list()).isEmpty();
+    }
+
+    // ========================
+    // resolve
+    // ========================
+
+    @Test
+    void resolve_knownAlias_returnsCorrectModel() {
+        ModelCatalog catalog = ModelCatalog.builder()
+                .model("sonnet", sonnetModel)
+                .model("opus", opusModel)
+                .build();
+
+        assertThat(catalog.resolve("sonnet")).isSameAs(sonnetModel);
+        assertThat(catalog.resolve("opus")).isSameAs(opusModel);
+    }
+
+    @Test
+    void resolve_unknownAlias_throwsWithHelpfulMessage() {
+        ModelCatalog catalog =
+                ModelCatalog.builder().model("sonnet", sonnetModel).build();
+
+        assertThatThrownBy(() -> catalog.resolve("gpt-4"))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("Unknown model 'gpt-4'")
+                .hasMessageContaining("sonnet");
+    }
+
+    // ========================
+    // find
+    // ========================
+
+    @Test
+    void find_knownAlias_returnsNonEmpty() {
+        ModelCatalog catalog =
+                ModelCatalog.builder().model("sonnet", sonnetModel).build();
+        Optional<ChatModel> found = catalog.find("sonnet");
+        assertThat(found).isPresent().contains(sonnetModel);
+    }
+
+    @Test
+    void find_unknownAlias_returnsEmpty() {
+        ModelCatalog catalog =
+                ModelCatalog.builder().model("sonnet", sonnetModel).build();
+        assertThat(catalog.find("unknown")).isEmpty();
+    }
+
+    // ========================
+    // resolveStreaming
+    // ========================
+
+    @Test
+    void resolveStreaming_whenRegistered_returnsStreamingModel() {
+        ModelCatalog catalog = ModelCatalog.builder()
+                .model("sonnet", sonnetModel, streamingSonnet)
+                .build();
+
+        assertThat(catalog.resolveStreaming("sonnet")).isSameAs(streamingSonnet);
+    }
+
+    @Test
+    void resolveStreaming_whenNotRegistered_returnsNull() {
+        ModelCatalog catalog =
+                ModelCatalog.builder().model("sonnet", sonnetModel).build();
+        assertThat(catalog.resolveStreaming("sonnet")).isNull();
+    }
+
+    @Test
+    void resolveStreaming_unknownAlias_returnsNull() {
+        ModelCatalog catalog =
+                ModelCatalog.builder().model("sonnet", sonnetModel).build();
+        assertThat(catalog.resolveStreaming("unknown")).isNull();
+    }
+
+    // ========================
+    // list
+    // ========================
+
+    @Test
+    void list_returnsModelInfosInInsertionOrder() {
+        ModelCatalog catalog = ModelCatalog.builder()
+                .model("sonnet", sonnetModel)
+                .model("opus", opusModel)
+                .build();
+
+        List<ModelCatalog.ModelInfo> infos = catalog.list();
+        assertThat(infos).hasSize(2);
+        assertThat(infos.get(0).alias()).isEqualTo("sonnet");
+        assertThat(infos.get(1).alias()).isEqualTo("opus");
+    }
+
+    // ========================
+    // deriveProvider
+    // ========================
+
+    @Test
+    void deriveProvider_unknownClass_returnsUnknown() {
+        // Our mock class doesn't contain known provider names
+        assertThat(ModelCatalog.deriveProvider(sonnetModel)).isEqualTo("unknown");
+    }
+
+    @Test
+    void deriveProvider_openAiClass_returnsOpenai() {
+        ChatModel openAiModel = new OpenAiChatModel();
+        assertThat(ModelCatalog.deriveProvider(openAiModel)).isEqualTo("openai");
+    }
+
+    @Test
+    void deriveProvider_anthropicClass_returnsAnthropic() {
+        ChatModel anthropicModel = new AnthropicChatModel();
+        assertThat(ModelCatalog.deriveProvider(anthropicModel)).isEqualTo("anthropic");
+    }
+
+    @Test
+    void deriveProvider_geminiClass_returnsGoogle() {
+        assertThat(ModelCatalog.deriveProvider(new GeminiChatModel())).isEqualTo("google");
+    }
+
+    @Test
+    void deriveProvider_vertexAiClass_returnsGoogle() {
+        assertThat(ModelCatalog.deriveProvider(new VertexaiChatModel())).isEqualTo("google");
+    }
+
+    @Test
+    void deriveProvider_googleClass_returnsGoogle() {
+        assertThat(ModelCatalog.deriveProvider(new GoogleChatModel())).isEqualTo("google");
+    }
+
+    @Test
+    void deriveProvider_mistralClass_returnsMistral() {
+        assertThat(ModelCatalog.deriveProvider(new MistralChatModel())).isEqualTo("mistral");
+    }
+
+    @Test
+    void deriveProvider_ollamaClass_returnsOllama() {
+        assertThat(ModelCatalog.deriveProvider(new OllamaChatModel())).isEqualTo("ollama");
+    }
+
+    @Test
+    void deriveProvider_cohereClass_returnsCohere() {
+        assertThat(ModelCatalog.deriveProvider(new CohereChatModel())).isEqualTo("cohere");
+    }
+
+    @Test
+    void deriveProvider_azureClass_returnsAzure() {
+        assertThat(ModelCatalog.deriveProvider(new AzureChatModel())).isEqualTo("azure");
+    }
+
+    @Test
+    void deriveProvider_bedrockClass_returnsBedrock() {
+        assertThat(ModelCatalog.deriveProvider(new BedrockChatModel())).isEqualTo("bedrock");
+    }
+
+    @Test
+    void deriveProvider_huggingfaceClass_returnsHuggingface() {
+        assertThat(ModelCatalog.deriveProvider(new HuggingfaceChatModel())).isEqualTo("huggingface");
+    }
+
+    // ========================
+    // size
+    // ========================
+
+    @Test
+    void size_reflectsRegisteredModelCount() {
+        ModelCatalog catalog = ModelCatalog.builder()
+                .model("sonnet", sonnetModel)
+                .model("opus", opusModel)
+                .build();
+        assertThat(catalog.size()).isEqualTo(2);
+    }
+
+    // ========================
+    // Helper stub classes for provider detection tests
+    // ========================
+
+    /**
+     * Stub whose class simple name contains "OpenAi" -- used to verify provider detection.
+     * ChatModel in LangChain4j 1.12.2 has only default methods, so no overrides required.
+     */
+    private static final class OpenAiChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Anthropic". */
+    private static final class AnthropicChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Gemini". */
+    private static final class GeminiChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Vertexai". */
+    private static final class VertexaiChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Google". */
+    private static final class GoogleChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Mistral". */
+    private static final class MistralChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Ollama". */
+    private static final class OllamaChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Cohere". */
+    private static final class CohereChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Azure". */
+    private static final class AzureChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Bedrock". */
+    private static final class BedrockChatModel implements ChatModel {}
+
+    /** Stub whose class name contains "Huggingface". */
+    private static final class HuggingfaceChatModel implements ChatModel {}
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunApiIntegrationTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunApiIntegrationTest.java
@@ -201,7 +201,6 @@ class RunApiIntegrationTest {
 
     @Test
     void getRuns_afterSubmission_returnsRun() throws Exception {
-        CountDownLatch doneLatch = new CountDownLatch(1);
         when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
 
         post("/api/runs", "{}");

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunApiIntegrationTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunApiIntegrationTest.java
@@ -1,0 +1,408 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import net.agentensemble.Ensemble;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.tool.AgentTool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the Ensemble Control API REST endpoints.
+ *
+ * <p>Each test starts a real embedded Javalin server on an ephemeral port, configures a mock
+ * ensemble as the template, and sends HTTP requests via {@link HttpClient} to verify the
+ * endpoint behavior end-to-end.
+ *
+ * <p>Uses {@code host("0.0.0.0")} so HTTP clients connecting from localhost are accepted without
+ * Origin validation.
+ */
+class RunApiIntegrationTest {
+
+    private WebDashboard dashboard;
+    private HttpClient httpClient;
+    private ObjectMapper objectMapper;
+    private Ensemble mockEnsemble;
+    private EnsembleOutput mockOutput;
+    private int port;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        objectMapper = new ObjectMapper();
+        mockEnsemble = mock(Ensemble.class);
+        mockOutput = mock(EnsembleOutput.class);
+
+        when(mockEnsemble.getTasks()).thenReturn(List.of());
+        when(mockOutput.getTaskOutputs()).thenReturn(List.of());
+        when(mockOutput.getMetrics()).thenReturn(null);
+
+        dashboard = WebDashboard.builder()
+                .port(0) // ephemeral
+                .host("0.0.0.0") // bypass localhost origin restriction for tests
+                .maxConcurrentRuns(3)
+                .build();
+        dashboard.start();
+
+        // Wire the mock ensemble as the template
+        dashboard.setEnsemble(mockEnsemble);
+
+        port = dashboard.actualPort();
+        httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dashboard.stop();
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl() + path))
+                .GET()
+                .timeout(Duration.ofSeconds(5))
+                .build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl() + path))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .timeout(Duration.ofSeconds(5))
+                .build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    // ========================
+    // POST /api/runs
+    // ========================
+
+    @Test
+    void postRuns_withInputs_returns202WithRunId() throws Exception {
+        CountDownLatch runStarted = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            runStarted.countDown();
+            return mockOutput;
+        });
+
+        HttpResponse<String> response = post("/api/runs", "{\"inputs\":{\"topic\":\"AI safety\"}}");
+
+        assertThat(response.statusCode()).isEqualTo(202);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("runId").asText()).startsWith("run-");
+        assertThat(body.get("status").asText()).isEqualTo("ACCEPTED");
+        assertThat(body.has("tasks")).isTrue();
+    }
+
+    @Test
+    void postRuns_emptyBody_returns202() throws Exception {
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        HttpResponse<String> response = post("/api/runs", "{}");
+        assertThat(response.statusCode()).isEqualTo(202);
+    }
+
+    @Test
+    void postRuns_invalidJson_returns400() throws Exception {
+        HttpResponse<String> response = post("/api/runs", "not-valid-json");
+        assertThat(response.statusCode()).isEqualTo(400);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("error").asText()).isEqualTo("BAD_REQUEST");
+    }
+
+    @Test
+    void postRuns_noEnsembleConfigured_returns503() throws Exception {
+        // Create a dashboard without wiring an ensemble
+        WebDashboard noEnsembleDashboard =
+                WebDashboard.builder().port(0).host("0.0.0.0").build();
+        noEnsembleDashboard.start();
+        try {
+            int p = noEnsembleDashboard.actualPort();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + p + "/api/runs"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(503);
+            JsonNode body = objectMapper.readTree(response.body());
+            assertThat(body.get("error").asText()).isEqualTo("NOT_CONFIGURED");
+        } finally {
+            noEnsembleDashboard.stop();
+        }
+    }
+
+    @Test
+    void postRuns_atConcurrencyLimit_returns429() throws Exception {
+        CountDownLatch blockLatch = new CountDownLatch(1);
+        CountDownLatch startedLatch = new CountDownLatch(3);
+
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            startedLatch.countDown();
+            blockLatch.await(5, TimeUnit.SECONDS);
+            return mockOutput;
+        });
+
+        // Submit 3 runs to fill the limit
+        post("/api/runs", "{}");
+        post("/api/runs", "{}");
+        post("/api/runs", "{}");
+        assertThat(startedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Fourth should be rejected
+        HttpResponse<String> response = post("/api/runs", "{}");
+        assertThat(response.statusCode()).isEqualTo(429);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("error").asText()).isEqualTo("CONCURRENCY_LIMIT");
+        assertThat(body.has("retryAfterMs")).isTrue();
+
+        blockLatch.countDown();
+    }
+
+    // ========================
+    // GET /api/runs
+    // ========================
+
+    @Test
+    void getRuns_empty_returnsEmptyList() throws Exception {
+        HttpResponse<String> response = get("/api/runs");
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("runs").isArray()).isTrue();
+        assertThat(body.get("total").asInt()).isZero();
+    }
+
+    @Test
+    void getRuns_afterSubmission_returnsRun() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        post("/api/runs", "{}");
+
+        // Wait for run to complete by polling
+        for (int i = 0; i < 20; i++) {
+            Thread.sleep(100);
+            HttpResponse<String> response = get("/api/runs");
+            JsonNode body = objectMapper.readTree(response.body());
+            if (body.get("total").asInt() > 0) {
+                assertThat(body.get("runs").get(0).get("runId").asText()).startsWith("run-");
+                return;
+            }
+        }
+        // The run should appear within 2 seconds
+        assertThat(false).as("Run did not appear in listing within timeout").isFalse();
+    }
+
+    @Test
+    void getRuns_withStatusFilter_filtersCorrectly() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            doneLatch.countDown();
+            return mockOutput;
+        });
+
+        post("/api/runs", "{}");
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(100); // give state time to update
+
+        HttpResponse<String> completedResponse = get("/api/runs?status=COMPLETED");
+        assertThat(completedResponse.statusCode()).isEqualTo(200);
+        JsonNode body = objectMapper.readTree(completedResponse.body());
+        assertThat(body.get("total").asInt()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void getRuns_withInvalidStatus_returns400() throws Exception {
+        HttpResponse<String> response = get("/api/runs?status=INVALID_STATUS");
+        assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    // ========================
+    // GET /api/runs/{runId}
+    // ========================
+
+    @Test
+    void getRunById_unknownId_returns404() throws Exception {
+        HttpResponse<String> response = get("/api/runs/run-nonexistent");
+        assertThat(response.statusCode()).isEqualTo(404);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("error").asText()).isEqualTo("RUN_NOT_FOUND");
+    }
+
+    @Test
+    void getRunById_knownId_returns200WithDetail() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            doneLatch.countDown();
+            return mockOutput;
+        });
+
+        HttpResponse<String> submitResponse = post("/api/runs", "{\"inputs\":{\"topic\":\"AI\"}}");
+        JsonNode submitBody = objectMapper.readTree(submitResponse.body());
+        String runId = submitBody.get("runId").asText();
+
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(100); // give state time to settle
+
+        HttpResponse<String> detailResponse = get("/api/runs/" + runId);
+        assertThat(detailResponse.statusCode()).isEqualTo(200);
+
+        JsonNode detail = objectMapper.readTree(detailResponse.body());
+        assertThat(detail.get("runId").asText()).isEqualTo(runId);
+        assertThat(detail.get("status").asText()).isEqualTo("COMPLETED");
+        assertThat(detail.get("inputs").get("topic").asText()).isEqualTo("AI");
+    }
+
+    // ========================
+    // GET /api/capabilities
+    // ========================
+
+    @Test
+    void getCapabilities_noCatalogs_returnsEmptyLists() throws Exception {
+        HttpResponse<String> response = get("/api/capabilities");
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("tools").isArray()).isTrue();
+        assertThat(body.get("models").isArray()).isTrue();
+        assertThat(body.get("preconfiguredTasks").isArray()).isTrue();
+    }
+
+    @Test
+    void getCapabilities_withToolCatalog_listsTools() throws Exception {
+        AgentTool mockTool = mock(AgentTool.class);
+        when(mockTool.name()).thenReturn("web_search");
+        when(mockTool.description()).thenReturn("Search the web");
+
+        WebDashboard dashboardWithCatalog = WebDashboard.builder()
+                .port(0)
+                .host("0.0.0.0")
+                .toolCatalog(ToolCatalog.builder().tool("web_search", mockTool).build())
+                .build();
+        dashboardWithCatalog.start();
+        try {
+            int p = dashboardWithCatalog.actualPort();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + p + "/api/capabilities"))
+                    .GET()
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+
+            JsonNode body = objectMapper.readTree(response.body());
+            assertThat(body.get("tools").size()).isEqualTo(1);
+            assertThat(body.get("tools").get(0).get("name").asText()).isEqualTo("web_search");
+            assertThat(body.get("tools").get(0).get("description").asText()).isEqualTo("Search the web");
+        } finally {
+            dashboardWithCatalog.stop();
+        }
+    }
+
+    // ========================
+    // Protocol tests: RunAckMessage + RunResultMessage serialization
+    // ========================
+
+    @Test
+    void runAckMessage_serialization_includesAllFields() throws Exception {
+        net.agentensemble.web.protocol.MessageSerializer serializer =
+                new net.agentensemble.web.protocol.MessageSerializer();
+        net.agentensemble.web.protocol.RunAckMessage msg =
+                new net.agentensemble.web.protocol.RunAckMessage("req-1", "run-abc", "ACCEPTED", 2, "SEQUENTIAL");
+        String json = serializer.toJson(msg);
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.get("type").asText()).isEqualTo("run_ack");
+        assertThat(node.get("requestId").asText()).isEqualTo("req-1");
+        assertThat(node.get("runId").asText()).isEqualTo("run-abc");
+        assertThat(node.get("status").asText()).isEqualTo("ACCEPTED");
+        assertThat(node.get("tasks").asInt()).isEqualTo(2);
+        assertThat(node.get("workflow").asText()).isEqualTo("SEQUENTIAL");
+    }
+
+    @Test
+    void runResultMessage_serialization_nullFieldsOmitted() throws Exception {
+        net.agentensemble.web.protocol.MessageSerializer serializer =
+                new net.agentensemble.web.protocol.MessageSerializer();
+        net.agentensemble.web.protocol.RunResultMessage msg = new net.agentensemble.web.protocol.RunResultMessage(
+                "run-abc", "COMPLETED", List.of(), 5000L, null, null);
+        String json = serializer.toJson(msg);
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.get("type").asText()).isEqualTo("run_result");
+        assertThat(node.get("runId").asText()).isEqualTo("run-abc");
+        assertThat(node.get("status").asText()).isEqualTo("COMPLETED");
+        assertThat(node.get("durationMs").asLong()).isEqualTo(5000L);
+        // null fields should be omitted (@JsonInclude NON_NULL)
+        assertThat(node.has("metrics")).isFalse();
+        assertThat(node.has("error")).isFalse();
+    }
+
+    // ========================
+    // RunResultMessage nested records
+    // ========================
+
+    @Test
+    void runResultMessage_withTaskOutputsAndMetrics_serializes() throws Exception {
+        net.agentensemble.web.protocol.MessageSerializer serializer =
+                new net.agentensemble.web.protocol.MessageSerializer();
+        List<net.agentensemble.web.protocol.RunResultMessage.TaskOutputDto> outputs =
+                List.of(new net.agentensemble.web.protocol.RunResultMessage.TaskOutputDto(
+                        "Research AI", "AI safety is important", 8200L));
+        net.agentensemble.web.protocol.RunResultMessage.MetricsDto metrics =
+                new net.agentensemble.web.protocol.RunResultMessage.MetricsDto(15000L, 7L);
+
+        net.agentensemble.web.protocol.RunResultMessage msg = new net.agentensemble.web.protocol.RunResultMessage(
+                "run-abc", "COMPLETED", outputs, 11300L, metrics, null);
+        String json = serializer.toJson(msg);
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.get("type").asText()).isEqualTo("run_result");
+        assertThat(node.get("outputs").size()).isEqualTo(1);
+        assertThat(node.get("outputs").get(0).get("taskName").asText()).isEqualTo("Research AI");
+        assertThat(node.get("outputs").get(0).get("output").asText()).isEqualTo("AI safety is important");
+        assertThat(node.get("metrics").get("totalTokens").asLong()).isEqualTo(15000L);
+        assertThat(node.get("metrics").get("totalToolCalls").asLong()).isEqualTo(7L);
+    }
+
+    // ========================
+    // Backward compatibility: existing endpoints still work
+    // ========================
+
+    @Test
+    void existingStatusEndpoint_stillReturns200() throws Exception {
+        HttpResponse<String> response = get("/api/status");
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode body = objectMapper.readTree(response.body());
+        assertThat(body.get("status").asText()).isEqualTo("running");
+    }
+
+    @Test
+    void existingHealthLiveEndpoint_stillReturns200() throws Exception {
+        HttpResponse<String> response = get("/api/health/live");
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunManagerTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunManagerTest.java
@@ -1,0 +1,290 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import net.agentensemble.Ensemble;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.web.RunState.Status;
+import net.agentensemble.web.protocol.RunResultMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RunManager}: submission, state tracking, concurrency limiting,
+ * eviction, and shutdown.
+ */
+class RunManagerTest {
+
+    private RunManager manager;
+    private Ensemble mockEnsemble;
+    private EnsembleOutput mockOutput;
+
+    @BeforeEach
+    void setUp() {
+        manager = new RunManager(/* maxConcurrentRuns= */ 2, /* maxRetainedRuns= */ 5);
+        mockEnsemble = mock(Ensemble.class);
+        mockOutput = mock(EnsembleOutput.class);
+
+        when(mockEnsemble.getTasks()).thenReturn(List.of());
+        when(mockOutput.getTaskOutputs()).thenReturn(List.of());
+        when(mockOutput.getMetrics()).thenReturn(null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        manager.shutdown();
+    }
+
+    // ========================
+    // Constructor validation
+    // ========================
+
+    @Test
+    void constructor_zeroMaxConcurrentRuns_throws() {
+        assertThatThrownBy(() -> new RunManager(0, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxConcurrentRuns must be >= 1");
+    }
+
+    @Test
+    void constructor_zeroMaxRetainedRuns_throws() {
+        assertThatThrownBy(() -> new RunManager(5, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxRetainedRuns must be >= 1");
+    }
+
+    // ========================
+    // submitRun -- happy path
+    // ========================
+
+    @Test
+    void submitRun_accepted_returnAcceptedState() throws Exception {
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            startLatch.countDown();
+            doneLatch.await(5, TimeUnit.SECONDS);
+            return mockOutput;
+        });
+
+        RunState state = manager.submitRun(mockEnsemble, Map.of("topic", "AI"), null, null, null, null);
+
+        assertThat(state.getStatus()).isEqualTo(Status.ACCEPTED);
+        assertThat(state.getRunId()).startsWith("run-");
+        assertThat(state.getTaskCount()).isZero();
+
+        // Allow run to complete
+        doneLatch.countDown();
+    }
+
+    @Test
+    void submitRun_completesSuccessfully_stateTransitionsToCompleted() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicReference<RunResultMessage> result = new AtomicReference<>();
+
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        RunState state = manager.submitRun(mockEnsemble, Map.of("topic", "AI"), null, null, null, resultMsg -> {
+            result.set(resultMsg);
+            doneLatch.countDown();
+        });
+
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(state.getStatus()).isEqualTo(Status.COMPLETED);
+        assertThat(result.get()).isNotNull();
+        assertThat(result.get().runId()).isEqualTo(state.getRunId());
+        assertThat(result.get().status()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void submitRun_ensembleThrows_stateTransitionsToFailed() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicReference<RunResultMessage> result = new AtomicReference<>();
+
+        when(mockEnsemble.run(any(Map.class), any())).thenThrow(new RuntimeException("LLM failed"));
+
+        RunState state = manager.submitRun(mockEnsemble, Map.of(), null, null, null, resultMsg -> {
+            result.set(resultMsg);
+            doneLatch.countDown();
+        });
+
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(state.getStatus()).isEqualTo(Status.FAILED);
+        assertThat(state.getError()).contains("LLM failed");
+        assertThat(result.get().status()).isEqualTo("FAILED");
+        assertThat(result.get().error()).contains("LLM failed");
+    }
+
+    // ========================
+    // Concurrency limiting
+    // ========================
+
+    @Test
+    void submitRun_atConcurrencyLimit_returnsRejected() throws InterruptedException {
+        CountDownLatch blockLatch = new CountDownLatch(1);
+        CountDownLatch startedLatch = new CountDownLatch(2); // wait for 2 runs to start
+
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            startedLatch.countDown();
+            blockLatch.await(5, TimeUnit.SECONDS);
+            return mockOutput;
+        });
+
+        // Submit 2 runs to fill the limit (maxConcurrentRuns = 2)
+        RunState s1 = manager.submitRun(mockEnsemble, Map.of(), null, null, null, null);
+        RunState s2 = manager.submitRun(mockEnsemble, Map.of(), null, null, null, null);
+        assertThat(startedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Third run should be rejected
+        RunState s3 = manager.submitRun(mockEnsemble, Map.of(), null, null, null, null);
+        assertThat(s3.getStatus()).isEqualTo(Status.REJECTED);
+
+        // Rejected state not retained
+        assertThat(manager.getRun(s3.getRunId())).isEmpty();
+
+        // Allow in-flight runs to complete
+        blockLatch.countDown();
+    }
+
+    @Test
+    void getActiveCount_reflectsRunningRuns() throws InterruptedException {
+        CountDownLatch blockLatch = new CountDownLatch(1);
+        CountDownLatch startedLatch = new CountDownLatch(1);
+
+        when(mockEnsemble.run(any(Map.class), any())).thenAnswer(inv -> {
+            startedLatch.countDown();
+            blockLatch.await(5, TimeUnit.SECONDS);
+            return mockOutput;
+        });
+
+        assertThat(manager.getActiveCount()).isZero();
+        manager.submitRun(mockEnsemble, Map.of(), null, null, null, null);
+        assertThat(startedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(manager.getActiveCount()).isEqualTo(1);
+
+        blockLatch.countDown();
+    }
+
+    // ========================
+    // getRun
+    // ========================
+
+    @Test
+    void getRun_existingRun_returnsPresent() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        RunState state = manager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch.countDown());
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        Optional<RunState> found = manager.getRun(state.getRunId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getRunId()).isEqualTo(state.getRunId());
+    }
+
+    @Test
+    void getRun_unknownId_returnsEmpty() {
+        assertThat(manager.getRun("run-nonexistent")).isEmpty();
+    }
+
+    // ========================
+    // listRuns
+    // ========================
+
+    @Test
+    void listAllRuns_returnsAllRetainedRuns() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(2);
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        manager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch.countDown());
+        manager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch.countDown());
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        List<RunState> runs = manager.listAllRuns();
+        assertThat(runs).hasSize(2);
+    }
+
+    @Test
+    void listRuns_withStatusFilter_returnsOnlyMatchingStatus() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        RunState completed = manager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch.countDown());
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        List<RunState> completedRuns = manager.listRuns(Status.COMPLETED, null, null);
+        assertThat(completedRuns).extracting(RunState::getRunId).contains(completed.getRunId());
+
+        List<RunState> failedRuns = manager.listRuns(Status.FAILED, null, null);
+        assertThat(failedRuns).extracting(RunState::getRunId).doesNotContain(completed.getRunId());
+    }
+
+    @Test
+    void listRuns_withTagFilter_returnsOnlyMatchingTags() throws Exception {
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+        manager.submitRun(mockEnsemble, Map.of(), Map.of("env", "staging"), null, null, r -> doneLatch.countDown());
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        List<RunState> stagingRuns = manager.listRuns(null, "env", "staging");
+        assertThat(stagingRuns).hasSize(1);
+
+        List<RunState> prodRuns = manager.listRuns(null, "env", "prod");
+        assertThat(prodRuns).isEmpty();
+    }
+
+    // ========================
+    // Eviction
+    // ========================
+
+    @Test
+    void eviction_oldestCompletedRunsEvictedWhenOverLimit() throws Exception {
+        RunManager smallManager = new RunManager(5, /* maxRetainedRuns= */ 2);
+        try {
+            when(mockEnsemble.run(any(Map.class), any())).thenReturn(mockOutput);
+
+            CountDownLatch doneLatch1 = new CountDownLatch(1);
+            CountDownLatch doneLatch2 = new CountDownLatch(1);
+            CountDownLatch doneLatch3 = new CountDownLatch(1);
+
+            RunState s1 = smallManager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch1.countDown());
+            assertThat(doneLatch1.await(5, TimeUnit.SECONDS)).isTrue();
+
+            RunState s2 = smallManager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch2.countDown());
+            assertThat(doneLatch2.await(5, TimeUnit.SECONDS)).isTrue();
+
+            RunState s3 = smallManager.submitRun(mockEnsemble, Map.of(), null, null, null, r -> doneLatch3.countDown());
+            assertThat(doneLatch3.await(5, TimeUnit.SECONDS)).isTrue();
+
+            // s1 should have been evicted (oldest completed), s2 and s3 should still be present
+            assertThat(smallManager.listAllRuns()).hasSize(2);
+            assertThat(smallManager.getRun(s1.getRunId())).isEmpty();
+            assertThat(smallManager.getRun(s2.getRunId())).isPresent();
+            assertThat(smallManager.getRun(s3.getRunId())).isPresent();
+        } finally {
+            smallManager.shutdown();
+        }
+    }
+
+    // ========================
+    // getMaxConcurrentRuns
+    // ========================
+
+    @Test
+    void getMaxConcurrentRuns_returnsConfiguredValue() {
+        assertThat(manager.getMaxConcurrentRuns()).isEqualTo(2);
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunManagerTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunManagerTest.java
@@ -81,9 +81,15 @@ class RunManagerTest {
 
         RunState state = manager.submitRun(mockEnsemble, Map.of("topic", "AI"), null, null, null, null);
 
-        assertThat(state.getStatus()).isEqualTo(Status.ACCEPTED);
+        // Run ID and task count are assigned deterministically at submission time.
         assertThat(state.getRunId()).startsWith("run-");
         assertThat(state.getTaskCount()).isZero();
+
+        // Wait for the virtual thread to start executing; this confirms that submitRun()
+        // returned before the run completed (non-blocking), and that the state has advanced
+        // to RUNNING (the virtual thread acquired the semaphore and called executeRun).
+        assertThat(startLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(state.getStatus()).isEqualTo(Status.RUNNING);
 
         // Allow run to complete
         doneLatch.countDown();

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestParserTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestParserTest.java
@@ -1,0 +1,111 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import net.agentensemble.Ensemble;
+import net.agentensemble.execution.RunOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RunRequestParser}: Level 1 configuration building.
+ */
+class RunRequestParserTest {
+
+    private RunRequestParser parser;
+    private Ensemble template;
+
+    @BeforeEach
+    void setUp() {
+        parser = new RunRequestParser(null, null);
+        template = mock(Ensemble.class);
+    }
+
+    // ========================
+    // buildFromTemplate -- null guards
+    // ========================
+
+    @Test
+    void buildFromTemplate_nullTemplate_throws() {
+        assertThatThrownBy(() -> parser.buildFromTemplate(null, Map.of(), RunOptions.DEFAULT))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("template ensemble must not be null");
+    }
+
+    // ========================
+    // buildFromTemplate -- happy paths
+    // ========================
+
+    @Test
+    void buildFromTemplate_withInputs_returnsConfigurationWithCopiedInputs() {
+        Map<String, String> inputs = Map.of("topic", "AI safety", "year", "2025");
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, inputs, null);
+
+        assertThat(config.template()).isSameAs(template);
+        assertThat(config.inputs()).containsEntry("topic", "AI safety").containsEntry("year", "2025");
+        assertThat(config.options()).isSameAs(RunOptions.DEFAULT);
+    }
+
+    @Test
+    void buildFromTemplate_nullInputs_defaultsToEmpty() {
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, null, null);
+        assertThat(config.inputs()).isEmpty();
+    }
+
+    @Test
+    void buildFromTemplate_emptyInputs_returnsEmptyInputs() {
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, Map.of(), null);
+        assertThat(config.inputs()).isEmpty();
+    }
+
+    @Test
+    void buildFromTemplate_withOptions_preservesOptions() {
+        RunOptions options = RunOptions.builder().maxToolOutputLength(5000).build();
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, Map.of(), options);
+        assertThat(config.options()).isSameAs(options);
+    }
+
+    @Test
+    void buildFromTemplate_nullOptions_defaultsToRunOptionsDefault() {
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, Map.of(), null);
+        assertThat(config.options()).isSameAs(RunOptions.DEFAULT);
+    }
+
+    @Test
+    void buildFromTemplate_inputsAreCopied_mutatingOriginalDoesNotAffectConfig() {
+        Map<String, String> mutableInputs = new java.util.HashMap<>();
+        mutableInputs.put("topic", "AI");
+
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, mutableInputs, null);
+        mutableInputs.put("year", "2025"); // mutate after building
+
+        assertThat(config.inputs()).doesNotContainKey("year");
+    }
+
+    // ========================
+    // Catalog accessors
+    // ========================
+
+    @Test
+    void getToolCatalog_returnsNullWhenNotConfigured() {
+        assertThat(parser.getToolCatalog()).isNull();
+    }
+
+    @Test
+    void getModelCatalog_returnsNullWhenNotConfigured() {
+        assertThat(parser.getModelCatalog()).isNull();
+    }
+
+    @Test
+    void withCatalogs_returnsConfiguredCatalogs() {
+        ToolCatalog tc = ToolCatalog.builder().build();
+        ModelCatalog mc = ModelCatalog.builder().build();
+        RunRequestParser parserWithCatalogs = new RunRequestParser(tc, mc);
+
+        assertThat(parserWithCatalogs.getToolCatalog()).isSameAs(tc);
+        assertThat(parserWithCatalogs.getModelCatalog()).isSameAs(mc);
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunStateTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunStateTest.java
@@ -1,0 +1,179 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+import net.agentensemble.web.RunState.Status;
+import net.agentensemble.web.RunState.TaskOutputSnapshot;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RunState}: construction, accessors, status transitions, thread-safe
+ * task output accumulation.
+ */
+class RunStateTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    private RunState makeState(Status status) {
+        return new RunState(
+                "run-abc123",
+                status,
+                T0,
+                Map.of("topic", "AI"),
+                Map.of("triggeredBy", "ci"),
+                3,
+                "SEQUENTIAL",
+                "session-42");
+    }
+
+    // ========================
+    // Construction & immutable accessors
+    // ========================
+
+    @Test
+    void construction_setsAllFields() {
+        RunState state = makeState(Status.ACCEPTED);
+
+        assertThat(state.getRunId()).isEqualTo("run-abc123");
+        assertThat(state.getStatus()).isEqualTo(Status.ACCEPTED);
+        assertThat(state.getStartedAt()).isEqualTo(T0);
+        assertThat(state.getInputs()).containsEntry("topic", "AI");
+        assertThat(state.getTags()).containsEntry("triggeredBy", "ci");
+        assertThat(state.getTaskCount()).isEqualTo(3);
+        assertThat(state.getWorkflow()).isEqualTo("SEQUENTIAL");
+        assertThat(state.getOriginSessionId()).isEqualTo("session-42");
+    }
+
+    @Test
+    void construction_nullInputs_defaultsToEmptyMap() {
+        RunState state = new RunState("r", Status.ACCEPTED, T0, null, null, 0, null, null);
+        assertThat(state.getInputs()).isEmpty();
+        assertThat(state.getTags()).isEmpty();
+    }
+
+    @Test
+    void construction_completedAtIsNullInitially() {
+        RunState state = makeState(Status.ACCEPTED);
+        assertThat(state.getCompletedAt()).isNull();
+    }
+
+    @Test
+    void construction_notCancelledInitially() {
+        RunState state = makeState(Status.ACCEPTED);
+        assertThat(state.isCancelled()).isFalse();
+    }
+
+    @Test
+    void construction_errorIsNullInitially() {
+        RunState state = makeState(Status.ACCEPTED);
+        assertThat(state.getError()).isNull();
+    }
+
+    @Test
+    void construction_taskOutputsEmptyInitially() {
+        RunState state = makeState(Status.ACCEPTED);
+        assertThat(state.getTaskOutputs()).isEmpty();
+    }
+
+    // ========================
+    // Status transitions
+    // ========================
+
+    @Test
+    void transitionTo_updatesStatus() {
+        RunState state = makeState(Status.ACCEPTED);
+        state.transitionTo(Status.RUNNING);
+        assertThat(state.getStatus()).isEqualTo(Status.RUNNING);
+
+        state.transitionTo(Status.COMPLETED);
+        assertThat(state.getStatus()).isEqualTo(Status.COMPLETED);
+    }
+
+    @Test
+    void compareAndSetStatus_successWhenExpectedMatches() {
+        RunState state = makeState(Status.ACCEPTED);
+        boolean updated = state.compareAndSetStatus(Status.ACCEPTED, Status.RUNNING);
+        assertThat(updated).isTrue();
+        assertThat(state.getStatus()).isEqualTo(Status.RUNNING);
+    }
+
+    @Test
+    void compareAndSetStatus_failsWhenExpectedDoesNotMatch() {
+        RunState state = makeState(Status.ACCEPTED);
+        boolean updated = state.compareAndSetStatus(Status.RUNNING, Status.COMPLETED);
+        assertThat(updated).isFalse();
+        assertThat(state.getStatus()).isEqualTo(Status.ACCEPTED);
+    }
+
+    // ========================
+    // Mutable field updates
+    // ========================
+
+    @Test
+    void setCompletedAt_updatesField() {
+        RunState state = makeState(Status.COMPLETED);
+        Instant completedAt = Instant.parse("2026-01-01T01:00:00Z");
+        state.setCompletedAt(completedAt);
+        assertThat(state.getCompletedAt()).isEqualTo(completedAt);
+    }
+
+    @Test
+    void setWorkflow_updatesField() {
+        RunState state = new RunState("r", Status.ACCEPTED, T0, null, null, 0, null, null);
+        state.setWorkflow("PARALLEL");
+        assertThat(state.getWorkflow()).isEqualTo("PARALLEL");
+    }
+
+    @Test
+    void incrementCompletedTasks_incrementsAtomically() {
+        RunState state = makeState(Status.RUNNING);
+        assertThat(state.getCompletedTasks()).isZero();
+        state.incrementCompletedTasks();
+        state.incrementCompletedTasks();
+        assertThat(state.getCompletedTasks()).isEqualTo(2);
+    }
+
+    @Test
+    void cancel_flagsAsCancelled() {
+        RunState state = makeState(Status.RUNNING);
+        assertThat(state.isCancelled()).isFalse();
+        state.cancel();
+        assertThat(state.isCancelled()).isTrue();
+    }
+
+    @Test
+    void setError_updatesErrorField() {
+        RunState state = makeState(Status.FAILED);
+        state.setError("LLM rate limit exceeded");
+        assertThat(state.getError()).isEqualTo("LLM rate limit exceeded");
+    }
+
+    // ========================
+    // Task output snapshots
+    // ========================
+
+    @Test
+    void addTaskOutput_appendsToList() {
+        RunState state = makeState(Status.COMPLETED);
+        TaskOutputSnapshot snap1 = new TaskOutputSnapshot(null, "Research AI", "Result 1", 8200L, 10000L, 3);
+        TaskOutputSnapshot snap2 = new TaskOutputSnapshot(null, "Write brief", "Result 2", 3100L, 5000L, 0);
+
+        state.addTaskOutput(snap1);
+        state.addTaskOutput(snap2);
+
+        assertThat(state.getTaskOutputs()).hasSize(2);
+        assertThat(state.getTaskOutputs().get(0)).isEqualTo(snap1);
+        assertThat(state.getTaskOutputs().get(1)).isEqualTo(snap2);
+    }
+
+    @Test
+    void getTaskOutputs_returnsUnmodifiableView() {
+        RunState state = makeState(Status.COMPLETED);
+        state.addTaskOutput(new TaskOutputSnapshot(null, "Task 1", "Output", null, -1L, 0));
+
+        // The list returned is unmodifiable
+        assertThat(state.getTaskOutputs()).hasSize(1);
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/ToolCatalogTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/ToolCatalogTest.java
@@ -1,0 +1,171 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import net.agentensemble.tool.AgentTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ToolCatalog}: builder validation, resolution, listing, and containment.
+ */
+class ToolCatalogTest {
+
+    private AgentTool webSearchTool;
+    private AgentTool calculatorTool;
+
+    @BeforeEach
+    void setUp() {
+        webSearchTool = mock(AgentTool.class);
+        when(webSearchTool.name()).thenReturn("web_search");
+        when(webSearchTool.description()).thenReturn("Search the web");
+
+        calculatorTool = mock(AgentTool.class);
+        when(calculatorTool.name()).thenReturn("calculator");
+        when(calculatorTool.description()).thenReturn("Evaluate math expressions");
+    }
+
+    // ========================
+    // Builder validation
+    // ========================
+
+    @Test
+    void builder_nullToolName_throws() {
+        assertThatThrownBy(() -> ToolCatalog.builder().tool(null, webSearchTool))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tool name must not be null or blank");
+    }
+
+    @Test
+    void builder_blankToolName_throws() {
+        assertThatThrownBy(() -> ToolCatalog.builder().tool("  ", webSearchTool))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tool name must not be null or blank");
+    }
+
+    @Test
+    void builder_nullTool_throws() {
+        assertThatThrownBy(() -> ToolCatalog.builder().tool("web_search", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tool must not be null");
+    }
+
+    @Test
+    void builder_duplicateName_throws() {
+        AgentTool another = mock(AgentTool.class);
+        when(another.description()).thenReturn("Another tool");
+
+        assertThatThrownBy(() ->
+                        ToolCatalog.builder().tool("web_search", webSearchTool).tool("web_search", another))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate tool name: 'web_search'");
+    }
+
+    @Test
+    void builder_emptyBuild_producesEmptyCatalog() {
+        ToolCatalog catalog = ToolCatalog.builder().build();
+        assertThat(catalog.size()).isZero();
+        assertThat(catalog.list()).isEmpty();
+    }
+
+    // ========================
+    // resolve
+    // ========================
+
+    @Test
+    void resolve_knownName_returnsCorrectTool() {
+        ToolCatalog catalog = ToolCatalog.builder()
+                .tool("web_search", webSearchTool)
+                .tool("calculator", calculatorTool)
+                .build();
+
+        assertThat(catalog.resolve("web_search")).isSameAs(webSearchTool);
+        assertThat(catalog.resolve("calculator")).isSameAs(calculatorTool);
+    }
+
+    @Test
+    void resolve_unknownName_throwsWithHelpfulMessage() {
+        ToolCatalog catalog =
+                ToolCatalog.builder().tool("web_search", webSearchTool).build();
+
+        assertThatThrownBy(() -> catalog.resolve("foobar"))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("Unknown tool 'foobar'")
+                .hasMessageContaining("web_search");
+    }
+
+    // ========================
+    // find
+    // ========================
+
+    @Test
+    void find_knownName_returnsNonEmpty() {
+        ToolCatalog catalog =
+                ToolCatalog.builder().tool("web_search", webSearchTool).build();
+        Optional<AgentTool> found = catalog.find("web_search");
+        assertThat(found).isPresent().contains(webSearchTool);
+    }
+
+    @Test
+    void find_unknownName_returnsEmpty() {
+        ToolCatalog catalog =
+                ToolCatalog.builder().tool("web_search", webSearchTool).build();
+        assertThat(catalog.find("unknown")).isEmpty();
+    }
+
+    // ========================
+    // list
+    // ========================
+
+    @Test
+    void list_returnsToolInfosInInsertionOrder() {
+        ToolCatalog catalog = ToolCatalog.builder()
+                .tool("web_search", webSearchTool)
+                .tool("calculator", calculatorTool)
+                .build();
+
+        List<ToolCatalog.ToolInfo> infos = catalog.list();
+        assertThat(infos).hasSize(2);
+        assertThat(infos.get(0).name()).isEqualTo("web_search");
+        assertThat(infos.get(0).description()).isEqualTo("Search the web");
+        assertThat(infos.get(1).name()).isEqualTo("calculator");
+        assertThat(infos.get(1).description()).isEqualTo("Evaluate math expressions");
+    }
+
+    // ========================
+    // contains
+    // ========================
+
+    @Test
+    void contains_registeredTool_returnsTrue() {
+        ToolCatalog catalog =
+                ToolCatalog.builder().tool("web_search", webSearchTool).build();
+        assertThat(catalog.contains("web_search")).isTrue();
+    }
+
+    @Test
+    void contains_unregisteredTool_returnsFalse() {
+        ToolCatalog catalog =
+                ToolCatalog.builder().tool("web_search", webSearchTool).build();
+        assertThat(catalog.contains("unknown")).isFalse();
+    }
+
+    // ========================
+    // size
+    // ========================
+
+    @Test
+    void size_reflectsRegisteredToolCount() {
+        ToolCatalog catalog = ToolCatalog.builder()
+                .tool("web_search", webSearchTool)
+                .tool("calculator", calculatorTool)
+                .build();
+        assertThat(catalog.size()).isEqualTo(2);
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/WebDashboardTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/WebDashboardTest.java
@@ -552,4 +552,65 @@ class WebDashboardTest {
         assertThat(helloJson).contains("ensemble_started");
         ws.sendClose(WebSocket.NORMAL_CLOSURE, "done").get(5, TimeUnit.SECONDS);
     }
+
+    // ========================
+    // Ensemble Control API builder coverage
+    // ========================
+
+    @Test
+    void maxConcurrentRunsOfZeroThrows() {
+        assertThatThrownBy(() ->
+                        WebDashboard.builder().port(0).maxConcurrentRuns(0).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxConcurrentRuns");
+    }
+
+    @Test
+    void maxConcurrentRunsNegativeThrows() {
+        assertThatThrownBy(() ->
+                        WebDashboard.builder().port(0).maxConcurrentRuns(-1).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxConcurrentRuns");
+    }
+
+    @Test
+    void maxRetainedCompletedRunsOfZeroThrows() {
+        assertThatThrownBy(() -> WebDashboard.builder()
+                        .port(0)
+                        .maxRetainedCompletedRuns(0)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxRetainedCompletedRuns");
+    }
+
+    @Test
+    void builderConfiguresToolAndModelCatalogs() {
+        ToolCatalog tc = ToolCatalog.builder().build();
+        ModelCatalog mc = ModelCatalog.builder().build();
+        // These builder calls must not throw and produce a valid dashboard
+        dashboard = WebDashboard.builder()
+                .port(0)
+                .toolCatalog(tc)
+                .modelCatalog(mc)
+                .maxConcurrentRuns(3)
+                .maxRetainedCompletedRuns(50)
+                .build();
+        assertThat(dashboard).isNotNull();
+    }
+
+    @Test
+    void builderConfiguresMaxSnapshotIterationsAndWorkspacePath() {
+        dashboard = WebDashboard.builder()
+                .port(0)
+                .maxSnapshotIterations(10)
+                .workspacePath(null) // null = disabled
+                .build();
+        assertThat(dashboard.getMaxSnapshotIterations()).isEqualTo(10);
+    }
+
+    @Test
+    void getMaxSnapshotIterationsReturnsConfiguredValue() {
+        dashboard = WebDashboard.builder().port(0).maxSnapshotIterations(7).build();
+        assertThat(dashboard.getMaxSnapshotIterations()).isEqualTo(7);
+    }
 }

--- a/docs/guides/ensemble-control-api.md
+++ b/docs/guides/ensemble-control-api.md
@@ -1,0 +1,275 @@
+# Ensemble Control API
+
+The Ensemble Control API adds HTTP-based run management to the live dashboard. External systems
+(CI pipelines, orchestrators, custom UIs) can submit ensemble runs, query their status, and
+discover available capabilities -- all without compiling Java code.
+
+This guide covers **Phase 1**: Level 1 run submission (template + input variables), state queries,
+and capabilities discovery. Phases 2-5 add per-task overrides, dynamic task creation, run control,
+SSE streaming, and REST review decisions.
+
+## Overview
+
+```
+POST /api/runs          Submit a run with input variables
+GET  /api/runs          List recent runs (filterable by status, tag)
+GET  /api/runs/{runId}  Get full run detail (status, task outputs, metrics)
+GET  /api/capabilities  List registered tools, models, preconfigured tasks
+```
+
+All endpoints are on the same Javalin server as the WebSocket dashboard -- no new port or process
+required.
+
+## Setup
+
+### 1. Configure the dashboard
+
+Add `toolCatalog`, `modelCatalog`, and (optionally) concurrency limits to `WebDashboard.builder()`:
+
+```java
+ToolCatalog tools = ToolCatalog.builder()
+    .tool("web_search", webSearchTool)
+    .tool("calculator", calculatorTool)
+    .build();
+
+ModelCatalog models = ModelCatalog.builder()
+    .model("sonnet", claudeSonnetModel)
+    .model("haiku", claudeHaikuModel)
+    .build();
+
+WebDashboard dashboard = WebDashboard.builder()
+    .port(7329)
+    .toolCatalog(tools)
+    .modelCatalog(models)
+    .maxConcurrentRuns(5)          // default: 5
+    .maxRetainedCompletedRuns(100) // default: 100
+    .build();
+```
+
+### 2. Wire the ensemble
+
+The template ensemble -- whose tasks and model define what can run -- is wired via
+`Ensemble.builder().webDashboard(dashboard)`:
+
+```java
+Ensemble.builder()
+    .chatLanguageModel(claudeSonnetModel)
+    .webDashboard(dashboard)
+    .task(Task.builder()
+        .description("Research {topic} focusing on recent developments in {year}")
+        .tools(webSearchTool)
+        .build())
+    .task(Task.builder()
+        .description("Write a concise executive summary of the research")
+        .build())
+    .build()
+    .start(7329);
+```
+
+After `start()` (long-running mode) or `run()` (one-shot), the REST endpoints are available.
+
+## Submitting a run
+
+### Level 1: Template inputs
+
+Send the input variables to substitute into `{placeholder}` patterns in task descriptions:
+
+```
+POST /api/runs
+Content-Type: application/json
+```
+
+```json
+{
+  "inputs": {
+    "topic": "AI safety",
+    "year": "2025"
+  },
+  "tags": {
+    "triggeredBy": "ci-pipeline",
+    "environment": "staging"
+  }
+}
+```
+
+Response (`202 Accepted`):
+
+```json
+{
+  "runId": "run-7f3a2b",
+  "status": "ACCEPTED",
+  "tasks": 2,
+  "workflow": "SEQUENTIAL"
+}
+```
+
+`tags` are arbitrary key-value metadata attached to the run for filtering and querying.
+
+### Empty body
+
+An empty body (or `{}`) submits the template ensemble with no input substitution:
+
+```
+POST /api/runs
+Content-Type: application/json
+{}
+```
+
+### Error responses
+
+| HTTP | Error code | Cause |
+|------|-----------|-------|
+| 400 | `BAD_REQUEST` | Invalid or unparseable JSON body |
+| 429 | `CONCURRENCY_LIMIT` | `maxConcurrentRuns` reached; includes `retryAfterMs` |
+| 503 | `NOT_CONFIGURED` | No template ensemble wired via `webDashboard()` |
+
+## Querying runs
+
+### List all runs
+
+```
+GET /api/runs
+```
+
+```json
+{
+  "runs": [
+    {
+      "runId": "run-7f3a2b",
+      "status": "RUNNING",
+      "startedAt": "2025-03-15T10:30:00Z",
+      "durationMs": null,
+      "taskCount": 2,
+      "completedTasks": 1,
+      "workflow": "SEQUENTIAL",
+      "tags": { "triggeredBy": "ci-pipeline" }
+    }
+  ],
+  "total": 1
+}
+```
+
+### Filter by status
+
+```
+GET /api/runs?status=COMPLETED
+GET /api/runs?status=RUNNING
+GET /api/runs?status=FAILED
+```
+
+Valid statuses: `ACCEPTED`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `REJECTED`.
+
+### Filter by tag
+
+```
+GET /api/runs?tag=triggeredBy:ci-pipeline
+GET /api/runs?tag=environment:staging
+```
+
+### Get run detail
+
+```
+GET /api/runs/{runId}
+```
+
+```json
+{
+  "runId": "run-7f3a2b",
+  "status": "COMPLETED",
+  "startedAt": "2025-03-15T10:30:00Z",
+  "completedAt": "2025-03-15T10:30:11Z",
+  "durationMs": 11340,
+  "workflow": "SEQUENTIAL",
+  "inputs": { "topic": "AI safety", "year": "2025" },
+  "tags": { "triggeredBy": "ci-pipeline" },
+  "tasks": [
+    {
+      "taskDescription": "Research AI safety focusing on recent developments in 2025",
+      "output": "## AI Safety Overview\n...",
+      "durationMs": 8200,
+      "tokenCount": 10150,
+      "toolCallCount": 5
+    },
+    {
+      "taskDescription": "Write a concise executive summary of the research",
+      "output": "# Executive Summary\n...",
+      "durationMs": 3100,
+      "tokenCount": 5080,
+      "toolCallCount": 0
+    }
+  ],
+  "metrics": {
+    "totalTokens": 15230,
+    "totalToolCalls": 5
+  }
+}
+```
+
+| HTTP | Error code | Cause |
+|------|-----------|-------|
+| 404 | `RUN_NOT_FOUND` | Unknown run ID or run was evicted |
+
+## Querying capabilities
+
+```
+GET /api/capabilities
+```
+
+Returns registered tools, models, and the preconfigured tasks from the template ensemble:
+
+```json
+{
+  "tools": [
+    { "name": "web_search", "description": "Search the web using Google" },
+    { "name": "calculator", "description": "Evaluate mathematical expressions" }
+  ],
+  "models": [
+    { "alias": "sonnet", "provider": "anthropic" },
+    { "alias": "haiku", "provider": "anthropic" }
+  ],
+  "preconfiguredTasks": [
+    { "description": "Research {topic} focusing on recent developments in {year}" },
+    { "description": "Write a concise executive summary of the research" }
+  ]
+}
+```
+
+If no catalog or template ensemble is configured, each list is empty (`[]`).
+
+## Concurrency
+
+`maxConcurrentRuns` limits how many runs execute simultaneously. When the limit is reached,
+new submissions return HTTP 429 immediately. The `retryAfterMs` field in the response body
+gives a rough hint for when to retry.
+
+```java
+WebDashboard.builder()
+    .maxConcurrentRuns(10)         // allow 10 parallel runs
+    .maxRetainedCompletedRuns(500) // keep 500 completed runs in memory
+    .build();
+```
+
+Completed, failed, and cancelled runs are retained in memory for querying until the
+`maxRetainedCompletedRuns` cap is reached, at which point the oldest are evicted.
+Active runs (ACCEPTED and RUNNING) are never evicted.
+
+## Live events
+
+While a run executes, the existing WebSocket dashboard continues to stream all events
+(`task_started`, `tool_called`, `token`, `llm_iteration_started`, etc.) to connected browsers.
+This is unchanged -- the REST Control API and WebSocket dashboard work together transparently.
+
+## Phase 1 limitations
+
+- **Level 1 only**: input variable substitution into the existing template ensemble's tasks.
+  Level 2 (per-task overrides) and Level 3 (dynamic task creation) are planned for Phase 2.
+- **No run cancellation**: mid-run cancel is planned for Phase 3.
+- **No SSE streaming**: event streaming for HTTP clients is planned for Phase 4.
+- **No REST review decisions**: REST-based human review is planned for Phase 5.
+
+## See also
+
+- [Live Dashboard guide](live-dashboard.md)
+- [Long-Running Ensembles guide](long-running-ensembles.md)
+- [Ensemble Configuration reference](../reference/ensemble-configuration.md)
+- [Design doc 28: Ensemble Control API](../design/28-ensemble-control-api.md)

--- a/docs/reference/ensemble-configuration.md
+++ b/docs/reference/ensemble-configuration.md
@@ -328,3 +328,77 @@ Standardized response envelope mirroring `WorkRequest`.
 | `result` | `String` | No | Output on success |
 | `error` | `String` | No | Error message on failure/rejection |
 | `durationMs` | `Long` | No | Execution duration in milliseconds |
+
+
+---
+
+## Ensemble Control API (Phase 1)
+
+New `WebDashboard.Builder` fields for the HTTP-based Control API.
+
+### ToolCatalog
+
+Immutable registry mapping tool names to `AgentTool` instances.
+
+```java
+ToolCatalog catalog = ToolCatalog.builder()
+    .tool("web_search", webSearchTool)
+    .tool("calculator", calculatorTool)
+    .build();
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `resolve(name)` | `AgentTool` | Returns the tool; throws `NoSuchElementException` if not found |
+| `find(name)` | `Optional<AgentTool>` | Returns empty Optional if not found |
+| `list()` | `List<ToolInfo>` | All registered tools in insertion order |
+| `contains(name)` | `boolean` | Whether the name is registered |
+| `size()` | `int` | Number of registered tools |
+
+### ModelCatalog
+
+Immutable registry mapping model aliases to `ChatModel` instances.
+
+```java
+ModelCatalog catalog = ModelCatalog.builder()
+    .model("sonnet", sonnetModel)
+    .model("haiku", haikuModel, haikuStreamingModel)
+    .build();
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `resolve(alias)` | `ChatModel` | Returns the model; throws `NoSuchElementException` if not found |
+| `find(alias)` | `Optional<ChatModel>` | Returns empty Optional if not found |
+| `resolveStreaming(alias)` | `StreamingChatModel` | Returns the streaming variant; null if not registered |
+| `list()` | `List<ModelInfo>` | All registered models in insertion order |
+| `size()` | `int` | Number of registered models |
+
+### WebDashboard.Builder -- Control API fields
+
+| Builder method | Type | Default | Description |
+|----------------|------|---------|-------------|
+| `toolCatalog(ToolCatalog)` | `ToolCatalog` | `null` | Registered tool allowlist for API requests |
+| `modelCatalog(ModelCatalog)` | `ModelCatalog` | `null` | Registered model allowlist for API requests |
+| `maxConcurrentRuns(int)` | `int` | `5` | Maximum runs executing simultaneously; must be >= 1 |
+| `maxRetainedCompletedRuns(int)` | `int` | `100` | Completed runs kept in memory for state queries; must be >= 1 |
+
+### REST endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/runs` | Submit a run (Level 1: template + inputs) |
+| `GET` | `/api/runs` | List retained runs; filter with `?status=` and `?tag=key:value` |
+| `GET` | `/api/runs/{runId}` | Get full run detail |
+| `GET` | `/api/capabilities` | List registered tools, models, and preconfigured tasks |
+
+### RunState.Status enum
+
+| Value | Description |
+|-------|-------------|
+| `ACCEPTED` | Run queued; concurrency permit acquired |
+| `RUNNING` | Run executing on a virtual thread |
+| `COMPLETED` | All tasks finished without error |
+| `FAILED` | Run terminated with an unhandled exception |
+| `CANCELLED` | Run cancelled cooperatively (Phase 3) |
+| `REJECTED` | Concurrency limit reached; run never executed |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,6 +3,28 @@
 
 ## Current Work
 
+Branch `feat/299-ensemble-control-api-phase1` -- Issue #299.
+Ensemble Control API Phase 1: catalogs, RunManager, REST endpoints for external run submission.
+
+### What was implemented
+
+**#299 -- Ensemble Control API Phase 1:**
+- `ToolCatalog` -- name-keyed `AgentTool` registry with builder and resolve/find/list/contains
+- `ModelCatalog` -- alias-keyed `ChatModel` registry with streaming support and provider detection
+- `RunState` -- mutable per-run lifecycle tracker with `Status` enum (ACCEPTED/RUNNING/COMPLETED/FAILED/CANCELLED/REJECTED)
+- `RunManager` -- concurrency-limited async run executor using `Semaphore` + virtual threads + eviction
+- `RunRequestParser` -- Level 1 template+inputs configuration builder
+- `RunAckMessage` / `RunResultMessage` -- new `ServerMessage` sealed interface permits (run_ack, run_result)
+- `WebDashboard.Builder` extended with `toolCatalog()`, `modelCatalog()`, `maxConcurrentRuns()`, `maxRetainedCompletedRuns()`
+- REST endpoints added to `WebSocketServer`: `POST /api/runs`, `GET /api/runs`, `GET /api/runs/{runId}`, `GET /api/capabilities`
+- `WebDashboard.stop()` shuts down `RunManager` executor
+- `ensembleSupplier` pattern provides the template ensemble to route handlers
+- Guide: `docs/guides/ensemble-control-api.md`
+- Reference updated: `docs/reference/ensemble-configuration.md`
+- Navigation updated: `mkdocs.yml`
+
+## Previous Context (IO-003)
+
 Branch `feat/io-003-iteration-snapshots` -- Issue #287 (IO-003).
 Persist LLM iteration data in late-join snapshots for conversation replay.
 

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased] -- 2026-04-09
+### Added
+- **Ensemble Control API Phase 1 (#299)**: HTTP-based run management for external systems
+  - `ToolCatalog` -- name-keyed `AgentTool` registry (allowlist for API requests)
+  - `ModelCatalog` -- alias-keyed `ChatModel` registry with streaming support and provider detection
+  - `RunState` -- thread-safe per-run lifecycle tracker with `Status` enum
+  - `RunManager` -- concurrency-limited async run executor (Semaphore + virtual threads + eviction)
+  - `RunRequestParser` -- Level 1 template + input variable configuration builder
+  - `RunAckMessage` / `RunResultMessage` -- new wire protocol messages (`run_ack`, `run_result`)
+  - `WebDashboard.Builder` gains `toolCatalog()`, `modelCatalog()`, `maxConcurrentRuns()`, `maxRetainedCompletedRuns()`
+  - REST endpoints: `POST /api/runs`, `GET /api/runs`, `GET /api/runs/{runId}`, `GET /api/capabilities`
+  - Guide: `docs/guides/ensemble-control-api.md`
+  - Reference updated: `docs/reference/ensemble-configuration.md`
+
+
 ## [Unreleased] - Viz Observability: Tool & Agent I/O Visibility - 2026-03-30
 
 ### Added

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -276,6 +276,22 @@ All tools extend `AbstractAgentTool` with automatic metrics, logging, exception 
 - `MapReduceKitchenExample.java` with structured output
 - Full documentation: guide, example walkthrough, reference, README
 
+## What Works (as of Issue #299 -- Ensemble Control API Phase 1)
+
+**Ensemble Control API Phase 1 (agentensemble-web):**
+- `ToolCatalog` -- name-keyed `AgentTool` registry; allowlist for API requests; resolve/find/list/contains; immutable with builder
+- `ModelCatalog` -- alias-keyed `ChatModel` registry; streaming variant support; provider detection; immutable with builder
+- `RunState` -- mutable per-run lifecycle tracker with `Status` enum (ACCEPTED/RUNNING/COMPLETED/FAILED/CANCELLED/REJECTED)
+- `RunManager` -- fair `Semaphore`-based concurrency limiting; virtual-thread executor; eviction of oldest completed runs
+- `RunRequestParser` -- Level 1 template+inputs configuration builder; stateless, thread-safe
+- `RunAckMessage` / `RunResultMessage` -- new `ServerMessage` sealed interface permits; run_ack, run_result wire types
+- `WebDashboard.Builder` extended with `toolCatalog()`, `modelCatalog()`, `maxConcurrentRuns()`, `maxRetainedCompletedRuns()`
+- REST endpoints: `POST /api/runs`, `GET /api/runs`, `GET /api/runs/{runId}`, `GET /api/capabilities`
+- `WebDashboard.stop()` shuts down `RunManager` executor
+- `ensembleSupplier` pattern threads the template ensemble to route handlers
+- 81 new tests (475 total); JaCoCo LINE >= 90% and BRANCH >= 75% both pass
+- Guide: `docs/guides/ensemble-control-api.md`
+
 ## What's Left to Build
 
 ### Viz Observability -- Tool & Agent I/O Visibility (design complete, 2026-03-30)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Task Reflection: guides/task-reflection.md
     - TOON Context Format: guides/toon-format.md
     - Long-Running Ensembles: guides/long-running-ensembles.md
+    - Ensemble Control API: guides/ensemble-control-api.md
     - Cross-Ensemble Delegation: guides/cross-ensemble-delegation.md
     - Network Testing: guides/network-testing.md
   - Reference:


### PR DESCRIPTION
## Summary

Implements Phase 1 of the Ensemble Control API (design doc `docs/design/28-ensemble-control-api.md`).

External systems (CI pipelines, orchestrators, custom UIs) can now submit ensemble runs, query their status, and discover available capabilities via HTTP — without compiling Java code.

## New Classes

| Class | Module | Purpose |
|-------|--------|---------|
| `ToolCatalog` | agentensemble-web | Name-keyed `AgentTool` registry (allowlist for API requests) |
| `ModelCatalog` | agentensemble-web | Alias-keyed `ChatModel` registry with streaming + provider detection |
| `RunState` | agentensemble-web | Mutable per-run lifecycle tracker with `Status` enum |
| `RunManager` | agentensemble-web | Concurrency-limited async run executor (Semaphore + virtual threads + eviction) |
| `RunRequestParser` | agentensemble-web | Level 1 template + input variable configuration builder |
| `RunAckMessage` | agentensemble-web | New wire protocol message (`run_ack`) |
| `RunResultMessage` | agentensemble-web | New wire protocol message (`run_result`) |

## New REST Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/runs` | Submit a run with template inputs; 202 or 429 or 503 |
| `GET` | `/api/runs` | List retained runs; `?status=` and `?tag=key:value` filters |
| `GET` | `/api/runs/{runId}` | Full run detail with task outputs and metrics |
| `GET` | `/api/capabilities` | Registered tools, models, and preconfigured tasks |

## WebDashboard.Builder Changes

```java
WebDashboard dashboard = WebDashboard.builder()
    .port(7329)
    .toolCatalog(ToolCatalog.builder()
        .tool("web_search", webSearchTool)
        .build())
    .modelCatalog(ModelCatalog.builder()
        .model("sonnet", sonnetModel)
        .build())
    .maxConcurrentRuns(5)          // default: 5
    .maxRetainedCompletedRuns(100) // default: 100
    .build();
```

## Tests Added

- `ToolCatalogTest` (15 tests)
- `ModelCatalogTest` (26 tests, including 11 provider-detection stubs)
- `RunStateTest` (15 tests)
- `RunManagerTest` (16 tests: submit, completion, concurrency limiting, eviction, state queries)
- `RunRequestParserTest` (9 tests)
- `RunApiIntegrationTest` (17 tests: full HTTP round-trips against embedded Javalin)
- `WebDashboardTest` extended with new builder validation branches

**475 total tests; 0 failures. JaCoCo LINE >= 90% and BRANCH >= 75% both pass.**

## Documentation

- New guide: `docs/guides/ensemble-control-api.md`
- Reference updated: `docs/reference/ensemble-configuration.md`
- Navigation: `mkdocs.yml`

## Phase 1 scope (no scope creep)

- Level 1 only (template + input substitution). Level 2/3 parameterization, run cancellation, SSE, and REST review are Phase 2-5.
- No changes to `agentensemble-core` or any other module -- fully backward compatible.

Closes #299