### PR TITLE
feat: agentensemble-executor -- direct in-process invocation from Temporal and other workflow engines

### DIFF
--- a/agentensemble-bom/build.gradle.kts
+++ b/agentensemble-bom/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
         api(project(":agentensemble-workspace"))
         api(project(":agentensemble-transport-redis"))
         api(project(":agentensemble-coding"))
+        api(project(":agentensemble-executor"))
 
         // Individual tool modules
         api(project(":agentensemble-tools:calculator"))

--- a/agentensemble-examples/build.gradle.kts
+++ b/agentensemble-examples/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":agentensemble-core"))
+    implementation(project(":agentensemble-executor"))
     implementation(project(":agentensemble-memory"))
     implementation(project(":agentensemble-review"))
 
@@ -69,6 +70,7 @@ application {
 //   ./gradlew :agentensemble-examples:runCodingAgent --args="/path/to/project"
 //   ./gradlew :agentensemble-examples:runIsolatedCoding --args="/path/to/git/repo"
 //   ./gradlew :agentensemble-examples:runMcpCoding --args="/path/to/git/project"
+//   ./gradlew :agentensemble-examples:runExecutor --args="quantum computing"
 
 mapOf(
     "runResearchWriter"  to "net.agentensemble.examples.ResearchWriterExample",
@@ -97,6 +99,7 @@ mapOf(
     "runCodingAgent" to "net.agentensemble.examples.CodingAgentExample",
     "runIsolatedCoding" to "net.agentensemble.examples.IsolatedCodingExample",
     "runMcpCoding" to "net.agentensemble.examples.McpCodingExample",
+    "runExecutor" to "net.agentensemble.examples.ExecutorExample",
 ).forEach { (taskName, mainClassName) ->
     tasks.register<JavaExec>(taskName) {
         group = "examples"

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/ExecutorExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/ExecutorExample.java
@@ -1,0 +1,146 @@
+package net.agentensemble.examples;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.Map;
+import net.agentensemble.executor.AgentSpec;
+import net.agentensemble.executor.EnsembleExecutor;
+import net.agentensemble.executor.EnsembleRequest;
+import net.agentensemble.executor.SimpleModelProvider;
+import net.agentensemble.executor.SimpleToolProvider;
+import net.agentensemble.executor.TaskExecutor;
+import net.agentensemble.executor.TaskRequest;
+import net.agentensemble.executor.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demonstrates the agentensemble-executor module for direct in-process invocation from an
+ * external workflow engine (Temporal, AWS Step Functions, Kafka Streams, etc.).
+ *
+ * Two modes are shown:
+ *   Part 1 -- TaskExecutor: each AgentEnsemble task is called as a separate step.
+ *             The caller passes context (upstream outputs) between steps explicitly.
+ *             This mirrors how a Temporal workflow would sequence activities.
+ *
+ *   Part 2 -- EnsembleExecutor: a full multi-task ensemble runs inside a single call.
+ *             AgentEnsemble's internal sequential orchestration handles task ordering.
+ *
+ * Heartbeat callbacks are wired to log output, illustrating how Temporal would receive
+ * heartbeats from Activity.getExecutionContext()::heartbeat.
+ *
+ * Usage:
+ *   Set OPENAI_API_KEY environment variable, then run:
+ *   ./gradlew :agentensemble-examples:runExecutor
+ *
+ * To change the topic:
+ *   ./gradlew :agentensemble-examples:runExecutor --args="quantum computing"
+ */
+public class ExecutorExample {
+
+    private static final Logger log = LoggerFactory.getLogger(ExecutorExample.class);
+
+    public static void main(String[] args) throws Exception {
+        String topic = args.length > 0 ? String.join(" ", args) : "the future of AI agents";
+
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("OPENAI_API_KEY environment variable is not set.");
+        }
+
+        var model = OpenAiChatModel.builder()
+                .apiKey(apiKey)
+                .modelName("gpt-4o-mini")
+                .temperature(0.7)
+                .build();
+
+        var modelProvider = SimpleModelProvider.of(model);
+        var toolProvider = SimpleToolProvider.empty(); // no external tools in this example
+
+        log.info("=== Part 1: TaskExecutor (task-per-activity pattern) ===");
+        runWithTaskExecutor(topic, modelProvider, toolProvider);
+
+        log.info("");
+        log.info("=== Part 2: EnsembleExecutor (ensemble-per-activity pattern) ===");
+        runWithEnsembleExecutor(topic, modelProvider, toolProvider);
+    }
+
+    // ========================
+    // Part 1: TaskExecutor
+    // ========================
+
+    /**
+     * Demonstrates calling AgentEnsemble one task at a time. Context (the research output)
+     * is passed explicitly to the downstream writing task -- mirroring how a Temporal workflow
+     * would pass activity results between sequential activities.
+     */
+    private static void runWithTaskExecutor(
+            String topic, SimpleModelProvider modelProvider, SimpleToolProvider toolProvider) {
+        var executor = new TaskExecutor(modelProvider, toolProvider);
+
+        // Step 1: research
+        log.info("Executing research task for topic: {}", topic);
+        TaskResult research = executor.execute(
+                TaskRequest.builder()
+                        .description("Research the topic: {topic}")
+                        .expectedOutput("A concise research summary with key findings")
+                        .agent(AgentSpec.of("Research Analyst", "Find accurate information on any topic"))
+                        .inputs(Map.of("topic", topic))
+                        .build(),
+                // In Temporal this would be: Activity.getExecutionContext()::heartbeat
+                // Here we log the heartbeat detail to show what would be sent.
+                heartbeat -> log.info("  [heartbeat] {}", heartbeat));
+
+        log.info("Research complete: {} chars, exit={}", research.output().length(), research.exitReason());
+
+        // Step 2: write -- injects research output as a template variable {research}
+        log.info("Executing writing task for topic: {}", topic);
+        TaskResult article = executor.execute(
+                TaskRequest.builder()
+                        .description("Write a blog post about {topic} based on this research: {research}")
+                        .expectedOutput("A polished, engaging 300-word blog post")
+                        .agent(AgentSpec.of("Technical Writer", "Write clear, compelling content"))
+                        .context(Map.of("research", research.output()))
+                        .inputs(Map.of("topic", topic))
+                        .build(),
+                heartbeat -> log.info("  [heartbeat] {}", heartbeat));
+
+        log.info("Writing complete: exit={}", article.exitReason());
+        log.info("Final article ({} chars):", article.output().length());
+        log.info("---");
+        log.info("{}", article.output());
+        log.info("---");
+    }
+
+    // ========================
+    // Part 2: EnsembleExecutor
+    // ========================
+
+    /**
+     * Demonstrates running a full two-task ensemble as a single call.
+     * AgentEnsemble handles the sequential orchestration internally.
+     */
+    private static void runWithEnsembleExecutor(
+            String topic, SimpleModelProvider modelProvider, SimpleToolProvider toolProvider) {
+        var executor = new EnsembleExecutor(modelProvider, toolProvider);
+
+        var result = executor.execute(
+                EnsembleRequest.builder()
+                        .task(TaskRequest.of("Research {topic}", "A concise research summary"))
+                        .task(TaskRequest.of(
+                                "Write a blog post about {topic}", "A polished, engaging 300-word blog post"))
+                        .workflow("SEQUENTIAL")
+                        .inputs(Map.of("topic", topic))
+                        .build(),
+                heartbeat -> log.info("  [heartbeat] {}", heartbeat));
+
+        log.info(
+                "Ensemble complete: {} tasks, {}ms, exit={}",
+                result.taskOutputs().size(),
+                result.totalDurationMs(),
+                result.exitReason());
+        log.info("Final output ({} chars):", result.finalOutput().length());
+        log.info("---");
+        log.info("{}", result.finalOutput());
+        log.info("---");
+    }
+}

--- a/agentensemble-executor/build.gradle.kts
+++ b/agentensemble-executor/build.gradle.kts
@@ -1,0 +1,99 @@
+import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
+
+plugins {
+    `java-library`
+    id("com.vanniktech.maven.publish")
+}
+
+// Coverage verification -- wired into check so CI fails if coverage drops below thresholds.
+tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                minimum = "0.85".toBigDecimal()
+            }
+            limit {
+                counter = "BRANCH"
+                minimum = "0.70".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("jacocoTestCoverageVerification"))
+    dependsOn(tasks.named("javadoc"))
+}
+
+dependencies {
+    // Core ensemble API -- exposes Agent, Task, Ensemble, EnsembleOutput, EnsembleListener, etc.
+    api(project(":agentensemble-core"))
+
+    // LangChain4j core -- ChatLanguageModel is part of the ModelProvider public API
+    api(libs.langchain4j.core)
+
+    // Logging facade -- no implementation, users bring their own
+    implementation(libs.slf4j.api)
+
+    // Lombok -- compile-time only, not shipped in the jar
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+
+    // Test dependencies
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.slf4j.simple)
+
+    testCompileOnly(libs.lombok)
+    testAnnotationProcessor(libs.lombok)
+
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+mavenPublishing {
+    coordinates(
+        groupId = "net.agentensemble",
+        artifactId = "agentensemble-executor",
+        version = "${project.version}",
+    )
+
+    publishToMavenCentral()
+    signAllPublications()
+
+    pom {
+        name = "AgentEnsemble Executor"
+        description =
+            "Orchestrator-agnostic task and ensemble executor for AgentEnsemble -- enables direct " +
+                "in-process invocation from Temporal, AWS Step Functions, Kafka Streams, or any " +
+                "external workflow engine"
+        url = "https://github.com/AgentEnsemble/agentensemble"
+
+        licenses {
+            license {
+                name = "MIT License"
+                url = "https://opensource.org/licenses/MIT"
+            }
+        }
+
+        developers {
+            developer {
+                id = "agentensemble"
+                name = "AgentEnsemble"
+                url = "https://github.com/AgentEnsemble"
+            }
+        }
+
+        scm {
+            connection = "scm:git:git://github.com/AgentEnsemble/agentensemble.git"
+            developerConnection = "scm:git:ssh://github.com/AgentEnsemble/agentensemble.git"
+            url = "https://github.com/AgentEnsemble/agentensemble"
+        }
+
+        issueManagement {
+            system = "GitHub"
+            url = "https://github.com/AgentEnsemble/agentensemble/issues"
+        }
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/AgentSpec.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/AgentSpec.java
@@ -1,0 +1,81 @@
+package net.agentensemble.executor;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Specification for configuring an agent within a {@link TaskRequest}.
+ *
+ * <p>When an {@code AgentSpec} is provided, {@link TaskExecutor} constructs an explicit
+ * {@link net.agentensemble.Agent} with the given role, goal, and tool set, rather than
+ * auto-synthesizing one from the task description.
+ *
+ * <p>All fields except {@code role} and {@code goal} are optional:
+ * <ul>
+ *   <li>{@code background} -- optional persona context injected into the agent's system prompt</li>
+ *   <li>{@code toolNames} -- names resolved by the {@link ToolProvider} registered on the executor</li>
+ *   <li>{@code maxIterations} -- overrides the default ReAct loop iteration limit</li>
+ * </ul>
+ *
+ * <h2>Example</h2>
+ * <pre>
+ * AgentSpec researcher = AgentSpec.builder()
+ *     .role("Research Analyst")
+ *     .goal("Find accurate, comprehensive information on any topic")
+ *     .background("You are a meticulous researcher with access to web search and date tools")
+ *     .toolNames(List.of("web-search", "datetime"))
+ *     .maxIterations(15)
+ *     .build();
+ *
+ * // Or with the convenience factory:
+ * AgentSpec writer = AgentSpec.of("Technical Writer", "Write clear, engaging documentation");
+ * </pre>
+ */
+@Value
+@Builder
+public class AgentSpec {
+
+    /** Role label for the agent (e.g., "Research Analyst", "Technical Writer"). Required. */
+    String role;
+
+    /** Primary objective for the agent (e.g., "Find accurate, comprehensive information"). Required. */
+    String goal;
+
+    /** Optional background context injected into the agent's system prompt. */
+    String background;
+
+    /**
+     * Tool names to equip the agent with. Each name is resolved by the {@link ToolProvider}
+     * registered on the executor. A null or empty list produces an agent with no tools.
+     */
+    List<String> toolNames;
+
+    /**
+     * Maximum number of ReAct loop iterations. When null, the framework default (25) is used.
+     */
+    Integer maxIterations;
+
+    /**
+     * Convenience factory: creates an {@code AgentSpec} with role and goal, no tools or background.
+     *
+     * @param role the agent role
+     * @param goal the agent goal
+     * @return a minimal agent spec
+     */
+    public static AgentSpec of(String role, String goal) {
+        return builder().role(role).goal(goal).build();
+    }
+
+    /**
+     * Convenience factory: creates an {@code AgentSpec} with role, goal, and background.
+     *
+     * @param role       the agent role
+     * @param goal       the agent goal
+     * @param background the agent background context
+     * @return an agent spec with background
+     */
+    public static AgentSpec of(String role, String goal, String background) {
+        return builder().role(role).goal(goal).background(background).build();
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleExecutor.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleExecutor.java
@@ -2,7 +2,9 @@ package net.agentensemble.executor;
 
 import dev.langchain4j.model.chat.ChatModel;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import net.agentensemble.Agent;
@@ -20,6 +22,19 @@ import net.agentensemble.workflow.Workflow;
  * (sequential, parallel, or hierarchical) to handle a complete pipeline within a single
  * external-workflow activity. For finer-grained control -- where each AgentEnsemble task maps
  * to a separate Temporal activity -- use {@link TaskExecutor} instead.
+ *
+ * <h2>Template variable resolution</h2>
+ *
+ * <p>Each task's {@code description} and {@code expectedOutput} are pre-resolved before the task
+ * is submitted to the ensemble. The resolution order for a given task is:
+ * <ol>
+ *   <li>Global inputs from {@code EnsembleRequest.getInputs()} (lowest precedence)</li>
+ *   <li>Per-task context from {@code TaskRequest.getContext()}</li>
+ *   <li>Per-task inputs from {@code TaskRequest.getInputs()} (highest precedence)</li>
+ * </ol>
+ * <p>Because each task's templates are resolved independently with its own merged map, per-task
+ * context and inputs do not leak across tasks -- a {@code {research}} variable set on task 1
+ * will not appear in task 2's resolved description unless task 2 also declares it.
  *
  * <h2>Usage in a Temporal Activity</h2>
  * <pre>
@@ -123,26 +138,16 @@ public class EnsembleExecutor {
 
         var ensembleBuilder = Ensemble.builder().chatLanguageModel(defaultModel);
 
-        // Apply global inputs first (lowest precedence; per-task inputs applied below).
-        if (request.getInputs() != null) {
-            request.getInputs().forEach(ensembleBuilder::input);
-        }
-
-        // Build each task and accumulate its inputs.
+        // Build each task. Templates are pre-resolved per task using a merged map of:
+        //   global inputs (lowest) < per-task context < per-task inputs (highest).
+        // This prevents per-task inputs from leaking into other tasks via the Ensemble's
+        // single shared input map.
         for (TaskRequest taskRequest : request.getTasks()) {
             ChatModel taskModel =
                     taskRequest.getModelName() != null ? modelProvider.get(taskRequest.getModelName()) : defaultModel;
 
-            ensembleBuilder.task(buildTask(taskRequest, taskModel));
-
-            // Per-task context entries (lower precedence within the task).
-            if (taskRequest.getContext() != null) {
-                taskRequest.getContext().forEach(ensembleBuilder::input);
-            }
-            // Per-task explicit inputs (higher precedence, override context and global inputs).
-            if (taskRequest.getInputs() != null) {
-                taskRequest.getInputs().forEach(ensembleBuilder::input);
-            }
+            Map<String, String> mergedInputs = buildMergedInputs(request.getInputs(), taskRequest);
+            ensembleBuilder.task(buildTask(taskRequest, taskModel, mergedInputs));
         }
 
         // Apply workflow mode when explicitly specified.
@@ -167,12 +172,50 @@ public class EnsembleExecutor {
         return modelName != null ? modelProvider.get(modelName) : modelProvider.getDefault();
     }
 
-    private Task buildTask(TaskRequest request, ChatModel model) {
-        var taskBuilder = Task.builder().description(request.getDescription());
-
-        if (request.getExpectedOutput() != null) {
-            taskBuilder.expectedOutput(request.getExpectedOutput());
+    /**
+     * Builds the per-task merged input map in precedence order:
+     * global inputs (lowest) < per-task context < per-task inputs (highest).
+     */
+    private static Map<String, String> buildMergedInputs(Map<String, String> globalInputs, TaskRequest taskRequest) {
+        Map<String, String> merged = new LinkedHashMap<>();
+        if (globalInputs != null) {
+            merged.putAll(globalInputs);
         }
+        if (taskRequest.getContext() != null) {
+            merged.putAll(taskRequest.getContext());
+        }
+        if (taskRequest.getInputs() != null) {
+            merged.putAll(taskRequest.getInputs());
+        }
+        return Map.copyOf(merged);
+    }
+
+    /**
+     * Resolves {@code {variable}} placeholders in the given template string using the provided
+     * variable map. Returns the template unchanged when it is null or the map is empty.
+     */
+    static String resolveTemplate(String template, Map<String, String> vars) {
+        if (template == null || vars.isEmpty()) {
+            return template;
+        }
+        String result = template;
+        for (Map.Entry<String, String> entry : vars.entrySet()) {
+            result = result.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+        return result;
+    }
+
+    private Task buildTask(TaskRequest request, ChatModel model, Map<String, String> mergedInputs) {
+        // Pre-resolve templates so per-task variables do not leak into other tasks.
+        String description = resolveTemplate(request.getDescription(), mergedInputs);
+
+        // When expectedOutput is null fall back to Task.DEFAULT_EXPECTED_OUTPUT so that
+        // TaskRequest.of(String description) (single-arg factory) is always executable.
+        String expectedOutput = request.getExpectedOutput() != null
+                ? resolveTemplate(request.getExpectedOutput(), mergedInputs)
+                : Task.DEFAULT_EXPECTED_OUTPUT;
+
+        var taskBuilder = Task.builder().description(description).expectedOutput(expectedOutput);
 
         if (request.getAgent() != null) {
             taskBuilder.agent(buildAgent(request.getAgent(), model));

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleExecutor.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleExecutor.java
@@ -1,0 +1,219 @@
+package net.agentensemble.executor;
+
+import dev.langchain4j.model.chat.ChatModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+import net.agentensemble.task.TaskOutput;
+import net.agentensemble.workflow.Workflow;
+
+/**
+ * Executes an {@link EnsembleRequest} in-process by building and running a full multi-task
+ * AgentEnsemble.
+ *
+ * <p>Use {@code EnsembleExecutor} when you want AgentEnsemble's internal orchestration engine
+ * (sequential, parallel, or hierarchical) to handle a complete pipeline within a single
+ * external-workflow activity. For finer-grained control -- where each AgentEnsemble task maps
+ * to a separate Temporal activity -- use {@link TaskExecutor} instead.
+ *
+ * <h2>Usage in a Temporal Activity</h2>
+ * <pre>
+ * public class ResearchPipelineActivityImpl implements ResearchPipelineActivity {
+ *
+ *     private final EnsembleExecutor executor = new EnsembleExecutor(
+ *         SimpleModelProvider.of(OpenAiChatModel.builder()
+ *             .apiKey(System.getenv("OPENAI_API_KEY"))
+ *             .modelName("gpt-4o-mini")
+ *             .build())
+ *     );
+ *
+ *     {@literal @}Override
+ *     public EnsembleResult run(EnsembleRequest request) {
+ *         return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+ *     }
+ * }
+ * </pre>
+ *
+ * <h2>Building a request</h2>
+ * <pre>
+ * EnsembleRequest request = EnsembleRequest.builder()
+ *     .task(TaskRequest.of("Research {topic}", "A comprehensive research summary"))
+ *     .task(TaskRequest.of("Write a blog post about {topic}", "A polished blog post"))
+ *     .workflow("SEQUENTIAL")
+ *     .inputs(Map.of("topic", "Artificial Intelligence"))
+ *     .build();
+ *
+ * EnsembleResult result = executor.execute(request);
+ * System.out.println(result.finalOutput());
+ * </pre>
+ *
+ * <p>Thread safety: {@code EnsembleExecutor} is thread-safe when the underlying
+ * {@link ModelProvider} and {@link ToolProvider} are thread-safe.
+ */
+public class EnsembleExecutor {
+
+    private final ModelProvider modelProvider;
+    private final ToolProvider toolProvider;
+
+    /**
+     * Creates an {@code EnsembleExecutor} that uses the given model provider. No tools are
+     * available to agents; use this constructor for LLM-only pipelines.
+     *
+     * @param modelProvider provides the {@link ChatModel} for each task; must not be null
+     * @throws NullPointerException if modelProvider is null
+     */
+    public EnsembleExecutor(ModelProvider modelProvider) {
+        this(modelProvider, SimpleToolProvider.empty());
+    }
+
+    /**
+     * Creates an {@code EnsembleExecutor} with both a model provider and a tool provider.
+     *
+     * @param modelProvider provides the {@link ChatModel} for each task; must not be null
+     * @param toolProvider  resolves tool instances by name from {@code AgentSpec.getToolNames()};
+     *                      must not be null
+     * @throws NullPointerException if either argument is null
+     */
+    public EnsembleExecutor(ModelProvider modelProvider, ToolProvider toolProvider) {
+        this.modelProvider = Objects.requireNonNull(modelProvider, "modelProvider must not be null");
+        this.toolProvider = Objects.requireNonNull(toolProvider, "toolProvider must not be null");
+    }
+
+    /**
+     * Executes the given ensemble request synchronously without heartbeating.
+     *
+     * <p>Equivalent to {@code execute(request, null)}.
+     *
+     * @param request the ensemble to run; must not be null and must contain at least one task
+     * @return the ensemble result; never null
+     * @throws NullPointerException     if request is null
+     * @throws IllegalArgumentException if the request contains no tasks
+     */
+    public EnsembleResult execute(EnsembleRequest request) {
+        return execute(request, null);
+    }
+
+    /**
+     * Executes the given ensemble request synchronously, emitting {@link HeartbeatDetail} events
+     * to the given consumer throughout execution.
+     *
+     * <p>For Temporal: {@code executor.execute(request, Activity.getExecutionContext()::heartbeat)}.
+     * Heartbeats keep the activity alive across long-running multi-task LLM pipelines.
+     *
+     * @param request           the ensemble to run; must not be null and must contain at least one task
+     * @param heartbeatConsumer receives {@link HeartbeatDetail} instances during execution;
+     *                          null disables heartbeating
+     * @return the ensemble result; never null
+     * @throws NullPointerException     if request is null
+     * @throws IllegalArgumentException if the request contains no tasks
+     */
+    public EnsembleResult execute(EnsembleRequest request, Consumer<Object> heartbeatConsumer) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        if (request.getTasks() == null || request.getTasks().isEmpty()) {
+            throw new IllegalArgumentException("EnsembleRequest must contain at least one task");
+        }
+
+        ChatModel defaultModel = resolveModel(request.getModelName());
+
+        var ensembleBuilder = Ensemble.builder().chatLanguageModel(defaultModel);
+
+        // Apply global inputs first (lowest precedence; per-task inputs applied below).
+        if (request.getInputs() != null) {
+            request.getInputs().forEach(ensembleBuilder::input);
+        }
+
+        // Build each task and accumulate its inputs.
+        for (TaskRequest taskRequest : request.getTasks()) {
+            ChatModel taskModel =
+                    taskRequest.getModelName() != null ? modelProvider.get(taskRequest.getModelName()) : defaultModel;
+
+            ensembleBuilder.task(buildTask(taskRequest, taskModel));
+
+            // Per-task context entries (lower precedence within the task).
+            if (taskRequest.getContext() != null) {
+                taskRequest.getContext().forEach(ensembleBuilder::input);
+            }
+            // Per-task explicit inputs (higher precedence, override context and global inputs).
+            if (taskRequest.getInputs() != null) {
+                taskRequest.getInputs().forEach(ensembleBuilder::input);
+            }
+        }
+
+        // Apply workflow mode when explicitly specified.
+        if (request.getWorkflow() != null) {
+            ensembleBuilder.workflow(Workflow.valueOf(request.getWorkflow()));
+        }
+
+        if (heartbeatConsumer != null) {
+            ensembleBuilder.listener(new HeartbeatEnsembleListener(heartbeatConsumer));
+        }
+
+        EnsembleOutput output = ensembleBuilder.build().run();
+
+        return toEnsembleResult(output);
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private ChatModel resolveModel(String modelName) {
+        return modelName != null ? modelProvider.get(modelName) : modelProvider.getDefault();
+    }
+
+    private Task buildTask(TaskRequest request, ChatModel model) {
+        var taskBuilder = Task.builder().description(request.getDescription());
+
+        if (request.getExpectedOutput() != null) {
+            taskBuilder.expectedOutput(request.getExpectedOutput());
+        }
+
+        if (request.getAgent() != null) {
+            taskBuilder.agent(buildAgent(request.getAgent(), model));
+        }
+
+        return taskBuilder.build();
+    }
+
+    private Agent buildAgent(AgentSpec spec, ChatModel model) {
+        var agentBuilder =
+                Agent.builder().role(spec.getRole()).goal(spec.getGoal()).llm(model);
+
+        if (spec.getBackground() != null) {
+            agentBuilder.background(spec.getBackground());
+        }
+        if (spec.getMaxIterations() != null) {
+            agentBuilder.maxIterations(spec.getMaxIterations());
+        }
+
+        List<String> toolNames = spec.getToolNames();
+        if (toolNames != null && !toolNames.isEmpty()) {
+            agentBuilder.tools(toolProvider.get(toolNames));
+        }
+
+        return agentBuilder.build();
+    }
+
+    private static EnsembleResult toEnsembleResult(EnsembleOutput output) {
+        List<String> taskOutputStrings = new ArrayList<>();
+        if (output.getTaskOutputs() != null) {
+            for (TaskOutput taskOutput : output.getTaskOutputs()) {
+                taskOutputStrings.add(taskOutput.getRaw());
+            }
+        }
+
+        long durationMs =
+                output.getTotalDuration() != null ? output.getTotalDuration().toMillis() : 0L;
+        String exitReason =
+                output.getExitReason() != null ? output.getExitReason().name() : "COMPLETED";
+
+        return new EnsembleResult(
+                output.getRaw(), List.copyOf(taskOutputStrings), durationMs, output.getTotalToolCalls(), exitReason);
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleRequest.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleRequest.java
@@ -18,9 +18,16 @@ import lombok.Value;
  * enum values: {@code "SEQUENTIAL"}, {@code "PARALLEL"}, or {@code "HIERARCHICAL"}.
  * When null, AgentEnsemble infers the workflow from task context dependencies.
  *
- * <p>Cross-task context within an ensemble run is handled internally by AgentEnsemble.
- * The per-task {@code TaskRequest.getContext()} entries are injected as additional template
- * variable inputs for that specific task.
+ * <p>Template variables in each task's {@code description} and {@code expectedOutput} are
+ * resolved per task by {@link EnsembleExecutor} before the tasks are submitted to the
+ * ensemble. Resolution precedence (lowest to highest):
+ * <ol>
+ *   <li>{@code getInputs()} -- global inputs applied to every task</li>
+ *   <li>{@code TaskRequest.getContext()} -- per-task upstream outputs</li>
+ *   <li>{@code TaskRequest.getInputs()} -- per-task explicit overrides</li>
+ * </ol>
+ * <p>Because resolution happens per task, per-task context and inputs are isolated -- a
+ * variable set on one task does not appear in another task's resolved text.
  *
  * <h2>Example</h2>
  * <pre>
@@ -50,7 +57,7 @@ public class EnsembleRequest {
 
     /**
      * Global template variable values applied to all tasks in the ensemble.
-     * Per-task {@link TaskRequest#getInputs()} entries take precedence when keys collide.
+     * Per-task {@code TaskRequest.getInputs()} entries take precedence when keys collide.
      */
     Map<String, String> inputs;
 

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleRequest.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleRequest.java
@@ -1,0 +1,62 @@
+package net.agentensemble.executor;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+
+/**
+ * A request to run a multi-task ensemble via {@link EnsembleExecutor}.
+ *
+ * <p>Use {@code EnsembleExecutor} when you want AgentEnsemble's internal orchestration
+ * (sequential, parallel, or hierarchical) to handle a full pipeline within a single
+ * external-workflow activity. For finer-grained control -- where each AgentEnsemble task
+ * maps to a separate Temporal activity -- use {@link TaskExecutor} instead.
+ *
+ * <p>The {@code getWorkflow()} string maps to {@code net.agentensemble.workflow.Workflow}
+ * enum values: {@code "SEQUENTIAL"}, {@code "PARALLEL"}, or {@code "HIERARCHICAL"}.
+ * When null, AgentEnsemble infers the workflow from task context dependencies.
+ *
+ * <p>Cross-task context within an ensemble run is handled internally by AgentEnsemble.
+ * The per-task {@code TaskRequest.getContext()} entries are injected as additional template
+ * variable inputs for that specific task.
+ *
+ * <h2>Example</h2>
+ * <pre>
+ * EnsembleRequest request = EnsembleRequest.builder()
+ *     .task(TaskRequest.of("Research artificial intelligence trends", "A research summary"))
+ *     .task(TaskRequest.of("Write a blog post about AI trends", "A polished blog post"))
+ *     .workflow("SEQUENTIAL")
+ *     .inputs(Map.of("audience", "software engineers"))
+ *     .build();
+ *
+ * EnsembleResult result = executor.execute(request);
+ * </pre>
+ */
+@Value
+@Builder
+public class EnsembleRequest {
+
+    /** The ordered list of tasks to run. At least one task must be provided. */
+    @Singular
+    List<TaskRequest> tasks;
+
+    /**
+     * Workflow mode. One of {@code "SEQUENTIAL"}, {@code "PARALLEL"}, {@code "HIERARCHICAL"},
+     * or {@code null} to let AgentEnsemble infer the mode from task dependencies.
+     */
+    String workflow;
+
+    /**
+     * Global template variable values applied to all tasks in the ensemble.
+     * Per-task {@link TaskRequest#getInputs()} entries take precedence when keys collide.
+     */
+    Map<String, String> inputs;
+
+    /**
+     * Optional model name resolved by the {@link ModelProvider} on the executor. When null,
+     * the provider's default model is used for all tasks that do not specify their own model.
+     */
+    String modelName;
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleResult.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/EnsembleResult.java
@@ -1,0 +1,28 @@
+package net.agentensemble.executor;
+
+import java.util.List;
+
+/**
+ * The result of executing an {@link EnsembleRequest} via {@link EnsembleExecutor}.
+ *
+ * <p>Contains the final output from the last completed task, all per-task output strings
+ * in execution order, aggregate timing, total tool call count, and the reason the run ended.
+ *
+ * @param finalOutput     the final text output from the last completed task
+ * @param taskOutputs     per-task output strings in execution order; never null
+ * @param totalDurationMs wall-clock duration for the full ensemble run in milliseconds
+ * @param totalToolCalls  total tool calls made across all tasks
+ * @param exitReason      why the ensemble run terminated (e.g., {@code "COMPLETED"}, {@code "ERROR"})
+ */
+public record EnsembleResult(
+        String finalOutput, List<String> taskOutputs, long totalDurationMs, int totalToolCalls, String exitReason) {
+
+    /**
+     * Returns {@code true} when all tasks completed successfully without early exit or error.
+     *
+     * @return true if the exit reason is {@code "COMPLETED"}
+     */
+    public boolean isComplete() {
+        return "COMPLETED".equals(exitReason);
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/FakeEnsembleExecutor.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/FakeEnsembleExecutor.java
@@ -1,0 +1,200 @@
+package net.agentensemble.executor;
+
+import dev.langchain4j.model.chat.DisabledChatModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A test double for {@link EnsembleExecutor} that returns configurable fake results without
+ * invoking any language model.
+ *
+ * <p>Because {@code FakeEnsembleExecutor} extends {@code EnsembleExecutor}, it can be injected
+ * anywhere an {@code EnsembleExecutor} is expected.
+ *
+ * <p>For each task in the {@link EnsembleRequest}, the fake evaluates its rules in registration
+ * order and returns the first matching output. The {@code EnsembleResult.finalOutput()} is taken
+ * from the last task's output, mirroring the behaviour of the real executor.
+ *
+ * <h2>Basic usage</h2>
+ *
+ * <pre>
+ * FakeEnsembleExecutor fake = FakeEnsembleExecutor.alwaysReturns("Pipeline complete.");
+ * EnsembleResult result = fake.execute(request);
+ * assertThat(result.isComplete()).isTrue();
+ * </pre>
+ *
+ * <h2>Rule-based responses</h2>
+ *
+ * <pre>
+ * FakeEnsembleExecutor fake = FakeEnsembleExecutor.builder()
+ *     .whenDescriptionContains("Research", "Research output: AI is growing.")
+ *     .whenDescriptionContains("Write",    "Final article: AI transforms society.")
+ *     .defaultOutput("Generic output")
+ *     .build();
+ *
+ * // Two-task ensemble -- each task gets its matching output
+ * EnsembleResult result = fake.execute(twoTaskRequest);
+ * assertThat(result.taskOutputs()).hasSize(2);
+ * assertThat(result.finalOutput()).isEqualTo("Final article: AI transforms society.");
+ * </pre>
+ *
+ * <p>All results have {@code exitReason = "COMPLETED"}, {@code totalToolCalls = 0}, and
+ * {@code totalDurationMs = 1L} so {@link EnsembleResult#isComplete()} always returns {@code true}.
+ *
+ * <p>Heartbeat callbacks are accepted but no events are emitted.
+ */
+public final class FakeEnsembleExecutor extends EnsembleExecutor {
+
+    /**
+     * No-op provider used only to satisfy the EnsembleExecutor constructor.
+     * It is never invoked because execute() is fully overridden in this class.
+     */
+    private static final SimpleModelProvider NO_OP_PROVIDER = SimpleModelProvider.of(new DisabledChatModel());
+
+    private final List<Rule> rules;
+    private final String defaultOutput;
+
+    private FakeEnsembleExecutor(List<Rule> rules, String defaultOutput) {
+        super(NO_OP_PROVIDER);
+        this.rules = List.copyOf(rules);
+        this.defaultOutput = Objects.requireNonNull(defaultOutput, "defaultOutput must not be null");
+    }
+
+    /**
+     * Creates a fake executor that returns the given output string for every task in every
+     * {@link #execute} call.
+     *
+     * @param output the output to return for each task; must not be null
+     * @return a configured fake executor
+     */
+    public static FakeEnsembleExecutor alwaysReturns(String output) {
+        Objects.requireNonNull(output, "output must not be null");
+        return new FakeEnsembleExecutor(List.of(), output);
+    }
+
+    /**
+     * Returns a builder for configuring rule-based fake responses.
+     *
+     * @return a fresh builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public EnsembleResult execute(EnsembleRequest request) {
+        return execute(request, null);
+    }
+
+    /**
+     * Returns a fake {@link EnsembleResult} without invoking any language model.
+     * Each task in the request is matched against the configured rules independently.
+     * The heartbeat consumer is accepted but no events are emitted.
+     *
+     * @param request           the ensemble request; must not be null and must contain at least one task
+     * @param heartbeatConsumer accepted but ignored in the fake
+     * @return a completed {@link EnsembleResult} with per-task fake outputs
+     * @throws IllegalArgumentException if the request contains no tasks
+     */
+    @Override
+    public EnsembleResult execute(EnsembleRequest request, Consumer<Object> heartbeatConsumer) {
+        Objects.requireNonNull(request, "request must not be null");
+        if (request.getTasks() == null || request.getTasks().isEmpty()) {
+            throw new IllegalArgumentException("EnsembleRequest must contain at least one task");
+        }
+
+        List<String> taskOutputs = new ArrayList<>();
+        for (TaskRequest taskRequest : request.getTasks()) {
+            String output = rules.stream()
+                    .filter(r -> r.matches(taskRequest))
+                    .findFirst()
+                    .map(r -> r.output)
+                    .orElse(defaultOutput);
+            taskOutputs.add(output);
+        }
+
+        String finalOutput = taskOutputs.getLast();
+        return new EnsembleResult(finalOutput, List.copyOf(taskOutputs), 1L, 0, "COMPLETED");
+    }
+
+    // ========================
+    // Builder
+    // ========================
+
+    /**
+     * Fluent builder for {@link FakeEnsembleExecutor}.
+     */
+    public static final class Builder {
+
+        private final List<Rule> rules = new ArrayList<>();
+        private String defaultOutput = "Fake ensemble output.";
+
+        private Builder() {}
+
+        /**
+         * Returns the configured output when a task's description contains the given
+         * substring (case-sensitive).
+         *
+         * <p>Rules are evaluated in registration order; the first match wins per task.
+         *
+         * @param substring substring to search for in {@code TaskRequest.getDescription()}
+         * @param output    output to return when matched; must not be null
+         * @return this builder
+         */
+        public Builder whenDescriptionContains(String substring, String output) {
+            Objects.requireNonNull(substring, "substring must not be null");
+            Objects.requireNonNull(output, "output must not be null");
+            rules.add(new Rule(
+                    req -> req.getDescription() != null && req.getDescription().contains(substring), output));
+            return this;
+        }
+
+        /**
+         * Returns the configured output when a task's description satisfies the given predicate.
+         *
+         * @param predicate applied to {@code TaskRequest.getDescription()}; must not be null
+         * @param output    output to return when matched; must not be null
+         * @return this builder
+         */
+        public Builder whenDescription(Predicate<String> predicate, String output) {
+            Objects.requireNonNull(predicate, "predicate must not be null");
+            Objects.requireNonNull(output, "output must not be null");
+            rules.add(new Rule(req -> req.getDescription() != null && predicate.test(req.getDescription()), output));
+            return this;
+        }
+
+        /**
+         * Sets the output returned when no rule matches a task.
+         * Defaults to {@code "Fake ensemble output."} when not set.
+         *
+         * @param output the default output; must not be null
+         * @return this builder
+         */
+        public Builder defaultOutput(String output) {
+            this.defaultOutput = Objects.requireNonNull(output, "output must not be null");
+            return this;
+        }
+
+        /**
+         * Builds the fake executor.
+         *
+         * @return the configured {@link FakeEnsembleExecutor}
+         */
+        public FakeEnsembleExecutor build() {
+            return new FakeEnsembleExecutor(rules, defaultOutput);
+        }
+    }
+
+    // ========================
+    // Internal
+    // ========================
+
+    private record Rule(Predicate<TaskRequest> predicate, String output) {
+        boolean matches(TaskRequest request) {
+            return predicate.test(request);
+        }
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/FakeTaskExecutor.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/FakeTaskExecutor.java
@@ -1,0 +1,230 @@
+package net.agentensemble.executor;
+
+import dev.langchain4j.model.chat.DisabledChatModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A test double for {@link TaskExecutor} that returns configurable fake results without
+ * invoking any language model.
+ *
+ * <p>Because {@code FakeTaskExecutor} extends {@code TaskExecutor}, it can be injected
+ * anywhere a {@code TaskExecutor} is expected -- including Temporal activity implementations,
+ * AWS Step Functions handlers, and Spring Batch tasklets.
+ *
+ * <h2>Basic usage -- single fixed response</h2>
+ *
+ * <pre>
+ * // Returns the same output for every execute() call.
+ * FakeTaskExecutor fake = FakeTaskExecutor.alwaysReturns("Research complete: AI is growing.");
+ * </pre>
+ *
+ * <h2>Rule-based responses</h2>
+ *
+ * <pre>
+ * FakeTaskExecutor fake = FakeTaskExecutor.builder()
+ *     .whenDescriptionContains("Research", "AI is advancing rapidly in 2026.")
+ *     .whenDescriptionContains("Write",    "Here is your polished article.")
+ *     .whenAgentRole("Summarizer",         "Summary: AI is transforming industry.")
+ *     .defaultOutput("Generic fake output for unmatched requests")
+ *     .build();
+ * </pre>
+ *
+ * <h2>Temporal activity test example</h2>
+ *
+ * <pre>
+ * // Production activity accepts TaskExecutor (FakeTaskExecutor is a subtype):
+ * public class ResearchActivityImpl implements ResearchActivity {
+ *     private final TaskExecutor executor;
+ *
+ *     public ResearchActivityImpl() { this.executor = realExecutor(); }
+ *     ResearchActivityImpl(TaskExecutor executor) { this.executor = executor; } // test hook
+ *
+ *     {@literal @}Override
+ *     public TaskResult research(TaskRequest request) {
+ *         return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+ *     }
+ * }
+ *
+ * // In the JUnit test (with Temporal TestWorkflowEnvironment):
+ * FakeTaskExecutor fake = FakeTaskExecutor.builder()
+ *     .whenDescriptionContains("Research", "AI is growing fast.")
+ *     .whenDescriptionContains("Write",    "Article: AI transforms society.")
+ *     .build();
+ *
+ * testEnv.newWorker(TASK_QUEUE).registerActivitiesImplementations(
+ *     new ResearchActivityImpl(fake));
+ *
+ * ResearchWorkflow workflow = testEnv.newWorkflowStub(ResearchWorkflow.class, options);
+ * String result = workflow.run("AI");
+ * assertThat(result).contains("AI transforms society.");
+ * </pre>
+ *
+ * <p>All results have {@code exitReason = "COMPLETED"}, {@code toolCallCount = 0}, and
+ * {@code durationMs = 1L} so {@link TaskResult#isComplete()} always returns {@code true}.
+ *
+ * <p>Heartbeat callbacks are not fired -- tests that need to verify heartbeat events should
+ * use a real {@link TaskExecutor} with a mocked {@link ModelProvider}.
+ */
+public final class FakeTaskExecutor extends TaskExecutor {
+
+    /**
+     * No-op provider used only to satisfy the TaskExecutor constructor.
+     * It is never invoked because execute() is fully overridden in this class.
+     */
+    private static final SimpleModelProvider NO_OP_PROVIDER = SimpleModelProvider.of(new DisabledChatModel());
+
+    private final List<Rule> rules;
+    private final String defaultOutput;
+
+    private FakeTaskExecutor(List<Rule> rules, String defaultOutput) {
+        super(NO_OP_PROVIDER);
+        this.rules = List.copyOf(rules);
+        this.defaultOutput = Objects.requireNonNull(defaultOutput, "defaultOutput must not be null");
+    }
+
+    /**
+     * Creates a fake executor that returns the given output string for every
+     * {@link #execute} call, regardless of the request.
+     *
+     * @param output the output to return; must not be null
+     * @return a configured fake executor
+     */
+    public static FakeTaskExecutor alwaysReturns(String output) {
+        Objects.requireNonNull(output, "output must not be null");
+        return new FakeTaskExecutor(List.of(), output);
+    }
+
+    /**
+     * Returns a builder for configuring rule-based fake responses.
+     *
+     * @return a fresh builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public TaskResult execute(TaskRequest request) {
+        return execute(request, null);
+    }
+
+    /**
+     * Returns a fake {@link TaskResult} without invoking any language model.
+     * The heartbeat consumer is accepted but no events are emitted.
+     *
+     * @param request           the task request; must not be null
+     * @param heartbeatConsumer accepted but ignored in the fake
+     * @return a completed {@link TaskResult} with the configured fake output
+     */
+    @Override
+    public TaskResult execute(TaskRequest request, Consumer<Object> heartbeatConsumer) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        String output = rules.stream()
+                .filter(r -> r.matches(request))
+                .findFirst()
+                .map(r -> r.output)
+                .orElse(defaultOutput);
+
+        return new TaskResult(output, 1L, 0, "COMPLETED");
+    }
+
+    // ========================
+    // Builder
+    // ========================
+
+    /**
+     * Fluent builder for {@link FakeTaskExecutor}.
+     */
+    public static final class Builder {
+
+        private final List<Rule> rules = new ArrayList<>();
+        private String defaultOutput = "Fake task output.";
+
+        private Builder() {}
+
+        /**
+         * Returns the configured output when the request's description contains the given
+         * substring (case-sensitive).
+         *
+         * <p>Rules are evaluated in registration order; the first match wins.
+         *
+         * @param substring substring to search for in {@code TaskRequest.getDescription()}
+         * @param output    output to return when matched; must not be null
+         * @return this builder
+         */
+        public Builder whenDescriptionContains(String substring, String output) {
+            Objects.requireNonNull(substring, "substring must not be null");
+            Objects.requireNonNull(output, "output must not be null");
+            rules.add(new Rule(
+                    req -> req.getDescription() != null && req.getDescription().contains(substring), output));
+            return this;
+        }
+
+        /**
+         * Returns the configured output when the request's description satisfies the given
+         * predicate.
+         *
+         * @param predicate applied to {@code TaskRequest.getDescription()}; must not be null
+         * @param output    output to return when matched; must not be null
+         * @return this builder
+         */
+        public Builder whenDescription(Predicate<String> predicate, String output) {
+            Objects.requireNonNull(predicate, "predicate must not be null");
+            Objects.requireNonNull(output, "output must not be null");
+            rules.add(new Rule(req -> req.getDescription() != null && predicate.test(req.getDescription()), output));
+            return this;
+        }
+
+        /**
+         * Returns the configured output when the request's agent spec has the given role
+         * (exact match, case-sensitive).
+         *
+         * @param role   the agent role to match
+         * @param output output to return when matched; must not be null
+         * @return this builder
+         */
+        public Builder whenAgentRole(String role, String output) {
+            Objects.requireNonNull(role, "role must not be null");
+            Objects.requireNonNull(output, "output must not be null");
+            rules.add(new Rule(
+                    req -> req.getAgent() != null && role.equals(req.getAgent().getRole()), output));
+            return this;
+        }
+
+        /**
+         * Sets the output returned when no rule matches.
+         * Defaults to {@code "Fake task output."} when not set.
+         *
+         * @param output the default output; must not be null
+         * @return this builder
+         */
+        public Builder defaultOutput(String output) {
+            this.defaultOutput = Objects.requireNonNull(output, "output must not be null");
+            return this;
+        }
+
+        /**
+         * Builds the fake executor.
+         *
+         * @return the configured {@link FakeTaskExecutor}
+         */
+        public FakeTaskExecutor build() {
+            return new FakeTaskExecutor(rules, defaultOutput);
+        }
+    }
+
+    // ========================
+    // Internal
+    // ========================
+
+    private record Rule(Predicate<TaskRequest> predicate, String output) {
+        boolean matches(TaskRequest request) {
+            return predicate.test(request);
+        }
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/HeartbeatDetail.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/HeartbeatDetail.java
@@ -1,0 +1,28 @@
+package net.agentensemble.executor;
+
+/**
+ * Serializable heartbeat payload emitted by {@link HeartbeatEnsembleListener} during execution.
+ *
+ * <p>External workflow orchestrators (Temporal, AWS Step Functions, etc.) receive this object
+ * as the heartbeat detail. It communicates the type of lifecycle event, a human-readable
+ * description, and optional positioning information (task index and ReAct iteration index).
+ *
+ * <p>Event types emitted by {@link HeartbeatEnsembleListener}:
+ * <ul>
+ *   <li>{@code "task_started"} -- an agent has begun executing a task</li>
+ *   <li>{@code "task_completed"} -- an agent successfully finished a task</li>
+ *   <li>{@code "task_failed"} -- an agent failed to complete a task</li>
+ *   <li>{@code "tool_call"} -- an agent invoked a tool within the ReAct loop</li>
+ *   <li>{@code "iteration_started"} -- a new ReAct iteration is beginning (LLM call pending)</li>
+ *   <li>{@code "iteration_completed"} -- a ReAct iteration finished (LLM response received)</li>
+ * </ul>
+ *
+ * <p>Temporal serialization: this record is serializable by Temporal's default Jackson
+ * {@code DataConverter}. The canonical constructor is used for deserialization.
+ *
+ * @param eventType   one of the event type strings listed above
+ * @param description human-readable detail (task description, tool name, agent role, etc.)
+ * @param taskIndex   1-based index of the executing task; null when not applicable
+ * @param iteration   0-based ReAct iteration index; null when not applicable
+ */
+public record HeartbeatDetail(String eventType, String description, Integer taskIndex, Integer iteration) {}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/HeartbeatEnsembleListener.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/HeartbeatEnsembleListener.java
@@ -1,0 +1,124 @@
+package net.agentensemble.executor;
+
+import java.util.function.Consumer;
+import net.agentensemble.callback.EnsembleListener;
+import net.agentensemble.callback.LlmIterationCompletedEvent;
+import net.agentensemble.callback.LlmIterationStartedEvent;
+import net.agentensemble.callback.TaskCompleteEvent;
+import net.agentensemble.callback.TaskFailedEvent;
+import net.agentensemble.callback.TaskStartEvent;
+import net.agentensemble.callback.ToolCallEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link EnsembleListener} that translates ensemble lifecycle events into heartbeat
+ * notifications for external workflow orchestrators.
+ *
+ * <p>Register this listener by passing a heartbeat callback to
+ * {@link TaskExecutor#execute(TaskRequest, Consumer)} or
+ * {@link EnsembleExecutor#execute(EnsembleRequest, Consumer)}. For Temporal:
+ *
+ * <pre>
+ * // In your Temporal Activity implementation:
+ * public TaskResult execute(TaskRequest request) {
+ *     return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+ * }
+ *
+ * // Or construct explicitly for custom routing:
+ * executor.execute(request, detail -> {
+ *     Activity.getExecutionContext().heartbeat(detail);
+ *     metrics.recordHeartbeat(detail.eventType());
+ * });
+ * </pre>
+ *
+ * <p>The following events are translated to heartbeat calls, each carrying a
+ * {@link HeartbeatDetail}:
+ * <ul>
+ *   <li>{@code onTaskStart} -- event type {@code "task_started"}</li>
+ *   <li>{@code onTaskComplete} -- event type {@code "task_completed"}</li>
+ *   <li>{@code onTaskFailed} -- event type {@code "task_failed"}</li>
+ *   <li>{@code onToolCall} -- event type {@code "tool_call"}</li>
+ *   <li>{@code onLlmIterationStarted} -- event type {@code "iteration_started"}</li>
+ *   <li>{@code onLlmIterationCompleted} -- event type {@code "iteration_completed"}</li>
+ * </ul>
+ *
+ * <p>Thread safety: in a parallel ensemble workflow, listener methods may be called
+ * concurrently. The consumer callback must be thread-safe. Temporal's
+ * {@code ActivityExecutionContext::heartbeat} is thread-safe.
+ *
+ * <p>Exception safety: exceptions thrown by the consumer are caught and logged but
+ * do not abort the ensemble execution, consistent with the {@link EnsembleListener} contract.
+ */
+public class HeartbeatEnsembleListener implements EnsembleListener {
+
+    private static final Logger log = LoggerFactory.getLogger(HeartbeatEnsembleListener.class);
+
+    private final Consumer<Object> heartbeatConsumer;
+
+    /**
+     * Constructs a listener that forwards lifecycle events to the given consumer.
+     *
+     * @param heartbeatConsumer the callback invoked with a {@link HeartbeatDetail} on each event;
+     *                          must not be null
+     * @throws IllegalArgumentException if heartbeatConsumer is null
+     */
+    public HeartbeatEnsembleListener(Consumer<Object> heartbeatConsumer) {
+        if (heartbeatConsumer == null) {
+            throw new IllegalArgumentException("heartbeatConsumer must not be null");
+        }
+        this.heartbeatConsumer = heartbeatConsumer;
+    }
+
+    @Override
+    public void onTaskStart(TaskStartEvent event) {
+        heartbeat(new HeartbeatDetail("task_started", event.taskDescription(), event.taskIndex(), null));
+    }
+
+    @Override
+    public void onTaskComplete(TaskCompleteEvent event) {
+        heartbeat(new HeartbeatDetail("task_completed", event.taskDescription(), event.taskIndex(), null));
+    }
+
+    @Override
+    public void onTaskFailed(TaskFailedEvent event) {
+        String description = event.taskDescription();
+        if (event.cause() != null && event.cause().getMessage() != null) {
+            description = description + ": " + event.cause().getMessage();
+        }
+        heartbeat(new HeartbeatDetail("task_failed", description, event.taskIndex(), null));
+    }
+
+    @Override
+    public void onToolCall(ToolCallEvent event) {
+        heartbeat(new HeartbeatDetail("tool_call", event.toolName(), event.taskIndex(), null));
+    }
+
+    @Override
+    public void onLlmIterationStarted(LlmIterationStartedEvent event) {
+        heartbeat(new HeartbeatDetail("iteration_started", event.agentRole(), null, event.iterationIndex()));
+    }
+
+    @Override
+    public void onLlmIterationCompleted(LlmIterationCompletedEvent event) {
+        heartbeat(new HeartbeatDetail("iteration_completed", event.agentRole(), null, event.iterationIndex()));
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private void heartbeat(HeartbeatDetail detail) {
+        try {
+            heartbeatConsumer.accept(detail);
+        } catch (Exception e) {
+            // Consistent with EnsembleListener contract: exceptions must not abort execution.
+            if (log.isWarnEnabled()) {
+                log.warn(
+                        "Heartbeat consumer threw an exception for event '{}' -- ignoring to preserve execution",
+                        detail.eventType(),
+                        e);
+            }
+        }
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/ModelProvider.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/ModelProvider.java
@@ -1,0 +1,44 @@
+package net.agentensemble.executor;
+
+import dev.langchain4j.model.chat.ChatModel;
+
+/**
+ * Provides {@link ChatModel} instances to {@link TaskExecutor} and
+ * {@link EnsembleExecutor} at execution time.
+ *
+ * <p>Implementations are configured on the worker side and are never serialized into workflow
+ * history. Models are resolved by the name carried in {@code TaskRequest.getModelName()} or
+ * {@code EnsembleRequest.getModelName()}. When no name is specified in the request,
+ * {@link #getDefault()} is used.
+ *
+ * <p>The built-in {@link SimpleModelProvider} covers most use cases:
+ *
+ * <pre>
+ * ModelProvider provider = SimpleModelProvider.builder()
+ *     .model("gpt-4o-mini", cheapModel)
+ *     .model("gpt-4o", premiumModel)
+ *     .defaultModel(cheapModel)
+ *     .build();
+ *
+ * TaskExecutor executor = new TaskExecutor(provider);
+ * </pre>
+ */
+public interface ModelProvider {
+
+    /**
+     * Returns the default {@link ChatModel} used when a request does not specify a model name.
+     *
+     * @return the default model; never null
+     * @throws IllegalStateException if no default model has been configured
+     */
+    ChatModel getDefault();
+
+    /**
+     * Returns the {@link ChatModel} registered under the given name.
+     *
+     * @param name the model name, as specified in {@code TaskRequest.getModelName()}
+     * @return the model; never null
+     * @throws IllegalArgumentException if no model is registered under {@code name}
+     */
+    ChatModel get(String name);
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/SimpleModelProvider.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/SimpleModelProvider.java
@@ -1,0 +1,149 @@
+package net.agentensemble.executor;
+
+import dev.langchain4j.model.chat.ChatModel;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A map-backed {@link ModelProvider} that resolves models by name.
+ *
+ * <p>Build an instance via the fluent {@link Builder}:
+ *
+ * <pre>
+ * ModelProvider provider = SimpleModelProvider.builder()
+ *     .model("gpt-4o-mini", cheapModel)
+ *     .model("gpt-4o", premiumModel)
+ *     .defaultModel(cheapModel)
+ *     .build();
+ *
+ * TaskExecutor executor = new TaskExecutor(provider);
+ * </pre>
+ *
+ * <p>For simple setups with a single model, use the convenience factory:
+ *
+ * <pre>
+ * ModelProvider provider = SimpleModelProvider.of(openAiModel);
+ * </pre>
+ */
+public final class SimpleModelProvider implements ModelProvider {
+
+    private final ChatModel defaultModel;
+    private final Map<String, ChatModel> models;
+
+    private SimpleModelProvider(ChatModel defaultModel, Map<String, ChatModel> models) {
+        this.defaultModel = defaultModel;
+        this.models = Collections.unmodifiableMap(new HashMap<>(models));
+    }
+
+    /**
+     * Creates a provider with a single model used as the default. The model is not
+     * accessible by name; use {@link #of(String, ChatModel)} or the builder when named
+     * access is needed.
+     *
+     * @param model the model to use as default; must not be null
+     * @return a provider backed by the given model
+     * @throws NullPointerException if model is null
+     */
+    public static SimpleModelProvider of(ChatModel model) {
+        Objects.requireNonNull(model, "model must not be null");
+        return new SimpleModelProvider(model, new HashMap<>());
+    }
+
+    /**
+     * Creates a provider with one named model that is also used as the default.
+     *
+     * @param name  the model name accessible via {@link #get(String)}
+     * @param model the model instance; must not be null
+     * @return a provider with the named model registered and set as default
+     * @throws NullPointerException if name or model is null
+     */
+    public static SimpleModelProvider of(String name, ChatModel model) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(model, "model must not be null");
+        Map<String, ChatModel> map = new HashMap<>();
+        map.put(name, model);
+        return new SimpleModelProvider(model, map);
+    }
+
+    /**
+     * Returns a new builder for constructing a {@code SimpleModelProvider}.
+     *
+     * @return a fresh builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public ChatModel getDefault() {
+        if (defaultModel == null) {
+            throw new IllegalStateException(
+                    "No default model configured. Register one via SimpleModelProvider.builder().defaultModel(...)");
+        }
+        return defaultModel;
+    }
+
+    @Override
+    public ChatModel get(String name) {
+        Objects.requireNonNull(name, "name must not be null");
+        ChatModel model = models.get(name);
+        if (model == null) {
+            throw new IllegalArgumentException(
+                    "No model registered with name '" + name + "'. Registered names: " + models.keySet());
+        }
+        return model;
+    }
+
+    /**
+     * Fluent builder for {@link SimpleModelProvider}.
+     */
+    public static final class Builder {
+
+        private ChatModel defaultModel;
+        private final Map<String, ChatModel> models = new HashMap<>();
+
+        private Builder() {}
+
+        /**
+         * Registers a model under the given name.
+         *
+         * <p>The name is used in {@code TaskRequest.getModelName()} or
+         * {@code EnsembleRequest.getModelName()} to select this model for a specific request.
+         *
+         * @param name  the model identifier; must not be null
+         * @param model the model instance; must not be null
+         * @return this builder
+         * @throws NullPointerException if name or model is null
+         */
+        public Builder model(String name, ChatModel model) {
+            Objects.requireNonNull(name, "name must not be null");
+            Objects.requireNonNull(model, "model must not be null");
+            models.put(name, model);
+            return this;
+        }
+
+        /**
+         * Sets the default model returned by {@link ModelProvider#getDefault()} when no
+         * model name is specified in a request.
+         *
+         * @param model the default model; must not be null
+         * @return this builder
+         * @throws NullPointerException if model is null
+         */
+        public Builder defaultModel(ChatModel model) {
+            this.defaultModel = Objects.requireNonNull(model, "model must not be null");
+            return this;
+        }
+
+        /**
+         * Builds the provider.
+         *
+         * @return the configured {@link SimpleModelProvider}
+         */
+        public SimpleModelProvider build() {
+            return new SimpleModelProvider(defaultModel, models);
+        }
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/SimpleToolProvider.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/SimpleToolProvider.java
@@ -1,0 +1,142 @@
+package net.agentensemble.executor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A map-backed {@link ToolProvider} that resolves tool instances by name.
+ *
+ * <p>Build an instance via the fluent {@link Builder}:
+ *
+ * <pre>
+ * ToolProvider tools = SimpleToolProvider.builder()
+ *     .tool("datetime", new DateTimeTool())
+ *     .tool("calculator", new CalculatorTool())
+ *     .tool("web-search", new WebSearchTool(apiKey))
+ *     .build();
+ *
+ * TaskExecutor executor = new TaskExecutor(modelProvider, tools);
+ * </pre>
+ *
+ * <p>For agents that need no tools:
+ *
+ * <pre>
+ * ToolProvider noTools = SimpleToolProvider.empty();
+ * TaskExecutor executor = new TaskExecutor(modelProvider, noTools);
+ * // Or, equivalently:
+ * TaskExecutor executor = new TaskExecutor(modelProvider);
+ * </pre>
+ *
+ * <p>Accepted tool types mirror AgentEnsemble's {@code ToolResolver} contract:
+ * {@code AgentTool} implementations, {@code @Tool}-annotated objects, and
+ * {@code DynamicToolProvider} implementations are all valid entries.
+ */
+public final class SimpleToolProvider implements ToolProvider {
+
+    private static final SimpleToolProvider EMPTY = new SimpleToolProvider(new HashMap<>());
+
+    private final Map<String, Object> tools;
+
+    private SimpleToolProvider(Map<String, Object> tools) {
+        this.tools = Collections.unmodifiableMap(new HashMap<>(tools));
+    }
+
+    /**
+     * Returns a shared provider with no registered tools. Useful for agents that rely
+     * solely on LLM reasoning without external tool access.
+     *
+     * @return the empty provider instance
+     */
+    public static SimpleToolProvider empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Creates a provider with a single named tool.
+     *
+     * @param name the tool name as referenced in {@code AgentSpec.getToolNames()}
+     * @param tool the tool instance
+     * @return a provider with the single tool registered
+     * @throws NullPointerException if name or tool is null
+     */
+    public static SimpleToolProvider of(String name, Object tool) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(tool, "tool must not be null");
+        Map<String, Object> map = new HashMap<>();
+        map.put(name, tool);
+        return new SimpleToolProvider(map);
+    }
+
+    /**
+     * Returns a new builder for constructing a {@code SimpleToolProvider}.
+     *
+     * @return a fresh builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public List<Object> get(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return List.of();
+        }
+        List<Object> result = new ArrayList<>(names.size());
+        for (String name : names) {
+            Object tool = tools.get(name);
+            if (tool == null) {
+                throw new IllegalArgumentException(
+                        "No tool registered with name '" + name + "'. Registered names: " + tools.keySet());
+            }
+            result.add(tool);
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public List<Object> getAll() {
+        return List.copyOf(tools.values());
+    }
+
+    /**
+     * Fluent builder for {@link SimpleToolProvider}.
+     */
+    public static final class Builder {
+
+        private final Map<String, Object> tools = new HashMap<>();
+
+        private Builder() {}
+
+        /**
+         * Registers a tool instance under the given name.
+         *
+         * <p>The name is referenced in {@code AgentSpec.getToolNames()} to equip an
+         * agent with this tool at execution time.
+         *
+         * @param name the tool identifier; must not be null
+         * @param tool the tool instance (AgentTool, {@code @Tool}-annotated object, or
+         *             DynamicToolProvider); must not be null
+         * @return this builder
+         * @throws NullPointerException if name or tool is null
+         */
+        public Builder tool(String name, Object tool) {
+            Objects.requireNonNull(name, "name must not be null");
+            Objects.requireNonNull(tool, "tool must not be null");
+            tools.put(name, tool);
+            return this;
+        }
+
+        /**
+         * Builds the provider.
+         *
+         * @return the configured {@link SimpleToolProvider}
+         */
+        public SimpleToolProvider build() {
+            return new SimpleToolProvider(tools);
+        }
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskExecutor.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskExecutor.java
@@ -1,0 +1,201 @@
+package net.agentensemble.executor;
+
+import dev.langchain4j.model.chat.ChatModel;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import net.agentensemble.Agent;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.ensemble.EnsembleOutput;
+
+/**
+ * Executes a single {@link TaskRequest} in-process by building and running a minimal
+ * AgentEnsemble.
+ *
+ * <p>This is the primary entry point for calling AgentEnsemble from an external workflow
+ * orchestrator (Temporal, AWS Step Functions, Kafka Streams, etc.) with task-level granularity.
+ * Each external activity wraps one {@code TaskExecutor.execute()} call. The orchestrator
+ * sequences activities and passes upstream outputs via {@code TaskRequest.getContext()}.
+ *
+ * <h2>Usage in a Temporal Activity</h2>
+ * <pre>
+ * // Activity implementation in the user's project:
+ * public class ResearchActivityImpl implements ResearchActivity {
+ *
+ *     private final TaskExecutor executor = new TaskExecutor(
+ *         SimpleModelProvider.of(OpenAiChatModel.builder()
+ *             .apiKey(System.getenv("OPENAI_API_KEY"))
+ *             .modelName("gpt-4o-mini")
+ *             .build()),
+ *         SimpleToolProvider.builder()
+ *             .tool("datetime", new DateTimeTool())
+ *             .tool("web-search", new WebSearchTool(apiKey))
+ *             .build()
+ *     );
+ *
+ *     {@literal @}Override
+ *     public TaskResult research(TaskRequest request) {
+ *         return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+ *     }
+ * }
+ * </pre>
+ *
+ * <h2>Context passing from upstream tasks</h2>
+ * <pre>
+ * // In the Temporal Workflow:
+ * TaskResult research = researchActivity.research(
+ *     TaskRequest.builder()
+ *         .description("Research {topic}")
+ *         .expectedOutput("A comprehensive research summary")
+ *         .inputs(Map.of("topic", topic))
+ *         .build());
+ *
+ * TaskResult article = writeActivity.write(
+ *     TaskRequest.builder()
+ *         .description("Write an article about {topic} based on: {research}")
+ *         .expectedOutput("A polished, well-structured article")
+ *         .context(Map.of("research", research.output()))
+ *         .inputs(Map.of("topic", topic))
+ *         .build());
+ * </pre>
+ *
+ * <p>Thread safety: {@code TaskExecutor} is thread-safe when the underlying
+ * {@link ModelProvider} and {@link ToolProvider} are thread-safe. A single instance
+ * may be shared across concurrent activity invocations.
+ */
+public class TaskExecutor {
+
+    private final ModelProvider modelProvider;
+    private final ToolProvider toolProvider;
+
+    /**
+     * Creates a {@code TaskExecutor} that uses the given model provider. No tools are
+     * available to agents; use this constructor for LLM-only (tool-free) agents.
+     *
+     * @param modelProvider provides the {@link ChatModel} for each task; must not be null
+     * @throws NullPointerException if modelProvider is null
+     */
+    public TaskExecutor(ModelProvider modelProvider) {
+        this(modelProvider, SimpleToolProvider.empty());
+    }
+
+    /**
+     * Creates a {@code TaskExecutor} with both a model provider and a tool provider.
+     *
+     * @param modelProvider provides the {@link ChatModel} for each task; must not be null
+     * @param toolProvider  resolves tool instances by name from {@code AgentSpec.getToolNames()};
+     *                      must not be null
+     * @throws NullPointerException if either argument is null
+     */
+    public TaskExecutor(ModelProvider modelProvider, ToolProvider toolProvider) {
+        this.modelProvider = Objects.requireNonNull(modelProvider, "modelProvider must not be null");
+        this.toolProvider = Objects.requireNonNull(toolProvider, "toolProvider must not be null");
+    }
+
+    /**
+     * Executes the given task request synchronously without heartbeating.
+     *
+     * <p>Equivalent to {@code execute(request, null)}.
+     *
+     * @param request the task to execute; must not be null
+     * @return the task result; never null
+     * @throws NullPointerException if request is null
+     */
+    public TaskResult execute(TaskRequest request) {
+        return execute(request, null);
+    }
+
+    /**
+     * Executes the given task request synchronously, emitting {@link HeartbeatDetail} events
+     * to the given consumer throughout execution.
+     *
+     * <p>For Temporal: {@code executor.execute(request, Activity.getExecutionContext()::heartbeat)}.
+     * Heartbeats keep the activity alive across long-running LLM and tool-call chains.
+     *
+     * <p>The consumer receives a {@link HeartbeatDetail} instance for each lifecycle event
+     * (task started, tool calls, LLM iterations, task completed/failed). Exceptions thrown
+     * by the consumer are caught and logged but do not abort execution.
+     *
+     * @param request           the task to execute; must not be null
+     * @param heartbeatConsumer receives {@link HeartbeatDetail} instances during execution;
+     *                          null disables heartbeating
+     * @return the task result; never null
+     * @throws NullPointerException if request is null
+     */
+    public TaskResult execute(TaskRequest request, Consumer<Object> heartbeatConsumer) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        ChatModel model = resolveModel(request.getModelName());
+
+        Task task = buildTask(request, model);
+
+        var ensembleBuilder = Ensemble.builder().chatLanguageModel(model).task(task);
+
+        // Inject context entries first (lower precedence) so explicit inputs can override them.
+        if (request.getContext() != null) {
+            request.getContext().forEach(ensembleBuilder::input);
+        }
+        // Explicit inputs take precedence over context entries on key collision.
+        if (request.getInputs() != null) {
+            request.getInputs().forEach(ensembleBuilder::input);
+        }
+
+        if (heartbeatConsumer != null) {
+            ensembleBuilder.listener(new HeartbeatEnsembleListener(heartbeatConsumer));
+        }
+
+        EnsembleOutput output = ensembleBuilder.build().run();
+
+        return toTaskResult(output);
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private ChatModel resolveModel(String modelName) {
+        return modelName != null ? modelProvider.get(modelName) : modelProvider.getDefault();
+    }
+
+    private Task buildTask(TaskRequest request, ChatModel model) {
+        var taskBuilder = Task.builder().description(request.getDescription());
+
+        if (request.getExpectedOutput() != null) {
+            taskBuilder.expectedOutput(request.getExpectedOutput());
+        }
+
+        if (request.getAgent() != null) {
+            taskBuilder.agent(buildAgent(request.getAgent(), model));
+        }
+
+        return taskBuilder.build();
+    }
+
+    private Agent buildAgent(AgentSpec spec, ChatModel model) {
+        var agentBuilder =
+                Agent.builder().role(spec.getRole()).goal(spec.getGoal()).llm(model);
+
+        if (spec.getBackground() != null) {
+            agentBuilder.background(spec.getBackground());
+        }
+        if (spec.getMaxIterations() != null) {
+            agentBuilder.maxIterations(spec.getMaxIterations());
+        }
+
+        List<String> toolNames = spec.getToolNames();
+        if (toolNames != null && !toolNames.isEmpty()) {
+            agentBuilder.tools(toolProvider.get(toolNames));
+        }
+
+        return agentBuilder.build();
+    }
+
+    private static TaskResult toTaskResult(EnsembleOutput output) {
+        long durationMs =
+                output.getTotalDuration() != null ? output.getTotalDuration().toMillis() : 0L;
+        String exitReason =
+                output.getExitReason() != null ? output.getExitReason().name() : "COMPLETED";
+        return new TaskResult(output.getRaw(), durationMs, output.getTotalToolCalls(), exitReason);
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskExecutor.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskExecutor.java
@@ -159,11 +159,12 @@ public class TaskExecutor {
     }
 
     private Task buildTask(TaskRequest request, ChatModel model) {
-        var taskBuilder = Task.builder().description(request.getDescription());
+        // When expectedOutput is null fall back to Task.DEFAULT_EXPECTED_OUTPUT so that
+        // TaskRequest.of(String description) (single-arg factory) is always executable.
+        String expectedOutput =
+                request.getExpectedOutput() != null ? request.getExpectedOutput() : Task.DEFAULT_EXPECTED_OUTPUT;
 
-        if (request.getExpectedOutput() != null) {
-            taskBuilder.expectedOutput(request.getExpectedOutput());
-        }
+        var taskBuilder = Task.builder().description(request.getDescription()).expectedOutput(expectedOutput);
 
         if (request.getAgent() != null) {
             taskBuilder.agent(buildAgent(request.getAgent(), model));

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskRequest.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskRequest.java
@@ -84,6 +84,11 @@ public class TaskRequest {
     /**
      * Convenience factory: creates a minimal request with only a description.
      *
+     * <p>When {@code expectedOutput} is null, both {@link TaskExecutor} and
+     * {@link EnsembleExecutor} substitute {@code Task.DEFAULT_EXPECTED_OUTPUT}
+     * ({@value net.agentensemble.Task#DEFAULT_EXPECTED_OUTPUT}) when building the
+     * underlying core task, so this factory always produces an executable request.
+     *
      * @param description the task description
      * @return a request with no agent spec, context, inputs, or model override
      */

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskRequest.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskRequest.java
@@ -1,0 +1,104 @@
+package net.agentensemble.executor;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * A request to execute a single AgentEnsemble task via {@link TaskExecutor}.
+ *
+ * <p>Each {@code TaskRequest} maps to exactly one external-workflow activity (e.g., a Temporal
+ * activity). The workflow engine is responsible for sequencing activities and passing upstream
+ * outputs via {@code getContext()}.
+ *
+ * <h2>Context passing between tasks</h2>
+ *
+ * <p>Outputs from upstream tasks are injected into this task's execution as template variable
+ * inputs. For example, if an upstream task's output is stored under the key {@code "research"},
+ * the task description may reference it as {@code {research}}:
+ *
+ * <pre>
+ * TaskRequest.builder()
+ *     .description("Write an article about {topic} based on: {research}")
+ *     .expectedOutput("A polished 500-word article")
+ *     .agent(AgentSpec.of("Writer", "Write compelling, accurate content"))
+ *     .context(Map.of("research", researchResult.output()))
+ *     .inputs(Map.of("topic", "Artificial Intelligence"))
+ *     .build();
+ * </pre>
+ *
+ * <p>Context entries and explicit inputs are merged before execution. Explicit
+ * {@code inputs} entries take precedence over {@code context} entries when both share a key.
+ *
+ * <h2>Agent auto-synthesis</h2>
+ *
+ * <p>When {@code getAgent()} is null, AgentEnsemble auto-synthesizes an agent persona
+ * from the task description and expected output. When {@code getAgent()} is set, the
+ * specified agent is used as-is.
+ */
+@Value
+@Builder
+public class TaskRequest {
+
+    /**
+     * The task description. Supports {@code {variable}} template placeholders resolved from
+     * {@link #getInputs()} and {@code getContext()}.
+     */
+    String description;
+
+    /**
+     * What the agent should produce. Supports {@code {variable}} template placeholders.
+     * Optional; the ensemble still executes without an expected output specification.
+     */
+    String expectedOutput;
+
+    /**
+     * Optional agent specification. When null, AgentEnsemble auto-synthesizes an agent
+     * persona from the task description and expected output.
+     */
+    AgentSpec agent;
+
+    /**
+     * Outputs from upstream tasks, keyed by label. Each entry is injected as a template
+     * variable so that {@code {label}} in the task description resolves to the upstream output.
+     *
+     * <p>May be null or empty when this is the first task in the pipeline.
+     */
+    Map<String, String> context;
+
+    /**
+     * Explicit template variable values for {@code {variable}} placeholders in the task
+     * description and expected output. These take precedence over {@code getContext()}
+     * entries when both share a key.
+     *
+     * <p>May be null or empty when no template substitution is needed.
+     */
+    Map<String, String> inputs;
+
+    /**
+     * Optional model name resolved by the {@link ModelProvider} on the executor. When null,
+     * the provider's default model is used.
+     */
+    String modelName;
+
+    /**
+     * Convenience factory: creates a minimal request with only a description.
+     *
+     * @param description the task description
+     * @return a request with no agent spec, context, inputs, or model override
+     */
+    public static TaskRequest of(String description) {
+        return builder().description(description).build();
+    }
+
+    /**
+     * Convenience factory: creates a request with a description and expected output.
+     *
+     * @param description    the task description
+     * @param expectedOutput what the agent should produce
+     * @return a request with no agent spec, context, inputs, or model override
+     */
+    public static TaskRequest of(String description, String expectedOutput) {
+        return builder().description(description).expectedOutput(expectedOutput).build();
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskResult.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/TaskResult.java
@@ -1,0 +1,21 @@
+package net.agentensemble.executor;
+
+/**
+ * The result of executing a single {@link TaskRequest} via {@link TaskExecutor}.
+ *
+ * @param output        the final text output produced by the agent
+ * @param durationMs    wall-clock duration of the task execution in milliseconds
+ * @param toolCallCount total number of tool calls made during execution
+ * @param exitReason    why the ensemble run terminated (e.g., {@code "COMPLETED"}, {@code "ERROR"})
+ */
+public record TaskResult(String output, long durationMs, int toolCallCount, String exitReason) {
+
+    /**
+     * Returns {@code true} when the task completed successfully without early exit or error.
+     *
+     * @return true if the exit reason is {@code "COMPLETED"}
+     */
+    public boolean isComplete() {
+        return "COMPLETED".equals(exitReason);
+    }
+}

--- a/agentensemble-executor/src/main/java/net/agentensemble/executor/ToolProvider.java
+++ b/agentensemble-executor/src/main/java/net/agentensemble/executor/ToolProvider.java
@@ -1,0 +1,47 @@
+package net.agentensemble.executor;
+
+import java.util.List;
+
+/**
+ * Provides tool instances to {@link TaskExecutor} and {@link EnsembleExecutor} at execution time.
+ *
+ * <p>Tools are resolved by name from {@code AgentSpec.getToolNames()}. Each name corresponds
+ * to an entry registered in the provider. Returned objects may be any type accepted by
+ * AgentEnsemble's {@code ToolResolver}:
+ * <ul>
+ *   <li>{@code AgentTool} implementations</li>
+ *   <li>Objects with {@code @Tool}-annotated methods (LangChain4j tool objects)</li>
+ *   <li>{@code DynamicToolProvider} implementations</li>
+ * </ul>
+ *
+ * <p>The built-in {@link SimpleToolProvider} covers most use cases:
+ *
+ * <pre>
+ * ToolProvider tools = SimpleToolProvider.builder()
+ *     .tool("datetime", new DateTimeTool())
+ *     .tool("calculator", new CalculatorTool())
+ *     .tool("web-search", new WebSearchTool(apiKey))
+ *     .build();
+ *
+ * TaskExecutor executor = new TaskExecutor(modelProvider, tools);
+ * </pre>
+ */
+public interface ToolProvider {
+
+    /**
+     * Returns the tool instances registered under the given names, in the same order
+     * as the input list.
+     *
+     * @param names the list of tool names from {@code AgentSpec.getToolNames()}
+     * @return the resolved tool instances; never null
+     * @throws IllegalArgumentException if any name has no registered tool
+     */
+    List<Object> get(List<String> names);
+
+    /**
+     * Returns all registered tool instances.
+     *
+     * @return all tools; never null, may be empty
+     */
+    List<Object> getAll();
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/EnsembleExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/EnsembleExecutorTest.java
@@ -117,6 +117,23 @@ class EnsembleExecutorTest {
     }
 
     // ========================
+    // execute() -- null expectedOutput default (Copilot fix)
+    // ========================
+
+    @Test
+    void execute_singleArgFactory_nullExpectedOutput_usesDefaultAndSucceeds() {
+        // TaskRequest.of(String) leaves expectedOutput null. EnsembleExecutor substitutes
+        // Task.DEFAULT_EXPECTED_OUTPUT so the task is always executable.
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Result.")));
+
+        var result = executor.execute(EnsembleRequest.builder()
+                .task(TaskRequest.of("Research something"))
+                .build());
+
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
     // execute() -- multiple tasks (sequential)
     // ========================
 
@@ -165,12 +182,11 @@ class EnsembleExecutorTest {
         var result = executor.execute(request);
 
         assertThat(result.taskOutputs()).hasSize(2);
-        // All outputs come from the same mock model in this test.
         assertThat(result.taskOutputs()).allSatisfy(output -> assertThat(output).isEqualTo("Task output."));
     }
 
     // ========================
-    // execute() -- global inputs
+    // execute() -- template pre-resolution (Copilot fix)
     // ========================
 
     @Test
@@ -185,6 +201,84 @@ class EnsembleExecutorTest {
         var result = executor.execute(request);
 
         assertThat(result.isComplete()).isTrue();
+    }
+
+    @Test
+    void execute_perTaskInputsAreIsolatedAndDoNotLeakToOtherTasks() {
+        // Task 1 sets "research" in its context. Task 2 has no context -- {research} in
+        // task 2's description should NOT be substituted by task 1's value. Without the
+        // per-task pre-resolution fix, the global input map would carry task 1's context
+        // into task 2's template resolution.
+        var model = mockModelWithResponse("Task output.");
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(model));
+
+        // Both tasks must run without throwing (pre-resolved descriptions are valid even
+        // when they contain unresolved {research} -- core Task.builder does not validate
+        // placeholder resolution, only that description is non-blank).
+        var result = executor.execute(EnsembleRequest.builder()
+                .task(TaskRequest.builder()
+                        .description("Research AI")
+                        .expectedOutput("Summary")
+                        .context(Map.of("research", "AI grows 40% YoY."))
+                        .build())
+                .task(TaskRequest.builder()
+                        .description("Write about AI")
+                        .expectedOutput("Article")
+                        // No context -- {research} is not substituted for task 2
+                        .build())
+                .build());
+
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.taskOutputs()).hasSize(2);
+    }
+
+    @Test
+    void execute_perTaskInputsTakePrecedenceOverGlobalInputs() {
+        // Task 1 uses a per-task input that overrides the global "topic".
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Done.")));
+
+        // Both tasks define their own "topic" -- this should not throw even though the
+        // global input and per-task input share a key.
+        var result = executor.execute(EnsembleRequest.builder()
+                .task(TaskRequest.builder()
+                        .description("Research {topic}")
+                        .expectedOutput("Summary about {topic}")
+                        .inputs(Map.of("topic", "Quantum Computing")) // overrides global
+                        .build())
+                .task(TaskRequest.of("Research {topic}", "Summary")) // uses global
+                .inputs(Map.of("topic", "Artificial Intelligence")) // global
+                .build());
+
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.taskOutputs()).hasSize(2);
+    }
+
+    // ========================
+    // EnsembleExecutor.resolveTemplate() (unit tests for the package-visible helper)
+    // ========================
+
+    @Test
+    void resolveTemplate_substitutesPlaceholders() {
+        var vars = Map.of("topic", "AI", "author", "Alice");
+
+        assertThat(EnsembleExecutor.resolveTemplate("Research {topic} by {author}", vars))
+                .isEqualTo("Research AI by Alice");
+    }
+
+    @Test
+    void resolveTemplate_nullTemplate_returnsNull() {
+        assertThat(EnsembleExecutor.resolveTemplate(null, Map.of("key", "val"))).isNull();
+    }
+
+    @Test
+    void resolveTemplate_emptyVars_returnsTemplateUnchanged() {
+        assertThat(EnsembleExecutor.resolveTemplate("Hello {name}", Map.of())).isEqualTo("Hello {name}");
+    }
+
+    @Test
+    void resolveTemplate_unknownPlaceholder_leftUnchanged() {
+        assertThat(EnsembleExecutor.resolveTemplate("Hello {unknown}", Map.of("topic", "AI")))
+                .isEqualTo("Hello {unknown}");
     }
 
     // ========================

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/EnsembleExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/EnsembleExecutorTest.java
@@ -1,0 +1,242 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link EnsembleExecutor} using mocked LLMs to avoid real network calls.
+ * Follows the same pattern as SequentialEnsembleIntegrationTest in agentensemble-core.
+ */
+class EnsembleExecutorTest {
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+    }
+
+    private ChatModel mockModelWithResponse(String response) {
+        var model = mock(ChatModel.class);
+        when(model.chat(any(ChatRequest.class))).thenReturn(textResponse(response));
+        return model;
+    }
+
+    // ========================
+    // Constructor validation
+    // ========================
+
+    @Test
+    void constructor_nullModelProvider_throwsNullPointer() {
+        assertThatThrownBy(() -> new EnsembleExecutor(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructor_nullToolProvider_throwsNullPointer() {
+        var modelProvider = SimpleModelProvider.of(mock(ChatModel.class));
+
+        assertThatThrownBy(() -> new EnsembleExecutor(modelProvider, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // execute() validation
+    // ========================
+
+    @Test
+    void execute_nullRequest_throwsNullPointer() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mock(ChatModel.class)));
+
+        assertThatThrownBy(() -> executor.execute((EnsembleRequest) null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void execute_emptyTaskList_throwsIllegalArgument() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mock(ChatModel.class)));
+        var request = EnsembleRequest.builder().tasks(List.of()).build();
+
+        assertThatThrownBy(() -> executor.execute(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one task");
+    }
+
+    @Test
+    void execute_nullTaskList_throwsIllegalArgument() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mock(ChatModel.class)));
+        var request = EnsembleRequest.builder().build(); // tasks defaults to empty list (via @Singular)
+
+        assertThatThrownBy(() -> executor.execute(request)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ========================
+    // execute() -- single task
+    // ========================
+
+    @Test
+    void execute_singleTask_returnsCompletedResult() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Research complete.")));
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.builder()
+                        .description("Research AI trends")
+                        .expectedOutput("A research summary")
+                        .agent(AgentSpec.of("Researcher", "Research and summarize"))
+                        .build())
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result).isNotNull();
+        assertThat(result.finalOutput()).isEqualTo("Research complete.");
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.exitReason()).isEqualTo("COMPLETED");
+        assertThat(result.taskOutputs()).hasSize(1);
+    }
+
+    @Test
+    void execute_singleTask_autoSynthesis_returnsCompletedResult() {
+        // No agent spec -- ensemble auto-synthesizes the agent.
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Auto-synthesized output.")));
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.of("Research AI ethics", "A summary of key ethical concerns"))
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result.finalOutput()).isEqualTo("Auto-synthesized output.");
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // execute() -- multiple tasks (sequential)
+    // ========================
+
+    @Test
+    void execute_multipleTasksSequential_returnsLastTaskOutputAsFinal() {
+        var model = mockModelWithResponse("Task output.");
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(model));
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.builder()
+                        .description("Research AI")
+                        .expectedOutput("A research summary")
+                        .agent(AgentSpec.builder()
+                                .role("Researcher")
+                                .goal("Research AI trends")
+                                .build())
+                        .build())
+                .task(TaskRequest.builder()
+                        .description("Write an article about AI")
+                        .expectedOutput("A polished article about AI")
+                        .agent(AgentSpec.builder()
+                                .role("Writer")
+                                .goal("Write compelling content")
+                                .build())
+                        .build())
+                .workflow("SEQUENTIAL")
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.taskOutputs()).hasSize(2);
+    }
+
+    @Test
+    void execute_multipleTasksSequential_taskOutputsInOrder() {
+        var model = mockModelWithResponse("Task output.");
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(model));
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.of("Task 1", "Output 1"))
+                .task(TaskRequest.of("Task 2", "Output 2"))
+                .workflow("SEQUENTIAL")
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result.taskOutputs()).hasSize(2);
+        // All outputs come from the same mock model in this test.
+        assertThat(result.taskOutputs()).allSatisfy(output -> assertThat(output).isEqualTo("Task output."));
+    }
+
+    // ========================
+    // execute() -- global inputs
+    // ========================
+
+    @Test
+    void execute_withGlobalInputs_runsSuccessfully() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Processed.")));
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.of("Research {topic}", "A research summary about {topic}"))
+                .inputs(Map.of("topic", "Artificial Intelligence"))
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // execute() -- heartbeating
+    // ========================
+
+    @Test
+    void execute_withHeartbeatConsumer_firesTaskStartedEvents() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Done.")));
+        var heartbeats = new ArrayList<HeartbeatDetail>();
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.builder()
+                        .description("Research AI")
+                        .expectedOutput("A research summary")
+                        .agent(AgentSpec.of("Researcher", "Research"))
+                        .build())
+                .build();
+
+        executor.execute(request, obj -> heartbeats.add((HeartbeatDetail) obj));
+
+        assertThat(heartbeats).isNotEmpty();
+        var eventTypes = heartbeats.stream().map(HeartbeatDetail::eventType).toList();
+        assertThat(eventTypes).contains("task_started", "task_completed");
+    }
+
+    @Test
+    void execute_withNullConsumer_runsWithoutHeartbeating() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("No heartbeats.")));
+
+        var result = executor.execute(
+                EnsembleRequest.builder()
+                        .task(TaskRequest.of("Research something", "A research result"))
+                        .build(),
+                null);
+
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // execute() -- aggregate metadata
+    // ========================
+
+    @Test
+    void execute_durationAndToolCallCountAreNonNegative() {
+        var executor = new EnsembleExecutor(SimpleModelProvider.of(mockModelWithResponse("Output.")));
+
+        var result = executor.execute(EnsembleRequest.builder()
+                .task(TaskRequest.of("Research AI", "A research summary"))
+                .build());
+
+        assertThat(result.totalDurationMs()).isGreaterThanOrEqualTo(0L);
+        assertThat(result.totalToolCalls()).isGreaterThanOrEqualTo(0);
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/FakeEnsembleExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/FakeEnsembleExecutorTest.java
@@ -88,7 +88,7 @@ class FakeEnsembleExecutorTest {
     }
 
     @Test
-    void builder_lastTaskOutputBecomesFinaOutput() {
+    void builder_lastTaskOutputBecomesFinalOutput() {
         var fake = FakeEnsembleExecutor.builder()
                 .whenDescriptionContains("Step 1", "Step 1 output.")
                 .whenDescriptionContains("Step 2", "Step 2 output.")

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/FakeEnsembleExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/FakeEnsembleExecutorTest.java
@@ -1,0 +1,196 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link FakeEnsembleExecutor}. */
+class FakeEnsembleExecutorTest {
+
+    // ========================
+    // alwaysReturns factory
+    // ========================
+
+    @Test
+    void alwaysReturns_singleTask_returnsConfiguredOutput() {
+        var fake = FakeEnsembleExecutor.alwaysReturns("Pipeline done.");
+
+        var result = fake.execute(EnsembleRequest.builder()
+                .task(TaskRequest.of("Research AI", "A summary"))
+                .build());
+
+        assertThat(result.finalOutput()).isEqualTo("Pipeline done.");
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.exitReason()).isEqualTo("COMPLETED");
+        assertThat(result.taskOutputs()).containsExactly("Pipeline done.");
+    }
+
+    @Test
+    void alwaysReturns_multipleTasks_sameOutputForEachTask() {
+        var fake = FakeEnsembleExecutor.alwaysReturns("Same for all.");
+
+        var result = fake.execute(EnsembleRequest.builder()
+                .task(TaskRequest.of("Task 1", "Output 1"))
+                .task(TaskRequest.of("Task 2", "Output 2"))
+                .build());
+
+        assertThat(result.taskOutputs()).containsExactly("Same for all.", "Same for all.");
+        assertThat(result.finalOutput()).isEqualTo("Same for all.");
+    }
+
+    @Test
+    void alwaysReturns_nullOutput_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeEnsembleExecutor.alwaysReturns(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // execute() null and empty validation
+    // ========================
+
+    @Test
+    void execute_nullRequest_throwsNullPointer() {
+        var fake = FakeEnsembleExecutor.alwaysReturns("x");
+
+        assertThatThrownBy(() -> fake.execute((EnsembleRequest) null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void execute_emptyTaskList_throwsIllegalArgument() {
+        var fake = FakeEnsembleExecutor.alwaysReturns("x");
+
+        assertThatThrownBy(() -> fake.execute(EnsembleRequest.builder().build()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ========================
+    // builder -- rule-based per-task matching
+    // ========================
+
+    @Test
+    void builder_eachTaskMatchedIndependently() {
+        var fake = FakeEnsembleExecutor.builder()
+                .whenDescriptionContains("Research", "Research result: AI is growing.")
+                .whenDescriptionContains("Write", "Final article: AI transforms society.")
+                .defaultOutput("Fallback output.")
+                .build();
+
+        var request = EnsembleRequest.builder()
+                .task(TaskRequest.of("Research AI trends", "A summary"))
+                .task(TaskRequest.of("Write a blog post about AI", "A blog post"))
+                .build();
+
+        var result = fake.execute(request);
+
+        assertThat(result.taskOutputs())
+                .containsExactly("Research result: AI is growing.", "Final article: AI transforms society.");
+        assertThat(result.finalOutput()).isEqualTo("Final article: AI transforms society.");
+    }
+
+    @Test
+    void builder_lastTaskOutputBecomesFinaOutput() {
+        var fake = FakeEnsembleExecutor.builder()
+                .whenDescriptionContains("Step 1", "Step 1 output.")
+                .whenDescriptionContains("Step 2", "Step 2 output.")
+                .whenDescriptionContains("Step 3", "Step 3 -- final.")
+                .build();
+
+        var result = fake.execute(EnsembleRequest.builder()
+                .task(TaskRequest.of("Step 1", "Out"))
+                .task(TaskRequest.of("Step 2", "Out"))
+                .task(TaskRequest.of("Step 3", "Out"))
+                .build());
+
+        assertThat(result.taskOutputs()).hasSize(3);
+        assertThat(result.finalOutput()).isEqualTo("Step 3 -- final.");
+    }
+
+    @Test
+    void builder_unmatchedTaskUsesDefaultOutput() {
+        var fake = FakeEnsembleExecutor.builder()
+                .whenDescriptionContains("Research", "Research output.")
+                .defaultOutput("Default for unmatched.")
+                .build();
+
+        var result = fake.execute(EnsembleRequest.builder()
+                .task(TaskRequest.of("Research AI", "Summary"))
+                .task(TaskRequest.of("Completely unrelated task", "Output"))
+                .build());
+
+        assertThat(result.taskOutputs()).containsExactly("Research output.", "Default for unmatched.");
+    }
+
+    // ========================
+    // heartbeat consumer
+    // ========================
+
+    @Test
+    void execute_withHeartbeatConsumer_doesNotEmitAnyEvents() {
+        var fake = FakeEnsembleExecutor.alwaysReturns("Done.");
+        var captured = new java.util.ArrayList<>();
+
+        fake.execute(
+                EnsembleRequest.builder().task(TaskRequest.of("Task", "Output")).build(), captured::add);
+
+        assertThat(captured).isEmpty();
+    }
+
+    @Test
+    void execute_withNullConsumer_runsWithoutError() {
+        var fake = FakeEnsembleExecutor.alwaysReturns("Done.");
+
+        var result = fake.execute(
+                EnsembleRequest.builder().task(TaskRequest.of("Task", "Output")).build(), null);
+
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // result shape
+    // ========================
+
+    @Test
+    void result_hasExpectedShape() {
+        var result = FakeEnsembleExecutor.alwaysReturns("Output.")
+                .execute(EnsembleRequest.builder()
+                        .task(TaskRequest.of("Task", "Out"))
+                        .build());
+
+        assertThat(result.finalOutput()).isEqualTo("Output.");
+        assertThat(result.exitReason()).isEqualTo("COMPLETED");
+        assertThat(result.totalToolCalls()).isZero();
+        assertThat(result.totalDurationMs()).isEqualTo(1L);
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // is a subtype of EnsembleExecutor
+    // ========================
+
+    @Test
+    void fakeEnsembleExecutor_isSubtypeOfEnsembleExecutor() {
+        FakeEnsembleExecutor fake = FakeEnsembleExecutor.alwaysReturns("Done.");
+
+        // Assignable to EnsembleExecutor -- key for constructor injection
+        EnsembleExecutor executor = fake;
+        var result = executor.execute(
+                EnsembleRequest.builder().task(TaskRequest.of("Task", "Output")).build());
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // builder validation
+    // ========================
+
+    @Test
+    void builder_nullSubstring_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeEnsembleExecutor.builder().whenDescriptionContains(null, "out"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void builder_nullDefaultOutput_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeEnsembleExecutor.builder().defaultOutput(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/FakeTaskExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/FakeTaskExecutorTest.java
@@ -1,0 +1,237 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link FakeTaskExecutor}. */
+class FakeTaskExecutorTest {
+
+    // ========================
+    // alwaysReturns factory
+    // ========================
+
+    @Test
+    void alwaysReturns_returnsThatOutputForAnyRequest() {
+        var fake = FakeTaskExecutor.alwaysReturns("Fixed output.");
+
+        var result = fake.execute(TaskRequest.of("Research AI", "A summary"));
+
+        assertThat(result.output()).isEqualTo("Fixed output.");
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.exitReason()).isEqualTo("COMPLETED");
+        assertThat(result.toolCallCount()).isZero();
+        assertThat(result.durationMs()).isPositive();
+    }
+
+    @Test
+    void alwaysReturns_nullOutput_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeTaskExecutor.alwaysReturns(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // execute() null validation
+    // ========================
+
+    @Test
+    void execute_nullRequest_throwsNullPointer() {
+        var fake = FakeTaskExecutor.alwaysReturns("x");
+
+        assertThatThrownBy(() -> fake.execute((TaskRequest) null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void execute_withConsumer_nullRequest_throwsNullPointer() {
+        var fake = FakeTaskExecutor.alwaysReturns("x");
+
+        assertThatThrownBy(() -> fake.execute(null, obj -> {})).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // builder -- whenDescriptionContains
+    // ========================
+
+    @Test
+    void builder_whenDescriptionContains_matchesSubstring() {
+        var fake = FakeTaskExecutor.builder()
+                .whenDescriptionContains("Research", "Research result.")
+                .whenDescriptionContains("Write", "Article written.")
+                .build();
+
+        var researchResult = fake.execute(TaskRequest.of("Research AI trends", "A summary"));
+        var writeResult = fake.execute(TaskRequest.of("Write an article", "An article"));
+
+        assertThat(researchResult.output()).isEqualTo("Research result.");
+        assertThat(writeResult.output()).isEqualTo("Article written.");
+    }
+
+    @Test
+    void builder_firstMatchWins_whenMultipleRulesMatch() {
+        var fake = FakeTaskExecutor.builder()
+                .whenDescriptionContains("Research", "First match.")
+                .whenDescriptionContains("Research AI", "Second match -- should not be returned.")
+                .build();
+
+        var result = fake.execute(TaskRequest.of("Research AI trends", "A summary"));
+
+        assertThat(result.output()).isEqualTo("First match.");
+    }
+
+    @Test
+    void builder_noMatchUsesDefaultOutput() {
+        var fake = FakeTaskExecutor.builder()
+                .whenDescriptionContains("Research", "Research result.")
+                .defaultOutput("No match default.")
+                .build();
+
+        var result = fake.execute(TaskRequest.of("Something completely different", "Output"));
+
+        assertThat(result.output()).isEqualTo("No match default.");
+    }
+
+    @Test
+    void builder_defaultOutputWithoutRules_alwaysReturnsDefault() {
+        var fake = FakeTaskExecutor.builder().defaultOutput("Always this.").build();
+
+        assertThat(fake.execute(TaskRequest.of("Task A", "Out")).output()).isEqualTo("Always this.");
+        assertThat(fake.execute(TaskRequest.of("Task B", "Out")).output()).isEqualTo("Always this.");
+    }
+
+    // ========================
+    // builder -- whenAgentRole
+    // ========================
+
+    @Test
+    void builder_whenAgentRole_matchesOnRole() {
+        var fake = FakeTaskExecutor.builder()
+                .whenAgentRole("Researcher", "Research output.")
+                .whenAgentRole("Writer", "Writing output.")
+                .defaultOutput("Fallback.")
+                .build();
+
+        var researchRequest = TaskRequest.builder()
+                .description("Do research")
+                .expectedOutput("Summary")
+                .agent(AgentSpec.of("Researcher", "Research"))
+                .build();
+        var writeRequest = TaskRequest.builder()
+                .description("Write something")
+                .expectedOutput("Article")
+                .agent(AgentSpec.of("Writer", "Write"))
+                .build();
+        var noAgentRequest = TaskRequest.of("No agent task", "Output");
+
+        assertThat(fake.execute(researchRequest).output()).isEqualTo("Research output.");
+        assertThat(fake.execute(writeRequest).output()).isEqualTo("Writing output.");
+        assertThat(fake.execute(noAgentRequest).output()).isEqualTo("Fallback.");
+    }
+
+    // ========================
+    // builder -- whenDescription predicate
+    // ========================
+
+    @Test
+    void builder_whenDescriptionPredicate_matchesOnCustomLogic() {
+        var fake = FakeTaskExecutor.builder()
+                .whenDescription(d -> d.startsWith("Research"), "Research output.")
+                .defaultOutput("Fallback.")
+                .build();
+
+        assertThat(fake.execute(TaskRequest.of("Research AI", "Out")).output()).isEqualTo("Research output.");
+        assertThat(fake.execute(TaskRequest.of("Write about AI", "Out")).output())
+                .isEqualTo("Fallback.");
+    }
+
+    // ========================
+    // heartbeat consumer
+    // ========================
+
+    @Test
+    void execute_withHeartbeatConsumer_doesNotEmitAnyEvents() {
+        var fake = FakeTaskExecutor.alwaysReturns("Done.");
+        var captured = new java.util.ArrayList<>();
+
+        fake.execute(TaskRequest.of("Task", "Output"), captured::add);
+
+        assertThat(captured).isEmpty(); // FakeTaskExecutor does not fire heartbeats
+    }
+
+    @Test
+    void execute_withNullConsumer_runsWithoutError() {
+        var fake = FakeTaskExecutor.alwaysReturns("Done.");
+
+        assertThat(fake.execute(TaskRequest.of("Task", "Output"), null).isComplete())
+                .isTrue();
+    }
+
+    // ========================
+    // context and inputs (no special handling needed -- fake ignores them)
+    // ========================
+
+    @Test
+    void execute_withContextAndInputs_runsSuccessfully() {
+        var fake = FakeTaskExecutor.alwaysReturns("Output with context.");
+
+        var request = TaskRequest.builder()
+                .description("Write about {topic} using: {research}")
+                .expectedOutput("Article")
+                .context(Map.of("research", "AI is advancing."))
+                .inputs(Map.of("topic", "Artificial Intelligence"))
+                .build();
+
+        assertThat(fake.execute(request).output()).isEqualTo("Output with context.");
+    }
+
+    // ========================
+    // is a subtype of TaskExecutor
+    // ========================
+
+    @Test
+    void fakeTaskExecutor_isSubtypeOfTaskExecutor() {
+        FakeTaskExecutor fake = FakeTaskExecutor.alwaysReturns("Output.");
+
+        // Assignable to TaskExecutor -- key for constructor injection
+        TaskExecutor executor = fake;
+        assertThat(executor.execute(TaskRequest.of("Task", "Output")).isComplete())
+                .isTrue();
+    }
+
+    // ========================
+    // builder validation
+    // ========================
+
+    @Test
+    void builder_nullSubstring_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeTaskExecutor.builder().whenDescriptionContains(null, "out"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void builder_nullOutput_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeTaskExecutor.builder().whenDescriptionContains("x", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void builder_nullDefaultOutput_throwsNullPointer() {
+        assertThatThrownBy(() -> FakeTaskExecutor.builder().defaultOutput(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // result shape
+    // ========================
+
+    @Test
+    void result_hasExpectedShape() {
+        var result = FakeTaskExecutor.alwaysReturns("Test output.").execute(TaskRequest.of("Any task", "Any output"));
+
+        assertThat(result.output()).isEqualTo("Test output.");
+        assertThat(result.exitReason()).isEqualTo("COMPLETED");
+        assertThat(result.toolCallCount()).isZero();
+        assertThat(result.durationMs()).isEqualTo(1L);
+        assertThat(result.isComplete()).isTrue();
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/HeartbeatEnsembleListenerTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/HeartbeatEnsembleListenerTest.java
@@ -1,0 +1,232 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import net.agentensemble.callback.LlmIterationCompletedEvent;
+import net.agentensemble.callback.LlmIterationStartedEvent;
+import net.agentensemble.callback.TaskCompleteEvent;
+import net.agentensemble.callback.TaskFailedEvent;
+import net.agentensemble.callback.TaskStartEvent;
+import net.agentensemble.callback.ToolCallEvent;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link HeartbeatEnsembleListener}. */
+class HeartbeatEnsembleListenerTest {
+
+    private List<HeartbeatDetail> captured() {
+        return new ArrayList<>();
+    }
+
+    private HeartbeatEnsembleListener listenerCapturing(List<HeartbeatDetail> sink) {
+        return new HeartbeatEnsembleListener(obj -> sink.add((HeartbeatDetail) obj));
+    }
+
+    // ========================
+    // Constructor
+    // ========================
+
+    @Test
+    void constructor_nullConsumer_throwsIllegalArgument() {
+        assertThatThrownBy(() -> new HeartbeatEnsembleListener(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ========================
+    // onTaskStart
+    // ========================
+
+    @Test
+    void onTaskStart_emitsTaskStartedEventType() {
+        var sink = captured();
+        listenerCapturing(sink).onTaskStart(new TaskStartEvent("Research AI", "Researcher", 1, 3));
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink.get(0).eventType()).isEqualTo("task_started");
+    }
+
+    @Test
+    void onTaskStart_populatesDescriptionAndTaskIndex() {
+        var sink = captured();
+        listenerCapturing(sink).onTaskStart(new TaskStartEvent("Research AI", "Researcher", 2, 5));
+
+        var detail = sink.get(0);
+        assertThat(detail.description()).isEqualTo("Research AI");
+        assertThat(detail.taskIndex()).isEqualTo(2);
+        assertThat(detail.iteration()).isNull();
+    }
+
+    // ========================
+    // onTaskComplete
+    // ========================
+
+    @Test
+    void onTaskComplete_emitsTaskCompletedEventType() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onTaskComplete(new TaskCompleteEvent("Research AI", "Researcher", null, Duration.ofSeconds(5), 1, 3));
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink.get(0).eventType()).isEqualTo("task_completed");
+    }
+
+    @Test
+    void onTaskComplete_populatesDescriptionAndTaskIndex() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onTaskComplete(new TaskCompleteEvent("Write article", "Writer", null, Duration.ofSeconds(10), 3, 5));
+
+        var detail = sink.get(0);
+        assertThat(detail.description()).isEqualTo("Write article");
+        assertThat(detail.taskIndex()).isEqualTo(3);
+        assertThat(detail.iteration()).isNull();
+    }
+
+    // ========================
+    // onTaskFailed
+    // ========================
+
+    @Test
+    void onTaskFailed_emitsTaskFailedEventType() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onTaskFailed(new TaskFailedEvent("Research AI", "Researcher", null, Duration.ofSeconds(2), 1, 3));
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink.get(0).eventType()).isEqualTo("task_failed");
+    }
+
+    @Test
+    void onTaskFailed_withCause_appendsCauseMessageToDescription() {
+        var sink = captured();
+        var cause = new RuntimeException("LLM timeout");
+        listenerCapturing(sink)
+                .onTaskFailed(new TaskFailedEvent("Research AI", "Researcher", cause, Duration.ofSeconds(2), 1, 3));
+
+        assertThat(sink.get(0).description()).contains("Research AI").contains("LLM timeout");
+    }
+
+    @Test
+    void onTaskFailed_withNullCause_usesTaskDescriptionOnly() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onTaskFailed(new TaskFailedEvent("Research AI", "Researcher", null, Duration.ofSeconds(2), 1, 3));
+
+        assertThat(sink.get(0).description()).isEqualTo("Research AI");
+    }
+
+    // ========================
+    // onToolCall
+    // ========================
+
+    @Test
+    void onToolCall_emitsToolCallEventType() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onToolCall(new ToolCallEvent(
+                        "web-search", "{}", "results", null, "Researcher", Duration.ofMillis(300), 2, "SUCCESS"));
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink.get(0).eventType()).isEqualTo("tool_call");
+    }
+
+    @Test
+    void onToolCall_populatesToolNameAndTaskIndex() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onToolCall(new ToolCallEvent(
+                        "datetime", "{}", "2026-04-09", null, "Researcher", Duration.ofMillis(50), 1, "SUCCESS"));
+
+        var detail = sink.get(0);
+        assertThat(detail.description()).isEqualTo("datetime");
+        assertThat(detail.taskIndex()).isEqualTo(1);
+        assertThat(detail.iteration()).isNull();
+    }
+
+    // ========================
+    // onLlmIterationStarted
+    // ========================
+
+    @Test
+    void onLlmIterationStarted_emitsIterationStartedEventType() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onLlmIterationStarted(new LlmIterationStartedEvent("Researcher", "Research AI", 0, List.of()));
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink.get(0).eventType()).isEqualTo("iteration_started");
+    }
+
+    @Test
+    void onLlmIterationStarted_populatesAgentRoleAndIterationIndex() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onLlmIterationStarted(new LlmIterationStartedEvent("Writer", "Write article", 2, List.of()));
+
+        var detail = sink.get(0);
+        assertThat(detail.description()).isEqualTo("Writer");
+        assertThat(detail.iteration()).isEqualTo(2);
+        assertThat(detail.taskIndex()).isNull();
+    }
+
+    // ========================
+    // onLlmIterationCompleted
+    // ========================
+
+    @Test
+    void onLlmIterationCompleted_emitsIterationCompletedEventType() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onLlmIterationCompleted(new LlmIterationCompletedEvent(
+                        "Researcher",
+                        "Research AI",
+                        1,
+                        "FINAL_ANSWER",
+                        "The answer",
+                        List.of(),
+                        100,
+                        50,
+                        Duration.ofMillis(500)));
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink.get(0).eventType()).isEqualTo("iteration_completed");
+    }
+
+    @Test
+    void onLlmIterationCompleted_populatesIterationIndex() {
+        var sink = captured();
+        listenerCapturing(sink)
+                .onLlmIterationCompleted(new LlmIterationCompletedEvent(
+                        "Writer",
+                        "Write article",
+                        3,
+                        "FINAL_ANSWER",
+                        "Done",
+                        List.of(),
+                        200,
+                        80,
+                        Duration.ofMillis(750)));
+
+        assertThat(sink.get(0).iteration()).isEqualTo(3);
+    }
+
+    // ========================
+    // Exception safety
+    // ========================
+
+    @Test
+    void consumerException_isCaughtAndDoesNotAbortExecution() {
+        // Consumer throws; the listener must swallow it (EnsembleListener contract).
+        var listener = new HeartbeatEnsembleListener(obj -> {
+            throw new RuntimeException("consumer failure");
+        });
+
+        // None of these should propagate the exception.
+        listener.onTaskStart(new TaskStartEvent("Task", "Agent", 1, 1));
+        listener.onToolCall(
+                new ToolCallEvent("tool", "{}", "result", null, "Agent", Duration.ofMillis(10), 1, "SUCCESS"));
+        listener.onLlmIterationStarted(new LlmIterationStartedEvent("Agent", "Task", 0, List.of()));
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/SimpleModelProviderTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/SimpleModelProviderTest.java
@@ -1,0 +1,119 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.model.chat.ChatModel;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SimpleModelProvider}. */
+class SimpleModelProviderTest {
+
+    // ========================
+    // of(ChatModel) factory
+    // ========================
+
+    @Test
+    void of_singleModel_getDefaultReturnsThatModel() {
+        var model = mock(ChatModel.class);
+        var provider = SimpleModelProvider.of(model);
+
+        assertThat(provider.getDefault()).isSameAs(model);
+    }
+
+    @Test
+    void of_singleModel_getByNameThrowsIllegalArgument() {
+        var model = mock(ChatModel.class);
+        var provider = SimpleModelProvider.of(model);
+
+        assertThatThrownBy(() -> provider.get("gpt-4o"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("gpt-4o");
+    }
+
+    @Test
+    void of_nullModel_throwsNullPointer() {
+        assertThatThrownBy(() -> SimpleModelProvider.of((ChatModel) null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // of(String, ChatModel) factory
+    // ========================
+
+    @Test
+    void of_namedModel_isAccessibleByNameAndAsDefault() {
+        var model = mock(ChatModel.class);
+        var provider = SimpleModelProvider.of("gpt-4o", model);
+
+        assertThat(provider.get("gpt-4o")).isSameAs(model);
+        assertThat(provider.getDefault()).isSameAs(model);
+    }
+
+    @Test
+    void of_namedModel_unknownNameThrowsIllegalArgument() {
+        var model = mock(ChatModel.class);
+        var provider = SimpleModelProvider.of("gpt-4o", model);
+
+        assertThatThrownBy(() -> provider.get("gpt-4o-mini"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("gpt-4o-mini")
+                .hasMessageContaining("gpt-4o");
+    }
+
+    @Test
+    void of_namedModel_nullNameThrowsNullPointer() {
+        assertThatThrownBy(() -> SimpleModelProvider.of(null, mock(ChatModel.class)))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void of_namedModel_nullModelThrowsNullPointer() {
+        assertThatThrownBy(() -> SimpleModelProvider.of("gpt-4o", null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // builder
+    // ========================
+
+    @Test
+    void builder_multipleModels_resolvesByName() {
+        var cheap = mock(ChatModel.class);
+        var premium = mock(ChatModel.class);
+
+        var provider = SimpleModelProvider.builder()
+                .model("cheap", cheap)
+                .model("premium", premium)
+                .defaultModel(cheap)
+                .build();
+
+        assertThat(provider.get("cheap")).isSameAs(cheap);
+        assertThat(provider.get("premium")).isSameAs(premium);
+        assertThat(provider.getDefault()).isSameAs(cheap);
+    }
+
+    @Test
+    void builder_noDefaultConfigured_getDefaultThrowsIllegalState() {
+        var provider = SimpleModelProvider.builder()
+                .model("gpt-4o", mock(ChatModel.class))
+                .build();
+
+        assertThatThrownBy(provider::getDefault)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No default model");
+    }
+
+    @Test
+    void builder_emptyBuild_getDefaultThrowsIllegalState() {
+        var provider = SimpleModelProvider.builder().build();
+
+        assertThatThrownBy(provider::getDefault).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void get_nullName_throwsNullPointer() {
+        var provider = SimpleModelProvider.of(mock(ChatModel.class));
+
+        assertThatThrownBy(() -> provider.get(null)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/SimpleToolProviderTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/SimpleToolProviderTest.java
@@ -1,0 +1,123 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SimpleToolProvider}. */
+class SimpleToolProviderTest {
+
+    private static final Object TOOL_A = new Object();
+    private static final Object TOOL_B = new Object();
+
+    // ========================
+    // empty()
+    // ========================
+
+    @Test
+    void empty_getAll_returnsEmptyList() {
+        assertThat(SimpleToolProvider.empty().getAll()).isEmpty();
+    }
+
+    @Test
+    void empty_getWithEmptyList_returnsEmptyList() {
+        assertThat(SimpleToolProvider.empty().get(List.of())).isEmpty();
+    }
+
+    @Test
+    void empty_getWithNullList_returnsEmptyList() {
+        assertThat(SimpleToolProvider.empty().get(null)).isEmpty();
+    }
+
+    // ========================
+    // of(String, Object) factory
+    // ========================
+
+    @Test
+    void of_singleTool_isAccessibleByName() {
+        var provider = SimpleToolProvider.of("calculator", TOOL_A);
+
+        assertThat(provider.get(List.of("calculator"))).containsExactly(TOOL_A);
+    }
+
+    @Test
+    void of_singleTool_getAll_containsTool() {
+        var provider = SimpleToolProvider.of("calculator", TOOL_A);
+
+        assertThat(provider.getAll()).containsExactly(TOOL_A);
+    }
+
+    @Test
+    void of_nullName_throwsNullPointer() {
+        assertThatThrownBy(() -> SimpleToolProvider.of(null, TOOL_A)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void of_nullTool_throwsNullPointer() {
+        assertThatThrownBy(() -> SimpleToolProvider.of("tool", null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // builder
+    // ========================
+
+    @Test
+    void builder_multipleTools_resolveByName() {
+        var provider =
+                SimpleToolProvider.builder().tool("a", TOOL_A).tool("b", TOOL_B).build();
+
+        assertThat(provider.get(List.of("a", "b"))).containsExactly(TOOL_A, TOOL_B);
+    }
+
+    @Test
+    void builder_multipleTools_getAll_containsAll() {
+        var provider =
+                SimpleToolProvider.builder().tool("a", TOOL_A).tool("b", TOOL_B).build();
+
+        assertThat(provider.getAll()).containsExactlyInAnyOrder(TOOL_A, TOOL_B);
+    }
+
+    @Test
+    void builder_nullName_throwsNullPointer() {
+        assertThatThrownBy(() -> SimpleToolProvider.builder().tool(null, TOOL_A))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void builder_nullTool_throwsNullPointer() {
+        assertThatThrownBy(() -> SimpleToolProvider.builder().tool("tool", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // get() error cases
+    // ========================
+
+    @Test
+    void get_unknownName_throwsIllegalArgument() {
+        var provider = SimpleToolProvider.of("calculator", TOOL_A);
+
+        assertThatThrownBy(() -> provider.get(List.of("unknown")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown")
+                .hasMessageContaining("calculator");
+    }
+
+    @Test
+    void get_mixedKnownAndUnknown_throwsIllegalArgument() {
+        var provider = SimpleToolProvider.of("calculator", TOOL_A);
+
+        assertThatThrownBy(() -> provider.get(List.of("calculator", "missing")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing");
+    }
+
+    @Test
+    void get_emptyNameList_returnsEmptyList() {
+        var provider = SimpleToolProvider.of("calculator", TOOL_A);
+
+        assertThat(provider.get(List.of())).isEmpty();
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/TaskExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/TaskExecutorTest.java
@@ -1,0 +1,236 @@
+package net.agentensemble.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link TaskExecutor} using mocked LLMs to avoid real network calls.
+ * Follows the same pattern as SequentialEnsembleIntegrationTest in agentensemble-core.
+ */
+class TaskExecutorTest {
+
+    private ChatResponse textResponse(String text) {
+        return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+    }
+
+    private ChatModel mockModelWithResponse(String response) {
+        var model = mock(ChatModel.class);
+        when(model.chat(any(ChatRequest.class))).thenReturn(textResponse(response));
+        return model;
+    }
+
+    // ========================
+    // Constructor validation
+    // ========================
+
+    @Test
+    void constructor_nullModelProvider_throwsNullPointer() {
+        assertThatThrownBy(() -> new TaskExecutor(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructor_nullToolProvider_throwsNullPointer() {
+        var modelProvider = SimpleModelProvider.of(mock(ChatModel.class));
+
+        assertThatThrownBy(() -> new TaskExecutor(modelProvider, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // execute() validation
+    // ========================
+
+    @Test
+    void execute_nullRequest_throwsNullPointer() {
+        var executor = new TaskExecutor(SimpleModelProvider.of(mock(ChatModel.class)));
+
+        assertThatThrownBy(() -> executor.execute((TaskRequest) null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void execute_withConsumer_nullRequest_throwsNullPointer() {
+        var executor = new TaskExecutor(SimpleModelProvider.of(mock(ChatModel.class)));
+
+        assertThatThrownBy(() -> executor.execute(null, obj -> {})).isInstanceOf(NullPointerException.class);
+    }
+
+    // ========================
+    // execute() -- basic happy path
+    // ========================
+
+    @Test
+    void execute_minimalRequest_returnsCompletedResult() {
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("AI is growing fast.")));
+
+        var request = TaskRequest.builder()
+                .description("Research the topic of AI")
+                .expectedOutput("A research summary")
+                .agent(AgentSpec.of("Researcher", "Research and summarize information"))
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result).isNotNull();
+        assertThat(result.output()).isEqualTo("AI is growing fast.");
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.exitReason()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void execute_autoSynthesisNoAgent_returnsCompletedResult() {
+        // No agent specified -- AgentEnsemble auto-synthesizes from the task description.
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Synthesized output.")));
+
+        var result = executor.execute(TaskRequest.of("Research AI trends", "A concise summary"));
+
+        assertThat(result.output()).isEqualTo("Synthesized output.");
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    @Test
+    void execute_durationAndToolCallCountPopulated() {
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Response.")));
+
+        var result = executor.execute(TaskRequest.builder()
+                .description("Summarize AI")
+                .expectedOutput("A short summary")
+                .agent(AgentSpec.of("Summarizer", "Summarize"))
+                .build());
+
+        // Duration is non-negative; tool call count is 0 when no tools used.
+        assertThat(result.durationMs()).isGreaterThanOrEqualTo(0L);
+        assertThat(result.toolCallCount()).isGreaterThanOrEqualTo(0);
+    }
+
+    // ========================
+    // execute() -- context and inputs
+    // ========================
+
+    @Test
+    void execute_withContextAndInputs_runsSuccessfully() {
+        // Context entries from upstream tasks and explicit inputs are both injected as
+        // template variables. This test verifies the ensemble runs without error and
+        // produces the mocked output.
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Article complete.")));
+
+        var request = TaskRequest.builder()
+                .description("Write about {topic} based on: {research}")
+                .expectedOutput("An article about {topic}")
+                .agent(AgentSpec.of("Writer", "Write compelling content"))
+                .context(Map.of("research", "AI is advancing rapidly in 2026."))
+                .inputs(Map.of("topic", "Artificial Intelligence"))
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result.output()).isEqualTo("Article complete.");
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    @Test
+    void execute_contextEntriesAloneWithNoExplicitInputs_runsSuccessfully() {
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Context-only result.")));
+
+        var request = TaskRequest.builder()
+                .description("Summarize: {upstream}")
+                .expectedOutput("A concise summary")
+                .agent(AgentSpec.of("Summarizer", "Summarize information"))
+                .context(Map.of("upstream", "Some upstream task output"))
+                .build();
+
+        assertThat(executor.execute(request).output()).isEqualTo("Context-only result.");
+    }
+
+    // ========================
+    // execute() -- heartbeating
+    // ========================
+
+    @Test
+    void execute_withHeartbeatConsumer_firesAtLeastTaskStartAndTaskCompleted() {
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Research done.")));
+        var heartbeats = new ArrayList<HeartbeatDetail>();
+
+        var request = TaskRequest.builder()
+                .description("Research AI")
+                .expectedOutput("A research summary")
+                .agent(AgentSpec.of("Researcher", "Research"))
+                .build();
+
+        executor.execute(request, obj -> heartbeats.add((HeartbeatDetail) obj));
+
+        assertThat(heartbeats).isNotEmpty();
+        var eventTypes = heartbeats.stream().map(HeartbeatDetail::eventType).toList();
+        assertThat(eventTypes).contains("task_started", "task_completed");
+    }
+
+    @Test
+    void execute_withNullConsumer_runsWithoutHeartbeating() {
+        // Passing null consumer is explicitly supported and disables heartbeating.
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("No heartbeats.")));
+
+        var result = executor.execute(
+                TaskRequest.builder()
+                        .description("Research something")
+                        .expectedOutput("A research result")
+                        .agent(AgentSpec.of("Researcher", "Research"))
+                        .build(),
+                null); // no heartbeating
+
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
+    // execute() -- model provider lookup
+    // ========================
+
+    @Test
+    void execute_namedModelInRequest_usesNamedModelFromProvider() {
+        var defaultModel = mockModelWithResponse("From default model.");
+        var premiumModel = mockModelWithResponse("From premium model.");
+
+        var provider = SimpleModelProvider.builder()
+                .model("premium", premiumModel)
+                .defaultModel(defaultModel)
+                .build();
+
+        var executor = new TaskExecutor(provider);
+
+        var result = executor.execute(TaskRequest.builder()
+                .description("Task using premium model")
+                .expectedOutput("A high-quality result")
+                .agent(AgentSpec.of("Agent", "Do work"))
+                .modelName("premium")
+                .build());
+
+        assertThat(result.output()).isEqualTo("From premium model.");
+    }
+
+    @Test
+    void execute_noModelNameInRequest_usesDefaultModel() {
+        var defaultModel = mockModelWithResponse("From default model.");
+        var provider = SimpleModelProvider.builder()
+                .model("other", mockModelWithResponse("From other model."))
+                .defaultModel(defaultModel)
+                .build();
+
+        var executor = new TaskExecutor(provider);
+
+        var result = executor.execute(TaskRequest.builder()
+                .description("Task with no model override")
+                .expectedOutput("A result")
+                .agent(AgentSpec.of("Agent", "Do work"))
+                .build());
+
+        assertThat(result.output()).isEqualTo("From default model.");
+    }
+}

--- a/agentensemble-executor/src/test/java/net/agentensemble/executor/TaskExecutorTest.java
+++ b/agentensemble-executor/src/test/java/net/agentensemble/executor/TaskExecutorTest.java
@@ -113,14 +113,27 @@ class TaskExecutorTest {
     }
 
     // ========================
+    // execute() -- null expectedOutput default (Copilot fix)
+    // ========================
+
+    @Test
+    void execute_singleArgFactory_nullExpectedOutput_usesDefaultAndSucceeds() {
+        // TaskRequest.of(String) leaves expectedOutput null. The executor substitutes
+        // Task.DEFAULT_EXPECTED_OUTPUT so the task is always executable.
+        var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Result.")));
+
+        var result = executor.execute(TaskRequest.of("Research something"));
+
+        assertThat(result.output()).isEqualTo("Result.");
+        assertThat(result.isComplete()).isTrue();
+    }
+
+    // ========================
     // execute() -- context and inputs
     // ========================
 
     @Test
     void execute_withContextAndInputs_runsSuccessfully() {
-        // Context entries from upstream tasks and explicit inputs are both injected as
-        // template variables. This test verifies the ensemble runs without error and
-        // produces the mocked output.
         var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("Article complete.")));
 
         var request = TaskRequest.builder()
@@ -175,7 +188,6 @@ class TaskExecutorTest {
 
     @Test
     void execute_withNullConsumer_runsWithoutHeartbeating() {
-        // Passing null consumer is explicitly supported and disables heartbeating.
         var executor = new TaskExecutor(SimpleModelProvider.of(mockModelWithResponse("No heartbeats.")));
 
         var result = executor.execute(
@@ -184,7 +196,7 @@ class TaskExecutorTest {
                         .expectedOutput("A research result")
                         .agent(AgentSpec.of("Researcher", "Research"))
                         .build(),
-                null); // no heartbeating
+                null);
 
         assertThat(result.isComplete()).isTrue();
     }

--- a/docs/guides/executor-integration.md
+++ b/docs/guides/executor-integration.md
@@ -1,0 +1,433 @@
+# External Workflow Integration (Temporal, Step Functions, etc.)
+
+The `agentensemble-executor` module lets you call AgentEnsemble **directly in-process** from any
+external workflow engine -- no HTTP server, no network hop, no Temporal SDK dependency required
+inside this library.
+
+Two execution modes are available:
+
+| Class | Granularity | Best for |
+|---|---|---|
+| `TaskExecutor` | One task = one external activity | Temporal workflows where each AgentEnsemble task is a separate activity with its own retry policy, timeout, and heartbeat |
+| `EnsembleExecutor` | One ensemble = one external activity | Simpler pipelines where AgentEnsemble's internal orchestration handles the full run inside a single activity |
+
+Two test doubles are also provided so your Temporal activities can be tested without a real LLM:
+
+| Class | Extends |
+|---|---|
+| `FakeTaskExecutor` | `TaskExecutor` |
+| `FakeEnsembleExecutor` | `EnsembleExecutor` |
+
+---
+
+## Heartbeats
+
+**Yes -- heartbeats still work.** The `HeartbeatEnsembleListener` bridges `EnsembleListener`
+lifecycle events to any `Consumer<Object>`. You pass Temporal's heartbeat method as the consumer:
+
+```java
+executor.execute(request, Activity.getExecutionContext()::heartbeat);
+```
+
+The consumer receives a `HeartbeatDetail` record for each event:
+
+| `eventType` | When fired |
+|---|---|
+| `task_started` | Agent begins executing a task |
+| `task_completed` | Agent finishes a task successfully |
+| `task_failed` | A task fails with an exception |
+| `tool_call` | Agent invokes a tool within the ReAct loop |
+| `iteration_started` | New ReAct iteration begins (LLM call pending) |
+| `iteration_completed` | ReAct iteration finishes (LLM response received) |
+
+`HeartbeatDetail` is a plain Java record serializable by Temporal's default Jackson
+`DataConverter`. Temporal stores the latest heartbeat detail in the activity's history, visible
+in the Temporal UI and accessible from the workflow via `Activity.getLastHeartbeatDetails()`.
+
+---
+
+## Adding the Dependency
+
+```kotlin
+// build.gradle.kts (in your Temporal worker project)
+dependencies {
+    implementation("net.agentensemble:agentensemble-executor:$agentEnsembleVersion")
+    // Optional: whichever tool modules the agents need
+    implementation("net.agentensemble:agentensemble-tools-datetime:$agentEnsembleVersion")
+}
+```
+
+---
+
+## Full Temporal Integration: Task-per-Activity
+
+This is the recommended Temporal pattern. Each `TaskRequest` maps to one Temporal activity.
+The Temporal workflow sequences activities and passes upstream outputs as context entries.
+
+### 1. Define the Activity interface (in your Temporal project)
+
+```java
+@ActivityInterface
+public interface ResearchPipelineActivity {
+
+    @ActivityMethod
+    TaskResult research(TaskRequest request);
+
+    @ActivityMethod
+    TaskResult write(TaskRequest request);
+}
+```
+
+### 2. Implement the activities
+
+Accept `TaskExecutor` by concrete type -- `FakeTaskExecutor` (a subtype) can then be injected
+in tests without any additional interface.
+
+```java
+public class ResearchPipelineActivityImpl implements ResearchPipelineActivity {
+
+    private final TaskExecutor executor;
+
+    /** Production constructor. */
+    public ResearchPipelineActivityImpl() {
+        this(new TaskExecutor(
+            SimpleModelProvider.of(
+                OpenAiChatModel.builder()
+                    .apiKey(System.getenv("OPENAI_API_KEY"))
+                    .modelName("gpt-4o-mini")
+                    .build()),
+            SimpleToolProvider.builder()
+                .tool("web-search", new WebSearchTool(System.getenv("SEARCH_API_KEY")))
+                .tool("datetime", new DateTimeTool())
+                .build()));
+    }
+
+    /** Package-private constructor for testing -- accepts FakeTaskExecutor. */
+    ResearchPipelineActivityImpl(TaskExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public TaskResult research(TaskRequest request) {
+        // heartbeat() keeps the activity alive during long LLM / tool-call chains
+        return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+    }
+
+    @Override
+    public TaskResult write(TaskRequest request) {
+        return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+    }
+}
+```
+
+### 3. Write the Temporal workflow
+
+The workflow orchestrates activities, passes upstream outputs as `context` entries, and handles
+all retry and timeout semantics via Temporal's standard policies.
+
+```java
+@WorkflowInterface
+public interface ResearchWorkflow {
+    @WorkflowMethod
+    String run(String topic);
+}
+
+public class ResearchWorkflowImpl implements ResearchWorkflow {
+
+    private static final ActivityOptions ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
+            // Allow up to 30 minutes per activity (LLM chains can be slow)
+            .setScheduleToCloseTimeout(Duration.ofMinutes(30))
+            // Temporal marks the activity as failed if no heartbeat arrives within 2 minutes.
+            // HeartbeatEnsembleListener fires on every LLM iteration and tool call, so
+            // the 2-minute window is generous for typical agent workloads.
+            .setHeartbeatTimeout(Duration.ofMinutes(2))
+            .setRetryOptions(RetryOptions.newBuilder()
+                    .setMaximumAttempts(3)
+                    .build())
+            .build();
+
+    private final ResearchPipelineActivity activity =
+            Workflow.newActivityStub(ResearchPipelineActivity.class, ACTIVITY_OPTIONS);
+
+    @Override
+    public String run(String topic) {
+
+        // Activity 1: Research
+        TaskResult research = activity.research(
+                TaskRequest.builder()
+                        .description("Research the latest developments in {topic}")
+                        .expectedOutput("A comprehensive, accurate research summary")
+                        .agent(AgentSpec.builder()
+                                .role("Research Analyst")
+                                .goal("Find accurate, up-to-date information on any topic")
+                                .toolNames(List.of("web-search", "datetime"))
+                                .build())
+                        .inputs(Map.of("topic", topic))
+                        .build());
+
+        // Activity 2: Write -- injects research output as a template variable {research}
+        TaskResult article = activity.write(
+                TaskRequest.builder()
+                        .description("Write a blog post about {topic} using this research: {research}")
+                        .expectedOutput("A well-structured, engaging 500-word blog post")
+                        .agent(AgentSpec.of("Technical Writer", "Write clear, compelling content"))
+                        .context(Map.of("research", research.output()))   // <-- upstream output
+                        .inputs(Map.of("topic", topic))
+                        .build());
+
+        return article.output();
+    }
+}
+```
+
+### 4. Register the Temporal worker
+
+```java
+WorkflowServiceStubs service = WorkflowServiceStubs.newLocalServiceStubs();
+WorkflowClient client = WorkflowClient.newInstance(service);
+WorkerFactory factory = WorkerFactory.newInstance(client);
+
+Worker worker = factory.newWorker("research-task-queue");
+worker.registerWorkflowImplementationTypes(ResearchWorkflowImpl.class);
+worker.registerActivitiesImplementations(new ResearchPipelineActivityImpl());
+
+factory.start();
+```
+
+### 5. Start a workflow from a client
+
+```java
+ResearchWorkflow workflow = client.newWorkflowStub(
+        ResearchWorkflow.class,
+        WorkflowOptions.newBuilder()
+                .setTaskQueue("research-task-queue")
+                .setWorkflowId("research-" + UUID.randomUUID())
+                .build());
+
+String result = workflow.run("Artificial Intelligence");
+System.out.println(result);
+```
+
+---
+
+## Testing Temporal Activities and Workflows
+
+Use `FakeTaskExecutor` to test both activity implementations and the full workflow
+(via `TestWorkflowEnvironment`) without any LLM calls.
+
+### Unit-testing a single activity
+
+```java
+import net.agentensemble.executor.FakeTaskExecutor;
+import net.agentensemble.executor.TaskRequest;
+import net.agentensemble.executor.TaskResult;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResearchActivityTest {
+
+    @Test
+    void research_callsExecutorWithCorrectRequest_returnsResult() {
+        // Arrange
+        FakeTaskExecutor fake = FakeTaskExecutor.builder()
+                .whenDescriptionContains("Research", "AI is advancing rapidly in 2026.")
+                .defaultOutput("Unexpected request")
+                .build();
+
+        var activity = new ResearchPipelineActivityImpl(fake);
+
+        var request = TaskRequest.builder()
+                .description("Research the latest developments in {topic}")
+                .expectedOutput("A research summary")
+                .inputs(Map.of("topic", "AI"))
+                .build();
+
+        // Act
+        TaskResult result = activity.research(request);
+
+        // Assert
+        assertThat(result.output()).isEqualTo("AI is advancing rapidly in 2026.");
+        assertThat(result.isComplete()).isTrue();
+    }
+}
+```
+
+### Integration-testing the full Temporal workflow
+
+Use Temporal's `TestWorkflowEnvironment` to run the real workflow code with fake activity
+implementations -- no LLM, no network, fast deterministic tests.
+
+```java
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.client.WorkflowOptions;
+import net.agentensemble.executor.FakeTaskExecutor;
+
+class ResearchWorkflowTest {
+
+    private TestWorkflowEnvironment testEnv;
+    private static final String TASK_QUEUE = "test-queue";
+
+    @BeforeEach
+    void setUp() {
+        testEnv = TestWorkflowEnvironment.newInstance();
+
+        // Configure a fake executor for both research and write activities
+        FakeTaskExecutor fake = FakeTaskExecutor.builder()
+                .whenDescriptionContains("Research", "Research done: AI grows 40% YoY.")
+                .whenDescriptionContains("Write",    "Article: AI is reshaping every industry.")
+                .build();
+
+        Worker worker = testEnv.newWorker(TASK_QUEUE);
+        worker.registerWorkflowImplementationTypes(ResearchWorkflowImpl.class);
+        worker.registerActivitiesImplementations(new ResearchPipelineActivityImpl(fake));
+        testEnv.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testEnv.close();
+    }
+
+    @Test
+    void run_sequencesResearchThenWrite_returnsArticleOutput() {
+        ResearchWorkflow workflow = testEnv.newWorkflowStub(
+                ResearchWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        String result = workflow.run("Artificial Intelligence");
+
+        assertThat(result).isEqualTo("Article: AI is reshaping every industry.");
+    }
+
+    @Test
+    void run_passesResearchContextToWriteActivity() {
+        // Use a custom fake that validates context passing
+        List<TaskRequest> capturedRequests = new ArrayList<>();
+        FakeTaskExecutor capturingFake = FakeTaskExecutor.builder()
+                .whenDescriptionContains("Research", "Research output.")
+                .whenDescriptionContains("Write",    "Article output.")
+                .build();
+
+        // You can also use Mockito to capture and verify the TaskRequest:
+        // TaskExecutor mockExecutor = mock(TaskExecutor.class);
+        // when(mockExecutor.execute(any(), any())).thenReturn(new TaskResult("output", 1, 0, "COMPLETED"));
+        // ArgumentCaptor<TaskRequest> captor = ArgumentCaptor.forClass(TaskRequest.class);
+        // verify(mockExecutor, times(2)).execute(captor.capture(), any());
+        // assertThat(captor.getAllValues().get(1).getContext()).containsKey("research");
+    }
+}
+```
+
+### `FakeTaskExecutor` API reference
+
+| Method | Description |
+|---|---|
+| `FakeTaskExecutor.alwaysReturns(String)` | Returns the same output for every `execute()` call |
+| `builder().whenDescriptionContains(substring, output)` | Returns `output` when the request's description contains `substring`; first match wins |
+| `builder().whenDescription(Predicate<String>, output)` | Returns `output` when the description predicate is true |
+| `builder().whenAgentRole(role, output)` | Returns `output` when `request.getAgent().getRole()` matches |
+| `builder().defaultOutput(String)` | Output returned when no rule matches (default: `"Fake task output."`) |
+
+`FakeEnsembleExecutor` has the same API. For multi-task requests, each task is matched
+independently; the final task's output becomes `EnsembleResult.finalOutput()`.
+
+---
+
+## Context Passing Between Tasks
+
+Upstream task outputs become template variables in downstream tasks:
+
+```java
+// Activity 1: Research returns "AI is growing fast."
+TaskResult research = activity.research(
+    TaskRequest.builder()
+        .description("Research {topic}")
+        .expectedOutput("A research summary")
+        .inputs(Map.of("topic", topic))
+        .build());
+
+// Activity 2: Write -- {research} resolves to the upstream output
+TaskResult article = activity.write(
+    TaskRequest.builder()
+        .description("Write about {topic} using: {research}")
+        .expectedOutput("A blog post")
+        .context(Map.of("research", research.output()))  // key = template variable name
+        .inputs(Map.of("topic", topic))
+        .build());
+```
+
+Context entries and explicit inputs are merged. Explicit `inputs()` take precedence over
+`context()` when both share a key.
+
+---
+
+## Ensemble-per-Activity (Simpler Pipelines)
+
+Use `EnsembleExecutor` when you want AgentEnsemble to handle a full pipeline inside a single
+Temporal activity:
+
+```java
+public class PipelineActivityImpl implements PipelineActivity {
+
+    private final EnsembleExecutor executor;
+
+    public PipelineActivityImpl() {
+        this(new EnsembleExecutor(SimpleModelProvider.of(buildModel())));
+    }
+
+    PipelineActivityImpl(EnsembleExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public EnsembleResult run(EnsembleRequest request) {
+        return executor.execute(request, Activity.getExecutionContext()::heartbeat);
+    }
+}
+```
+
+In tests, inject `FakeEnsembleExecutor`:
+
+```java
+FakeEnsembleExecutor fake = FakeEnsembleExecutor.builder()
+        .whenDescriptionContains("Research", "Research output.")
+        .whenDescriptionContains("Write",    "Article output.")
+        .build();
+
+PipelineActivityImpl activity = new PipelineActivityImpl(fake);
+```
+
+---
+
+## Model and Tool Provider Configuration
+
+Models and tools are configured on the **worker side** and are never serialized into workflow
+history. Use `modelName` in a `TaskRequest` to select a specific model at request time:
+
+```java
+ModelProvider models = SimpleModelProvider.builder()
+        .model("gpt-4o-mini", cheapModel)
+        .model("gpt-4o", premiumModel)
+        .defaultModel(cheapModel)
+        .build();
+
+// Workflow code -- selecting a named model for a specific task:
+TaskRequest.builder()
+        .description("Synthesize the final executive summary")
+        .expectedOutput("A crisp one-page summary")
+        .modelName("gpt-4o")        // resolved by the worker's ModelProvider at run time
+        .agent(AgentSpec.of("Executive Synthesizer", "Produce board-level summaries"))
+        .build();
+```
+
+---
+
+## Works with Any External Orchestrator
+
+The `agentensemble-executor` module has **no Temporal SDK dependency**. The heartbeat consumer
+is a plain `Consumer<Object>`. The same executors work with:
+
+- **Temporal** -- `Activity.getExecutionContext()::heartbeat`
+- **AWS Step Functions** -- pass a heartbeat callback to a state machine activity poller
+- **Kafka Streams** -- call `execute()` inside a `Processor`
+- **Spring Batch** -- wrap in a `Tasklet`
+- **Plain threads** -- pass `null` for no heartbeating

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,6 +3,44 @@
 
 ## Current Work
 
+**`agentensemble-executor` module** -- direct in-process invocation from external workflow engines.
+
+### What was implemented
+
+New standalone module `agentensemble-executor` (package `net.agentensemble.executor`) with no
+Temporal SDK dependency. Enables calling AgentEnsemble directly from any external workflow
+orchestrator (Temporal, AWS Step Functions, Kafka Streams, etc.) with task-level or
+ensemble-level granularity.
+
+**DTOs (request/result, Lombok @Value @Builder):**
+- `AgentSpec` -- agent role, goal, background, tool names, max iterations
+- `TaskRequest` -- description, expectedOutput, agent, context, inputs, modelName
+- `TaskResult` -- output, durationMs, toolCallCount, exitReason
+- `EnsembleRequest` -- list of TaskRequests (@Singular), workflow mode, inputs, modelName
+- `EnsembleResult` -- finalOutput, taskOutputs, totalDurationMs, totalToolCalls, exitReason
+- `HeartbeatDetail` -- serializable heartbeat payload (eventType, description, taskIndex, iteration)
+
+**Core executors:**
+- `TaskExecutor` -- executes a single TaskRequest in-process; heartbeat via `Consumer<Object>`
+- `EnsembleExecutor` -- executes a full EnsembleRequest in-process; same heartbeat API
+
+**Heartbeat integration:**
+- `HeartbeatEnsembleListener` -- EnsembleListener that forwards 6 event types to a Consumer
+
+**Configuration (worker-side, never serialized):**
+- `ModelProvider` / `ToolProvider` -- interfaces for model and tool resolution by name
+- `SimpleModelProvider` / `SimpleToolProvider` -- map-backed implementations with builders
+
+**Test doubles (in main jar, usable in users' test code):**
+- `FakeTaskExecutor` -- extends `TaskExecutor`; rule-based `whenDescriptionContains()`, `whenAgentRole()`, `alwaysReturns()` factories; no LLM, no network
+- `FakeEnsembleExecutor` -- same pattern, each task matched independently; last task output = `finalOutput()`
+
+**Tests:** 98 tests passing (66 core + 18 `FakeTaskExecutorTest` + 14 `FakeEnsembleExecutorTest`; 0.85 line / 0.70 branch coverage)
+**Documentation:** `docs/guides/executor-integration.md` (full Temporal integration + testing guide), `mkdocs.yml` nav
+**Example:** `ExecutorExample.java` + `runExecutor` Gradle task
+
+## Previous Context
+
 Branch `feat/299-ensemble-control-api-phase1` -- Issue #299.
 Ensemble Control API Phase 1: catalogs, RunManager, REST endpoints for external run submission.
 

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased] -- 2026-04-09
 ### Added
+- **`agentensemble-executor` module**: Orchestrator-agnostic direct in-process invocation
+  - `TaskExecutor` -- single-task execution with `Consumer<Object>` heartbeat callback
+  - `EnsembleExecutor` -- full-ensemble execution with the same heartbeat API
+  - `HeartbeatEnsembleListener` -- bridges `EnsembleListener` events to the heartbeat consumer
+  - `HeartbeatDetail` -- serializable heartbeat payload (Jackson-compatible, Temporal-ready)
+  - `AgentSpec`, `TaskRequest`, `TaskResult`, `EnsembleRequest`, `EnsembleResult` -- DTOs
+  - `ModelProvider` / `ToolProvider` interfaces + `Simple*` map-backed implementations
+  - `FakeTaskExecutor` -- test double extending `TaskExecutor`; rule-based responses, no LLM
+  - `FakeEnsembleExecutor` -- test double extending `EnsembleExecutor`; same API
+  - No Temporal SDK dependency -- `Consumer<Object>` heartbeat works with any orchestrator
+  - 98 unit + integration tests (66 core + 18 `FakeTaskExecutorTest` + 14 `FakeEnsembleExecutorTest`)
+  - Guide: `docs/guides/executor-integration.md` (full Temporal integration + testing patterns)
+  - Example: `ExecutorExample.java`; added to BOM, `settings.gradle.kts`, `agentensemble-examples`
+
 - **Ensemble Control API Phase 1 (#299)**: HTTP-based run management for external systems
   - `ToolCatalog` -- name-keyed `AgentTool` registry (allowlist for API requests)
   - `ModelCatalog` -- alias-keyed `ChatModel` registry with streaming support and provider detection

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
     - Logging: guides/logging.md
     - Template Variables: guides/template-variables.md
     - Framework Integration: guides/framework-integration.md
+    - External Workflow Integration: guides/executor-integration.md
     - Testing: guides/testing.md
     - Deterministic Orchestration: guides/deterministic-orchestration.md
     - Task Reflection: guides/task-reflection.md

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,6 +61,9 @@ include("agentensemble-metrics-micrometer")
 // OpenTelemetry integration (optional span creation at framework boundaries)
 include("agentensemble-telemetry-opentelemetry")
 
+// Executor module (orchestrator-agnostic direct invocation -- Temporal, Step Functions, etc.)
+include("agentensemble-executor")
+
 // Developer tooling module (DAG export, trace utilities)
 include("agentensemble-devtools")
 


### PR DESCRIPTION
## Summary

Adds the `agentensemble-executor` module: a zero-dependency bridge for calling AgentEnsemble directly in-process from any external workflow engine (Temporal, AWS Step Functions, Kafka Streams, etc.). No HTTP server, no network hop, no Temporal SDK required inside this library.

## Motivation

The standard approach of calling AgentEnsemble over the network requires standing up a WebSocket server and wiring it through the Temporal activity. This module enables a much simpler pattern: the Temporal activity embeds `agentensemble-core` on the classpath and calls `TaskExecutor.execute(request, heartbeatConsumer)` directly.

## What's included

### Core executors
- **`TaskExecutor`** -- single task per external activity; `Consumer<Object>` heartbeat
- **`EnsembleExecutor`** -- full ensemble per external activity; same heartbeat API

### Heartbeat integration
- **`HeartbeatEnsembleListener`** bridges `EnsembleListener` events to `Consumer<Object>`
- **`HeartbeatDetail`** -- Jackson-serializable record (compatible with Temporal's default `DataConverter`)
- Events fired: `task_started`, `task_completed`, `task_failed`, `tool_call`, `iteration_started`, `iteration_completed`

### Test doubles (in main jar -- users need them in their test classpath)
- **`FakeTaskExecutor`** extends `TaskExecutor`; rule-based responses, zero LLM calls
- **`FakeEnsembleExecutor`** extends `EnsembleExecutor`; same pattern
- Designed for use with Temporal `TestWorkflowEnvironment` -- no API keys required

### DTOs and configuration
- `AgentSpec`, `TaskRequest`, `TaskResult`, `EnsembleRequest`, `EnsembleResult`
- `ModelProvider` / `ToolProvider` interfaces (worker-side, never serialized into workflow history)
- `SimpleModelProvider` / `SimpleToolProvider` map-backed implementations

## Usage in Temporal

```java
// Activity implementation (user's separate project):
public class ResearchActivityImpl implements ResearchActivity {
    private final TaskExecutor executor;

    public ResearchActivityImpl() {
        this(new TaskExecutor(SimpleModelProvider.of(buildModel())));
    }

    ResearchActivityImpl(TaskExecutor executor) { // package-private for testing
        this.executor = executor;
    }

    @Override
    public TaskResult research(TaskRequest request) {
        return executor.execute(request, Activity.getExecutionContext()::heartbeat);
    }
}
```

## Testing with FakeTaskExecutor

```java
FakeTaskExecutor fake = FakeTaskExecutor.builder()
    .whenDescriptionContains("Research", "AI grew 40% YoY.")
    .whenDescriptionContains("Write",    "Article: AI reshapes industry.")
    .build();

testEnv.newWorker(TASK_QUEUE)
    .registerActivitiesImplementations(new ResearchActivityImpl(fake));

ResearchWorkflow wf = testEnv.newWorkflowStub(ResearchWorkflow.class, options);
assertThat(wf.run("AI")).isEqualTo("Article: AI reshapes industry.");
```

## Tests

**98/98 passing** -- unit tests + integration tests with mocked `ChatModel` (same pattern as existing `SequentialEnsembleIntegrationTest`).

Coverage: LINE >= 0.85, BRANCH >= 0.70.

## Files changed

| File | Change |
|---|---|
| `agentensemble-executor/` | New module (25 files) |
| `settings.gradle.kts` | `include("agentensemble-executor")` |
| `agentensemble-bom/build.gradle.kts` | Add to BOM |
| `agentensemble-examples/` | `ExecutorExample.java` + `runExecutor` Gradle task |
| `docs/guides/executor-integration.md` | Full Temporal integration guide |
| `mkdocs.yml` | Nav entry under Guides |
| `memory-bank/` | activeContext.md, changelog.md |