### PR TITLE
feat: Ensemble Control API Phase 2 -- Level 2/3 parameterization + WebSocket run submission

### DIFF
--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -1151,12 +1151,21 @@ public class Ensemble {
      * <p>This method is used by the Ensemble Control API (Phase 2+) to execute Level 2
      * (per-task overrides) and Level 3 (dynamic tasks) runs against a configured template.
      *
-     * @param newTasks the replacement task list; must not be null or empty
+     * @param newTasks the replacement task list; must not be null, empty, or contain null elements
      * @return a new Ensemble with {@code newTasks} and all other settings from this instance
-     * @throws NullPointerException if {@code newTasks} is null
+     * @throws NullPointerException     if {@code newTasks} is null or contains a null element
+     * @throws IllegalArgumentException if {@code newTasks} is empty
      */
     public Ensemble withTasks(List<Task> newTasks) {
         Objects.requireNonNull(newTasks, "newTasks must not be null");
+        if (newTasks.isEmpty()) {
+            throw new IllegalArgumentException("newTasks must not be empty");
+        }
+        for (int i = 0; i < newTasks.size(); i++) {
+            if (newTasks.get(i) == null) {
+                throw new NullPointerException("newTasks must not contain null elements (at index " + i + ")");
+            }
+        }
         return Ensemble.builder()
                 // Replace the task list; phases are intentionally not copied
                 // (API-submitted runs always use the flat task list)

--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -1138,6 +1138,72 @@ public class Ensemble {
         return List.copyOf(result);
     }
 
+    /**
+     * Returns a copy of this ensemble with the given task list replacing the original.
+     *
+     * <p>All core execution settings are preserved: model, agent synthesizer, workflow,
+     * listeners, review handler, memory store, rate limits, output settings, etc.
+     *
+     * <p>The dashboard lifecycle is not inherited: {@code ownsDashboardLifecycle} is set to
+     * {@code false} on the returned ensemble, since the dashboard is already running and
+     * should not be stopped when the returned ensemble's run completes.
+     *
+     * <p>This method is used by the Ensemble Control API (Phase 2+) to execute Level 2
+     * (per-task overrides) and Level 3 (dynamic tasks) runs against a configured template.
+     *
+     * @param newTasks the replacement task list; must not be null or empty
+     * @return a new Ensemble with {@code newTasks} and all other settings from this instance
+     * @throws NullPointerException if {@code newTasks} is null
+     */
+    public Ensemble withTasks(List<Task> newTasks) {
+        Objects.requireNonNull(newTasks, "newTasks must not be null");
+        return Ensemble.builder()
+                // Replace the task list; phases are intentionally not copied
+                // (API-submitted runs always use the flat task list)
+                .tasks(newTasks)
+                // Core LLM settings
+                .chatLanguageModel(chatLanguageModel)
+                .streamingChatLanguageModel(streamingChatLanguageModel)
+                .agentSynthesizer(agentSynthesizer)
+                // Workflow and manager
+                .workflow(workflow)
+                .managerLlm(managerLlm)
+                .managerMaxIterations(managerMaxIterations)
+                .managerPromptStrategy(managerPromptStrategy)
+                // Execution settings
+                .verbose(verbose)
+                .toolExecutor(toolExecutor)
+                .toolMetrics(toolMetrics)
+                .maxDelegationDepth(maxDelegationDepth)
+                .parallelErrorStrategy(parallelErrorStrategy)
+                .hierarchicalConstraints(hierarchicalConstraints)
+                .delegationPolicies(delegationPolicies)
+                // Memory and context
+                .memoryStore(memoryStore)
+                .contextFormat(contextFormat)
+                .reflectionStore(reflectionStore)
+                // Review integration
+                .reviewHandler(reviewHandler)
+                .reviewPolicy(reviewPolicy)
+                // Event streaming (critical: carries dashboard listener)
+                .listeners(listeners)
+                // Observability
+                .captureMode(captureMode)
+                .traceExporter(traceExporter)
+                .costConfiguration(costConfiguration)
+                // Dashboard -- not owned; it is already running
+                .dashboard(dashboard)
+                .ownsDashboardLifecycle(false)
+                // Rate limiting and output settings
+                .rateLimit(rateLimit)
+                .maxToolOutputLength(maxToolOutputLength)
+                .toolLogTruncateLength(toolLogTruncateLength)
+                .drainTimeout(drainTimeout)
+                // Default inputs from the template (merged with API inputs at run time)
+                .inputs(inputs)
+                .build();
+    }
+
     private EnsembleOutput runWithInputs(
             Map<String, String> resolvedInputs, int maxToolOutputLength, int toolLogTruncateLength) {
         String ensembleId = UUID.randomUUID().toString();

--- a/agentensemble-core/src/main/java/net/agentensemble/Task.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Task.java
@@ -83,6 +83,21 @@ public class Task {
     public static final String DEFAULT_EXPECTED_OUTPUT = "Produce a complete and accurate response to the task.";
 
     /**
+     * Optional logical name for this task.
+     *
+     * <p>Used by the Ensemble Control API (Phase 2+) for task matching in Level 2 overrides
+     * and as a reference target in Level 3 dynamic task context resolution ({@code $name}
+     * syntax). Also exposed via {@code GET /api/capabilities} so callers can discover
+     * available task names.
+     *
+     * <p>Names must be non-blank when set. They do not need to be unique across an
+     * ensemble, but unique names make override matching unambiguous.
+     *
+     * <p>Default: {@code null} (unnamed task; matched by description prefix in Level 2).
+     */
+    String name;
+
+    /**
      * What the agent should do. Supports {variable} template placeholders
      * resolved at ensemble.run(inputs) time. Required.
      */
@@ -451,6 +466,7 @@ public class Task {
     public static class TaskBuilder {
 
         // Default values
+        private String name = null;
         private Agent agent = null;
         private ChatModel chatLanguageModel = null;
         private StreamingChatModel streamingChatLanguageModel = null;
@@ -660,6 +676,7 @@ public class Task {
         }
 
         public Task build() {
+            validateName();
             validateDescription();
             validateExpectedOutput();
             List<Object> effectiveTools = tools != null ? tools : List.of();
@@ -679,6 +696,7 @@ public class Task {
             inputGuardrails = List.copyOf(effectiveInputGuardrails);
             outputGuardrails = List.copyOf(effectiveOutputGuardrails);
             return new Task(
+                    name,
                     description,
                     expectedOutput,
                     agent,
@@ -712,6 +730,12 @@ public class Task {
                 chatLanguageModel = RateLimitedChatModel.of(chatLanguageModel, rateLimit);
                 // Rate limit consumed at build time; not stored on the Task.
                 rateLimit = null;
+            }
+        }
+
+        private void validateName() {
+            if (name != null && name.isBlank()) {
+                throw new ValidationException("Task name must not be blank when set");
             }
         }
 

--- a/agentensemble-core/src/test/java/net/agentensemble/EnsembleTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/EnsembleTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import net.agentensemble.callback.EnsembleListener;
 import net.agentensemble.ratelimit.RateLimit;
@@ -218,5 +220,118 @@ class EnsembleTest {
                 .build();
         assertThat(ensemble.getChatLanguageModel()).isSameAs(model);
         assertThat(ensemble.getRateLimit()).isEqualTo(RateLimit.perMinute(60));
+    }
+
+    // ========================
+    // withTasks()
+    // ========================
+
+    @Test
+    void withTasks_returnsNewEnsembleWithReplacedTasks() {
+        Task original = Task.of("Original task");
+        Task replacement = Task.of("Replacement task");
+        Ensemble ensemble = Ensemble.builder().task(original).build();
+
+        Ensemble copy = ensemble.withTasks(List.of(replacement));
+
+        assertThat(copy.getTasks()).containsExactly(replacement);
+        // original ensemble's task list must be unchanged (immutability)
+        assertThat(ensemble.getTasks()).containsExactly(original);
+    }
+
+    @Test
+    void withTasks_preservesListeners() {
+        EnsembleListener listener = new EnsembleListener() {};
+        Task task = Task.of("Task");
+        Ensemble ensemble = Ensemble.builder().task(task).listener(listener).build();
+
+        Ensemble copy = ensemble.withTasks(List.of(Task.of("New task")));
+
+        assertThat(copy.getListeners()).containsExactly(listener);
+    }
+
+    @Test
+    void withTasks_preservesChatLanguageModel() {
+        ChatModel model = mock(ChatModel.class);
+        Task task = Task.of("Task");
+        Ensemble ensemble =
+                Ensemble.builder().chatLanguageModel(model).task(task).build();
+
+        Ensemble copy = ensemble.withTasks(List.of(Task.of("New task")));
+
+        assertThat(copy.getChatLanguageModel()).isSameAs(model);
+    }
+
+    @Test
+    void withTasks_preservesWorkflow() {
+        Task task = Task.of("Task");
+        Ensemble ensemble =
+                Ensemble.builder().task(task).workflow(Workflow.SEQUENTIAL).build();
+
+        Ensemble copy = ensemble.withTasks(List.of(Task.of("New task")));
+
+        assertThat(copy.getWorkflow()).isEqualTo(Workflow.SEQUENTIAL);
+    }
+
+    @Test
+    void withTasks_ownsDashboardLifecycleFalse() {
+        Task task = Task.of("Task");
+        Ensemble ensemble = Ensemble.builder().task(task).build();
+
+        Ensemble copy = ensemble.withTasks(List.of(Task.of("New task")));
+
+        // Copies must never own the dashboard lifecycle -- the original (or caller) owns it
+        assertThat(copy.isOwnsDashboardLifecycle()).isFalse();
+    }
+
+    @Test
+    void withTasks_preservesInputs() {
+        Task task = Task.of("Task");
+        Ensemble ensemble = Ensemble.builder().task(task).input("topic", "AI").build();
+
+        Ensemble copy = ensemble.withTasks(List.of(Task.of("New task")));
+
+        assertThat(copy.getInputs()).containsEntry("topic", "AI");
+    }
+
+    @Test
+    void withTasks_multipleTasks_allPresent() {
+        Task t1 = Task.of("Task one");
+        Task t2 = Task.of("Task two");
+        Task t3 = Task.of("Task three");
+        Ensemble ensemble = Ensemble.builder().task(Task.of("Original")).build();
+
+        Ensemble copy = ensemble.withTasks(List.of(t1, t2, t3));
+
+        assertThat(copy.getTasks()).containsExactly(t1, t2, t3);
+    }
+
+    @Test
+    void withTasks_nullList_throwsNullPointerException() {
+        Ensemble ensemble = Ensemble.builder().task(Task.of("Task")).build();
+
+        assertThatThrownBy(() -> ensemble.withTasks(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("newTasks must not be null");
+    }
+
+    @Test
+    void withTasks_emptyList_throwsIllegalArgumentException() {
+        Ensemble ensemble = Ensemble.builder().task(Task.of("Task")).build();
+
+        assertThatThrownBy(() -> ensemble.withTasks(List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("newTasks must not be empty");
+    }
+
+    @Test
+    void withTasks_listWithNullElement_throwsNullPointerException() {
+        Ensemble ensemble = Ensemble.builder().task(Task.of("Task")).build();
+        List<Task> tasksWithNull = new ArrayList<>();
+        tasksWithNull.add(null);
+
+        assertThatThrownBy(() -> ensemble.withTasks(tasksWithNull))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("null elements");
     }
 }

--- a/agentensemble-core/src/test/java/net/agentensemble/TaskTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/TaskTest.java
@@ -1,6 +1,7 @@
 package net.agentensemble;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.model.chat.ChatModel;
@@ -816,5 +817,93 @@ class TaskTest {
         assertThat(task.getHandler()).isNotNull();
         assertThat(task.getInputGuardrails()).hasSize(1);
         assertThat(task.getOutputGuardrails()).hasSize(1);
+    }
+
+    // ========================
+    // Task.name field (Phase 2 -- Ensemble Control API)
+    // ========================
+
+    @Test
+    void name_isNullByDefault() {
+        var task = Task.builder()
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .build();
+
+        assertThat(task.getName()).isNull();
+    }
+
+    @Test
+    void name_whenSetViaBuilder_isReturned() {
+        var task = Task.builder()
+                .name("researcher")
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .build();
+
+        assertThat(task.getName()).isEqualTo("researcher");
+    }
+
+    @Test
+    void name_blank_throwsValidationException() {
+        assertThatThrownBy(() -> Task.builder()
+                        .name("  ")
+                        .description("Research AI trends")
+                        .expectedOutput("A detailed report")
+                        .build())
+                .isInstanceOf(net.agentensemble.exception.ValidationException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void name_empty_throwsValidationException() {
+        assertThatThrownBy(() -> Task.builder()
+                        .name("")
+                        .description("Research AI trends")
+                        .expectedOutput("A detailed report")
+                        .build())
+                .isInstanceOf(net.agentensemble.exception.ValidationException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void toBuilder_preservesName() {
+        var original = Task.builder()
+                .name("researcher")
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .build();
+
+        var copy = original.toBuilder().build();
+
+        assertThat(copy.getName()).isEqualTo("researcher");
+    }
+
+    @Test
+    void toBuilder_allowsNameChange() {
+        var original = Task.builder()
+                .name("researcher")
+                .description("Research AI trends")
+                .expectedOutput("A detailed report")
+                .build();
+
+        var copy = original.toBuilder().name("senior-researcher").build();
+
+        assertThat(copy.getName()).isEqualTo("senior-researcher");
+        assertThat(original.getName()).isEqualTo("researcher");
+    }
+
+    @Test
+    void taskOf_descriptionOnly_hasNullName() {
+        var task = Task.of("Research AI trends");
+
+        assertThat(task.getName()).isNull();
+    }
+
+    @Test
+    void taskOf_descriptionAndExpectedOutput_hasNullName() {
+        var task = Task.of("Research AI trends", "A detailed report");
+
+        assertThat(task.getName()).isNull();
     }
 }

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunRequestParser.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunRequestParser.java
@@ -1,28 +1,40 @@
 package net.agentensemble.web;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.chat.ChatModel;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
 import net.agentensemble.execution.RunOptions;
+import net.agentensemble.tool.AgentTool;
 
 /**
  * Converts API run requests into {@link RunConfiguration} values ready for execution.
  *
- * <p>In Phase 1 (this implementation), only <strong>Level 1</strong> is supported:
- * run the pre-configured template ensemble with input variable substitution. The
- * template ensemble's tasks run as-is; {@code {variable}} placeholders in task
- * descriptions are resolved by the {@code TemplateResolver} inside
- * {@code Ensemble.run(inputs, options)}.
- *
- * <p>Future phases will add:
+ * <p>Supports three levels of parameterization:
  * <ul>
- *   <li>Level 2 -- per-task overrides (description, model, tool add/remove)</li>
- *   <li>Level 3 -- fully dynamic task creation from a JSON task list</li>
+ *   <li><strong>Level 1</strong> -- run the pre-configured template ensemble with input variable
+ *       substitution. The template ensemble's tasks run as-is; {@code {variable}} placeholders in
+ *       task descriptions are resolved by the {@code TemplateResolver} inside
+ *       {@code Ensemble.run(inputs, options)}. Use {@link #buildFromTemplate}.</li>
+ *   <li><strong>Level 2</strong> -- per-task overrides at runtime (description, expectedOutput,
+ *       model, maxIterations, additionalContext, tools add/remove). Use
+ *       {@link #buildFromTemplateWithOverrides}.</li>
+ *   <li><strong>Level 3</strong> -- fully dynamic task creation from a JSON task list. Use
+ *       {@link #buildFromDynamicTasks}.</li>
  * </ul>
  *
  * <p>Instances are stateless and safe for concurrent use.
  */
 public final class RunRequestParser {
+
+    private static final int DESCRIPTION_PREFIX_LENGTH = 50;
 
     private final ToolCatalog toolCatalog;
     private final ModelCatalog modelCatalog;
@@ -30,8 +42,9 @@ public final class RunRequestParser {
     /**
      * Creates a parser with the given catalog references.
      *
-     * <p>Catalogs may be {@code null} in Phase 1 (Level 1 parsing does not resolve
-     * tools or models from catalogs). They are retained here for Phase 2+ use.
+     * <p>Catalogs may be {@code null} when Level 1 only is needed. Level 2/3 tool and model
+     * resolution requires non-null catalogs; attempting those operations with a null catalog
+     * throws {@link IllegalStateException}.
      *
      * @param toolCatalog  the registered tool allowlist; may be null
      * @param modelCatalog the registered model allowlist; may be null
@@ -40,6 +53,10 @@ public final class RunRequestParser {
         this.toolCatalog = toolCatalog;
         this.modelCatalog = modelCatalog;
     }
+
+    // ========================
+    // Level 1
+    // ========================
 
     /**
      * Level 1: builds a run configuration from a template ensemble and input variables.
@@ -57,7 +74,349 @@ public final class RunRequestParser {
         Objects.requireNonNull(template, "template ensemble must not be null");
         Map<String, String> effectiveInputs = inputs != null ? Map.copyOf(inputs) : Map.of();
         RunOptions effectiveOptions = options != null ? options : RunOptions.DEFAULT;
-        return new RunConfiguration(template, effectiveInputs, effectiveOptions);
+        return new RunConfiguration(template, null, effectiveInputs, effectiveOptions);
+    }
+
+    // ========================
+    // Level 2
+    // ========================
+
+    /**
+     * Level 2: builds a run configuration from a template ensemble with per-task overrides.
+     *
+     * <p>The template's task list is copied and each task named in {@code taskOverrides} is
+     * replaced with a modified copy produced via {@link Task#toBuilder()}. The original task
+     * objects are never mutated.
+     *
+     * <p>Override key matching (first match wins):
+     * <ol>
+     *   <li>Exact task {@code name} match (case-insensitive).</li>
+     *   <li>Description prefix match -- the first {@value #DESCRIPTION_PREFIX_LENGTH} characters
+     *       of the task description compared case-insensitively to the override key.</li>
+     * </ol>
+     *
+     * <p>Supported override fields:
+     * <ul>
+     *   <li>{@code description} -- replaces task description (String); supports template vars.</li>
+     *   <li>{@code expectedOutput} -- replaces task expected output (String).</li>
+     *   <li>{@code model} -- model alias resolved from {@link ModelCatalog}; replaces
+     *       {@code chatLanguageModel}.</li>
+     *   <li>{@code maxIterations} -- integer (or parseable String).</li>
+     *   <li>{@code additionalContext} -- String appended to the task description.</li>
+     *   <li>{@code tools} -- {@code Map} with optional {@code add} and {@code remove} keys,
+     *       each a {@code List<String>} of tool names resolved from {@link ToolCatalog}.</li>
+     * </ul>
+     *
+     * @param template      the pre-configured template ensemble; must not be null
+     * @param inputs        the input variables; may be null
+     * @param options       per-run execution overrides; may be null
+     * @param taskOverrides map of task identifier to override fields; may be null or empty
+     * @return a {@link RunConfiguration} with the overridden task list
+     * @throws NullPointerException     if {@code template} is null
+     * @throws IllegalArgumentException if an override key matches no task, or a tool/model alias
+     *                                  cannot be resolved
+     * @throws IllegalStateException    if a tool or model is referenced but the corresponding
+     *                                  catalog is not configured
+     */
+    public RunConfiguration buildFromTemplateWithOverrides(
+            Ensemble template,
+            Map<String, String> inputs,
+            RunOptions options,
+            Map<String, Map<String, Object>> taskOverrides) {
+        Objects.requireNonNull(template, "template ensemble must not be null");
+        Map<String, String> effectiveInputs = inputs != null ? Map.copyOf(inputs) : Map.of();
+        RunOptions effectiveOptions = options != null ? options : RunOptions.DEFAULT;
+
+        List<Task> tasks = new ArrayList<>(template.getTasks());
+        Map<String, Map<String, Object>> effectiveOverrides = (taskOverrides != null) ? taskOverrides : Map.of();
+
+        for (Map.Entry<String, Map<String, Object>> entry : effectiveOverrides.entrySet()) {
+            String overrideKey = entry.getKey();
+            Map<String, Object> fields = entry.getValue();
+
+            int taskIndex = findTaskIndex(tasks, overrideKey);
+            if (taskIndex < 0) {
+                throw new IllegalArgumentException("No task found matching override key: '"
+                        + overrideKey
+                        + "'. "
+                        + "Override keys must match a task name (exact, case-insensitive) "
+                        + "or the first "
+                        + DESCRIPTION_PREFIX_LENGTH
+                        + " characters of a task description (case-insensitive).");
+            }
+
+            Task original = tasks.get(taskIndex);
+            Task overridden = applyOverrides(original, fields);
+            tasks.set(taskIndex, overridden);
+        }
+
+        return new RunConfiguration(template, List.copyOf(tasks), effectiveInputs, effectiveOptions);
+    }
+
+    // ========================
+    // Level 3
+    // ========================
+
+    /**
+     * Level 3: builds a run configuration from a fully dynamic task list defined in JSON.
+     *
+     * <p>Tasks are defined as maps with the following fields (all except {@code description}
+     * are optional):
+     * <ul>
+     *   <li>{@code name} -- logical name for context references and capability listing.</li>
+     *   <li>{@code description} -- <strong>required</strong>; what the agent should do.</li>
+     *   <li>{@code expectedOutput} -- what the output should look like; defaults to
+     *       {@link Task#DEFAULT_EXPECTED_OUTPUT}.</li>
+     *   <li>{@code tools} -- {@code List<String>} of tool names resolved from
+     *       {@link ToolCatalog}.</li>
+     *   <li>{@code model} -- model alias resolved from {@link ModelCatalog}.</li>
+     *   <li>{@code maxIterations} -- integer (or parseable String).</li>
+     *   <li>{@code context} -- {@code List<String>} of references to predecessor tasks.
+     *       Each reference is {@code $name} (by task name) or {@code $N} (by 0-based index).
+     *       Circular references are detected and rejected.</li>
+     *   <li>{@code outputSchema} -- JSON Schema {@code Map} injected into the task's
+     *       {@code expectedOutput} as a structured output instruction.</li>
+     *   <li>{@code additionalContext} -- {@code String} appended to the task description.</li>
+     * </ul>
+     *
+     * @param template the template ensemble providing default model and settings; must not be null
+     * @param taskDefs the task definitions; must not be null or empty
+     * @param inputs   the input variables; may be null
+     * @param options  per-run execution overrides; may be null
+     * @return a {@link RunConfiguration} with the dynamically built task list
+     * @throws NullPointerException     if {@code template} is null
+     * @throws IllegalArgumentException if {@code taskDefs} is null/empty, a required field is
+     *                                  missing, a context reference is unresolvable, a circular
+     *                                  dependency is detected, or a tool/model alias is unknown
+     * @throws IllegalStateException    if a tool or model is referenced but the catalog is null
+     */
+    @SuppressWarnings("unchecked")
+    public RunConfiguration buildFromDynamicTasks(
+            Ensemble template, List<Map<String, Object>> taskDefs, Map<String, String> inputs, RunOptions options) {
+        Objects.requireNonNull(template, "template ensemble must not be null");
+        if (taskDefs == null || taskDefs.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Dynamic tasks list must not be null or empty; provide at least one task definition.");
+        }
+
+        Map<String, String> effectiveInputs = inputs != null ? Map.copyOf(inputs) : Map.of();
+        RunOptions effectiveOptions = options != null ? options : RunOptions.DEFAULT;
+
+        int n = taskDefs.size();
+
+        // Step 1: Register task names for $name reference resolution
+        Map<String, Integer> nameToIndex = new LinkedHashMap<>();
+        for (int i = 0; i < n; i++) {
+            Object nameObj = taskDefs.get(i).get("name");
+            if (nameObj instanceof String name && !name.isBlank()) {
+                nameToIndex.put(name, i);
+            }
+        }
+
+        // Step 2: Parse context references into dependency index lists
+        // deps.get(i) = list of indices that task i depends on
+        List<List<Integer>> deps = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            Map<String, Object> def = taskDefs.get(i);
+            List<String> contextRefs = (List<String>) def.getOrDefault("context", List.of());
+            List<Integer> taskDeps = new ArrayList<>();
+            for (String ref : contextRefs) {
+                taskDeps.add(resolveContextRef(ref, nameToIndex, n));
+            }
+            deps.add(taskDeps);
+        }
+
+        // Step 3: Topological sort (Kahn's algorithm) -- detects cycles and gives build order
+        int[] buildOrder = topologicalSort(deps, n);
+
+        // Step 4: Build tasks in topological order; accumulate built objects for context resolution
+        Task[] builtTasks = new Task[n];
+        for (int idx : buildOrder) {
+            Map<String, Object> def = taskDefs.get(idx);
+            List<Task> contextTasks = new ArrayList<>();
+            for (int depIdx : deps.get(idx)) {
+                contextTasks.add(builtTasks[depIdx]);
+            }
+            builtTasks[idx] = buildDynamicTask(def, contextTasks);
+        }
+
+        // Step 5: Collect tasks in original declaration order
+        List<Task> result = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            result.add(builtTasks[i]);
+        }
+
+        return new RunConfiguration(template, List.copyOf(result), effectiveInputs, effectiveOptions);
+    }
+
+    /**
+     * Resolves a context reference string ({@code $name} or {@code $N}) to an index in the
+     * task list.
+     *
+     * @throws IllegalArgumentException if the reference is unknown or out of bounds
+     */
+    private static int resolveContextRef(String ref, Map<String, Integer> nameToIndex, int taskCount) {
+        if (!ref.startsWith("$")) {
+            throw new IllegalArgumentException("Context reference must start with '$'; got: '" + ref + "'.");
+        }
+
+        String identifier = ref.substring(1);
+
+        // Try parsing as integer index ($0, $1, $2, ...)
+        try {
+            int idx = Integer.parseInt(identifier);
+            if (idx < 0 || idx >= taskCount) {
+                throw new IllegalArgumentException("Context reference '"
+                        + ref
+                        + "' is out of bounds; task list has "
+                        + taskCount
+                        + " task(s) (valid indices: 0.."
+                        + (taskCount - 1)
+                        + ").");
+            }
+            return idx;
+        } catch (NumberFormatException e) {
+            // Not a numeric index -- treat as name reference
+        }
+
+        // Resolve by name ($researcher, $writer, etc.)
+        Integer idx = nameToIndex.get(identifier);
+        if (idx == null) {
+            throw new IllegalArgumentException("Unknown context reference '$"
+                    + identifier
+                    + "'. No task with name '"
+                    + identifier
+                    + "' was found in the task list.");
+        }
+        return idx;
+    }
+
+    /**
+     * Topological sort using Kahn's algorithm.
+     *
+     * @param deps      deps.get(i) = list of task indices that task i depends on
+     * @param n         number of tasks
+     * @return array of task indices in a valid processing order (dependencies first)
+     * @throws IllegalArgumentException if a circular dependency is detected
+     */
+    private static int[] topologicalSort(List<List<Integer>> deps, int n) {
+        // Build reverse adjacency list: rdeps.get(j) = list of tasks that depend on j
+        List<List<Integer>> rdeps = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            rdeps.add(new ArrayList<>());
+        }
+        int[] inDegree = new int[n];
+        for (int i = 0; i < n; i++) {
+            inDegree[i] = deps.get(i).size();
+            for (int dep : deps.get(i)) {
+                rdeps.get(dep).add(i);
+            }
+        }
+
+        // Initialize queue with tasks that have no dependencies
+        Queue<Integer> queue = new ArrayDeque<>();
+        for (int i = 0; i < n; i++) {
+            if (inDegree[i] == 0) {
+                queue.offer(i);
+            }
+        }
+
+        int[] order = new int[n];
+        int count = 0;
+        while (!queue.isEmpty()) {
+            int idx = queue.poll();
+            order[count++] = idx;
+            for (int dependent : rdeps.get(idx)) {
+                if (--inDegree[dependent] == 0) {
+                    queue.offer(dependent);
+                }
+            }
+        }
+
+        if (count < n) {
+            throw new IllegalArgumentException(
+                    "A circular dependency was detected in the dynamic task context references. "
+                            + "Ensure no task's context references form a cycle.");
+        }
+
+        return order;
+    }
+
+    /**
+     * Builds a single {@link Task} from a definition map, wiring in the resolved context tasks.
+     *
+     * @throws IllegalArgumentException if required fields are missing or invalid
+     */
+    @SuppressWarnings("unchecked")
+    private Task buildDynamicTask(Map<String, Object> def, List<Task> contextTasks) {
+        // description is required
+        Object descObj = def.get("description");
+        if (!(descObj instanceof String desc) || desc.isBlank()) {
+            throw new IllegalArgumentException("Dynamic task definition is missing required field 'description'. "
+                    + "Each task must specify a non-blank description.");
+        }
+
+        // Handle additionalContext: append to description
+        Object addCtxObj = def.get("additionalContext");
+        if (addCtxObj instanceof String addCtx && !addCtx.isBlank()) {
+            desc = desc + "\n\n" + addCtx;
+        }
+
+        // expectedOutput with optional outputSchema injection
+        String expectedOutput =
+                def.containsKey("expectedOutput") ? (String) def.get("expectedOutput") : Task.DEFAULT_EXPECTED_OUTPUT;
+
+        Object schemaObj = def.get("outputSchema");
+        if (schemaObj instanceof Map<?, ?> schemaMap) {
+            String schemaJson = serializeSchema(schemaMap);
+            expectedOutput = expectedOutput + "\n\nRespond with JSON matching this schema:\n" + schemaJson;
+        }
+
+        Task.TaskBuilder builder = Task.builder().description(desc).expectedOutput(expectedOutput);
+
+        // name (optional)
+        Object nameObj = def.get("name");
+        if (nameObj instanceof String name && !name.isBlank()) {
+            builder.name(name);
+        }
+
+        // context
+        if (!contextTasks.isEmpty()) {
+            builder.context(contextTasks);
+        }
+
+        // tools
+        Object toolsObj = def.get("tools");
+        if (toolsObj instanceof List<?> toolNames) {
+            List<Object> resolvedTools = new ArrayList<>();
+            for (Object t : toolNames) {
+                resolvedTools.add(resolveTool((String) t));
+            }
+            builder.tools(resolvedTools);
+        }
+
+        // model
+        Object modelObj = def.get("model");
+        if (modelObj instanceof String modelAlias) {
+            builder.chatLanguageModel(resolveModel(modelAlias));
+        }
+
+        // maxIterations
+        Object maxIterObj = def.get("maxIterations");
+        if (maxIterObj != null) {
+            builder.maxIterations(toInt(maxIterObj, "maxIterations"));
+        }
+
+        return builder.build();
+    }
+
+    /** Serializes a schema map to compact JSON. Falls back to {@code toString()} on error. */
+    private static String serializeSchema(Map<?, ?> schema) {
+        try {
+            return new ObjectMapper().writeValueAsString(schema);
+        } catch (Exception e) {
+            return schema.toString();
+        }
     }
 
     /**
@@ -74,12 +433,177 @@ public final class RunRequestParser {
         return modelCatalog;
     }
 
+    // ========================
+    // Internal helpers
+    // ========================
+
+    /**
+     * Finds the index of the first task in {@code tasks} that matches {@code key}.
+     *
+     * <p>Matching order:
+     * <ol>
+     *   <li>Exact task name (case-insensitive).</li>
+     *   <li>Description prefix (first {@value #DESCRIPTION_PREFIX_LENGTH} chars,
+     *       case-insensitive).</li>
+     * </ol>
+     *
+     * @return the index of the matching task, or {@code -1} if not found
+     */
+    private static int findTaskIndex(List<Task> tasks, String key) {
+        String lowerKey = key.toLowerCase();
+
+        // Pass 1: exact name match (case-insensitive)
+        for (int i = 0; i < tasks.size(); i++) {
+            String name = tasks.get(i).getName();
+            if (name != null && name.toLowerCase().equals(lowerKey)) {
+                return i;
+            }
+        }
+
+        // Pass 2: description prefix match (case-insensitive, first 50 chars)
+        for (int i = 0; i < tasks.size(); i++) {
+            String desc = tasks.get(i).getDescription();
+            if (desc != null) {
+                String prefix = desc.substring(0, Math.min(DESCRIPTION_PREFIX_LENGTH, desc.length()))
+                        .toLowerCase();
+                if (prefix.equals(lowerKey)) {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Applies the given override fields to {@code task} and returns a new modified copy.
+     * The original task is never mutated.
+     */
+    @SuppressWarnings("unchecked")
+    private Task applyOverrides(Task task, Map<String, Object> fields) {
+        Task.TaskBuilder builder = task.toBuilder();
+
+        for (Map.Entry<String, Object> entry : fields.entrySet()) {
+            String field = entry.getKey();
+            Object value = entry.getValue();
+
+            switch (field) {
+                case "description" -> builder.description((String) value);
+                case "expectedOutput" -> builder.expectedOutput((String) value);
+                case "maxIterations" -> builder.maxIterations(toInt(value, "maxIterations"));
+                case "model" -> builder.chatLanguageModel(resolveModel((String) value));
+                case "additionalContext" -> {
+                    String ctx = (String) value;
+                    String newDesc = task.getDescription() + "\n\n" + ctx;
+                    builder.description(newDesc);
+                }
+                case "tools" -> {
+                    Map<String, Object> toolsMap = (Map<String, Object>) value;
+                    List<Object> currentTools = new ArrayList<>(task.getTools());
+
+                    if (toolsMap.containsKey("add")) {
+                        List<String> toAdd = (List<String>) toolsMap.get("add");
+                        for (String toolName : toAdd) {
+                            currentTools.add(resolveTool(toolName));
+                        }
+                    }
+
+                    if (toolsMap.containsKey("remove")) {
+                        List<String> toRemove = (List<String>) toolsMap.get("remove");
+                        for (String toolName : toRemove) {
+                            AgentTool resolved = resolveTool(toolName);
+                            currentTools.removeIf(t -> t == resolved);
+                        }
+                    }
+
+                    builder.tools(List.copyOf(currentTools));
+                }
+                default -> {
+                    // Unknown override fields are silently ignored for forward compatibility
+                }
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Converts a value to {@code int}. Accepts {@link Integer}, {@link Long}, or a
+     * {@link String} that is parseable as an integer.
+     */
+    private static int toInt(Object value, String fieldName) {
+        if (value instanceof Integer i) {
+            return i;
+        }
+        if (value instanceof Long l) {
+            return l.intValue();
+        }
+        if (value instanceof String s) {
+            try {
+                return Integer.parseInt(s);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Override field '" + fieldName + "' must be an integer; got: " + s);
+            }
+        }
+        throw new IllegalArgumentException("Override field '" + fieldName + "' must be an integer; got: "
+                + value.getClass().getSimpleName());
+    }
+
+    /**
+     * Resolves a model alias from the model catalog.
+     *
+     * @throws IllegalStateException    if no model catalog is configured
+     * @throws IllegalArgumentException if the alias is not found in the catalog
+     */
+    private ChatModel resolveModel(String alias) {
+        if (modelCatalog == null) {
+            throw new IllegalStateException("ModelCatalog is not configured. Configure a ModelCatalog on WebDashboard "
+                    + "to use model overrides in API run requests.");
+        }
+        return modelCatalog
+                .find(alias)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown model alias: '"
+                        + alias
+                        + "'. Available models: "
+                        + modelCatalog.list().stream()
+                                .map(ModelCatalog.ModelInfo::alias)
+                                .toList()));
+    }
+
+    /**
+     * Resolves a tool name from the tool catalog.
+     *
+     * @throws IllegalStateException    if no tool catalog is configured
+     * @throws IllegalArgumentException if the tool name is not found in the catalog
+     */
+    private AgentTool resolveTool(String toolName) {
+        if (toolCatalog == null) {
+            throw new IllegalStateException("ToolCatalog is not configured. Configure a ToolCatalog on WebDashboard "
+                    + "to use tool references in API run requests.");
+        }
+        return toolCatalog
+                .find(toolName)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown tool: '"
+                        + toolName
+                        + "'. Available tools: "
+                        + toolCatalog.list().stream()
+                                .map(ToolCatalog.ToolInfo::name)
+                                .toList()));
+    }
+
+    // ========================
+    // RunConfiguration
+    // ========================
+
     /**
      * A validated, ready-to-execute run configuration produced by {@link RunRequestParser}.
      *
-     * @param template the template ensemble to run
-     * @param inputs   the resolved input variables (never null, may be empty)
-     * @param options  the effective run options (never null)
+     * @param template      the template ensemble to run (always non-null)
+     * @param overrideTasks when non-null, replaces the template's task list at execution time;
+     *                      null for Level 1 runs (template tasks used as-is)
+     * @param inputs        the resolved input variables (never null, may be empty)
+     * @param options       the effective run options (never null)
      */
-    public record RunConfiguration(Ensemble template, Map<String, String> inputs, RunOptions options) {}
+    public record RunConfiguration(
+            Ensemble template, List<Task> overrideTasks, Map<String, String> inputs, RunOptions options) {}
 }

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunRequestParser.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunRequestParser.java
@@ -6,6 +6,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
@@ -218,7 +219,20 @@ public final class RunRequestParser {
         List<List<Integer>> deps = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             Map<String, Object> def = taskDefs.get(i);
-            List<String> contextRefs = (List<String>) def.getOrDefault("context", List.of());
+            Object contextObj = def.getOrDefault("context", List.of());
+            if (!(contextObj instanceof List<?> rawContextList)) {
+                throw new IllegalArgumentException(
+                        "Dynamic task field 'context' must be an array of task name or index references "
+                                + "($name or $N); got non-array value.");
+            }
+            List<String> contextRefs = new ArrayList<>();
+            for (Object ref : rawContextList) {
+                if (!(ref instanceof String refStr)) {
+                    throw new IllegalArgumentException(
+                            "Dynamic task 'context' entries must be strings ($name or $N); got: " + ref);
+                }
+                contextRefs.add(refStr);
+            }
             List<Integer> taskDeps = new ArrayList<>();
             for (String ref : contextRefs) {
                 taskDeps.add(resolveContextRef(ref, nameToIndex, n));
@@ -363,8 +377,19 @@ public final class RunRequestParser {
         }
 
         // expectedOutput with optional outputSchema injection
-        String expectedOutput =
-                def.containsKey("expectedOutput") ? (String) def.get("expectedOutput") : Task.DEFAULT_EXPECTED_OUTPUT;
+        // Validate type explicitly to produce a useful error rather than ClassCastException
+        String expectedOutput = Task.DEFAULT_EXPECTED_OUTPUT;
+        if (def.containsKey("expectedOutput")) {
+            Object expectedOutputObj = def.get("expectedOutput");
+            if (!(expectedOutputObj instanceof String expectedOutputValue)) {
+                throw new IllegalArgumentException(
+                        "Dynamic task field 'expectedOutput' must be a non-null string when provided; " + "got: "
+                                + (expectedOutputObj == null
+                                        ? "null"
+                                        : expectedOutputObj.getClass().getSimpleName()));
+            }
+            expectedOutput = expectedOutputValue;
+        }
 
         Object schemaObj = def.get("outputSchema");
         if (schemaObj instanceof Map<?, ?> schemaMap) {
@@ -390,7 +415,13 @@ public final class RunRequestParser {
         if (toolsObj instanceof List<?> toolNames) {
             List<Object> resolvedTools = new ArrayList<>();
             for (Object t : toolNames) {
-                resolvedTools.add(resolveTool((String) t));
+                // Validate each element is a non-blank String to produce a useful error
+                // rather than ClassCastException
+                if (!(t instanceof String toolName) || toolName.isBlank()) {
+                    throw new IllegalArgumentException("Invalid tool name in dynamic task definition: " + t
+                            + ". Tool names must be non-blank strings.");
+                }
+                resolvedTools.add(resolveTool(toolName));
             }
             builder.tools(resolvedTools);
         }
@@ -450,12 +481,14 @@ public final class RunRequestParser {
      * @return the index of the matching task, or {@code -1} if not found
      */
     private static int findTaskIndex(List<Task> tasks, String key) {
-        String lowerKey = key.toLowerCase();
+        // Use Locale.ROOT for all case-insensitive comparisons to avoid locale-dependent
+        // behavior (e.g. Turkish locale where toLowerCase("I") != "i").
+        String lowerKey = key.toLowerCase(Locale.ROOT);
 
         // Pass 1: exact name match (case-insensitive)
         for (int i = 0; i < tasks.size(); i++) {
             String name = tasks.get(i).getName();
-            if (name != null && name.toLowerCase().equals(lowerKey)) {
+            if (name != null && name.toLowerCase(Locale.ROOT).equals(lowerKey)) {
                 return i;
             }
         }
@@ -465,7 +498,7 @@ public final class RunRequestParser {
             String desc = tasks.get(i).getDescription();
             if (desc != null) {
                 String prefix = desc.substring(0, Math.min(DESCRIPTION_PREFIX_LENGTH, desc.length()))
-                        .toLowerCase();
+                        .toLowerCase(Locale.ROOT);
                 if (prefix.equals(lowerKey)) {
                     return i;
                 }
@@ -478,25 +511,44 @@ public final class RunRequestParser {
     /**
      * Applies the given override fields to {@code task} and returns a new modified copy.
      * The original task is never mutated.
+     *
+     * <p>Description is computed deterministically before the switch loop: a {@code description}
+     * override replaces the original, then {@code additionalContext} is always appended at the
+     * end. This prevents map iteration order from determining which value wins when both keys
+     * appear in the same override map.
      */
     @SuppressWarnings("unchecked")
     private Task applyOverrides(Task task, Map<String, Object> fields) {
         Task.TaskBuilder builder = task.toBuilder();
+
+        // Compute the effective description with deterministic precedence:
+        //   1. 'description' override replaces the original (if present)
+        //   2. 'additionalContext' is always appended at the end (if present)
+        // This two-step pre-computation avoids any ordering dependency on Map iteration.
+        boolean hasDescOverride = fields.containsKey("description");
+        boolean hasAddCtx = fields.containsKey("additionalContext");
+        if (hasDescOverride || hasAddCtx) {
+            String base = hasDescOverride ? (String) fields.get("description") : task.getDescription();
+            if (hasAddCtx) {
+                Object ctxObj = fields.get("additionalContext");
+                if (ctxObj instanceof String ctx && !ctx.isBlank()) {
+                    base = base + "\n\n" + ctx;
+                }
+            }
+            builder.description(base);
+        }
 
         for (Map.Entry<String, Object> entry : fields.entrySet()) {
             String field = entry.getKey();
             Object value = entry.getValue();
 
             switch (field) {
-                case "description" -> builder.description((String) value);
+                case "description", "additionalContext" -> {
+                    // Already handled above in the deterministic pre-computation block
+                }
                 case "expectedOutput" -> builder.expectedOutput((String) value);
                 case "maxIterations" -> builder.maxIterations(toInt(value, "maxIterations"));
                 case "model" -> builder.chatLanguageModel(resolveModel((String) value));
-                case "additionalContext" -> {
-                    String ctx = (String) value;
-                    String newDesc = task.getDescription() + "\n\n" + ctx;
-                    builder.description(newDesc);
-                }
                 case "tools" -> {
                     Map<String, Object> toolsMap = (Map<String, Object>) value;
                     List<Object> currentTools = new ArrayList<>(task.getTools());
@@ -504,15 +556,24 @@ public final class RunRequestParser {
                     if (toolsMap.containsKey("add")) {
                         List<String> toAdd = (List<String>) toolsMap.get("add");
                         for (String toolName : toAdd) {
-                            currentTools.add(resolveTool(toolName));
+                            AgentTool resolved = resolveTool(toolName);
+                            // De-duplicate by name to avoid adding the same tool twice
+                            boolean alreadyPresent = currentTools.stream()
+                                    .anyMatch(t -> t instanceof AgentTool at
+                                            && at.name().equals(resolved.name()));
+                            if (!alreadyPresent) {
+                                currentTools.add(resolved);
+                            }
                         }
                     }
 
                     if (toolsMap.containsKey("remove")) {
                         List<String> toRemove = (List<String>) toolsMap.get("remove");
                         for (String toolName : toRemove) {
-                            AgentTool resolved = resolveTool(toolName);
-                            currentTools.removeIf(t -> t == resolved);
+                            // Remove by name for reliability; reference equality (==) is fragile
+                            // when template tasks were constructed outside the catalog.
+                            currentTools.removeIf(
+                                    t -> t instanceof AgentTool at && at.name().equals(toolName));
                         }
                     }
 

--- a/agentensemble-web/src/main/java/net/agentensemble/web/RunState.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/RunState.java
@@ -75,6 +75,13 @@ public final class RunState {
     // Mutable fields (thread-safe)
     // ========================
 
+    /**
+     * Immutable snapshot of the status set at construction time (ACCEPTED or REJECTED).
+     * Unlike {@link #getStatus()}, this value never changes, even after the run transitions
+     * to RUNNING, COMPLETED, or FAILED.
+     */
+    private final Status initialStatus;
+
     private final AtomicReference<Status> status;
     private final AtomicInteger completedTasks = new AtomicInteger(0);
     private final List<TaskOutputSnapshot> taskOutputs;
@@ -96,6 +103,7 @@ public final class RunState {
             String workflow,
             String originSessionId) {
         this.runId = runId;
+        this.initialStatus = initialStatus;
         this.status = new AtomicReference<>(initialStatus);
         this.startedAt = startedAt;
         this.inputs = inputs != null ? Map.copyOf(inputs) : Map.of();
@@ -122,6 +130,18 @@ public final class RunState {
      */
     public Status getStatus() {
         return status.get();
+    }
+
+    /**
+     * Returns the status recorded at the moment this {@link RunState} was constructed
+     * ({@link Status#ACCEPTED} or {@link Status#REJECTED}).
+     *
+     * <p>Unlike {@link #getStatus()}, this value is immutable and safe to read at any time
+     * without a race with the execution thread that transitions the state to RUNNING or
+     * COMPLETED.
+     */
+    public Status getInitialStatus() {
+        return initialStatus;
     }
 
     /**

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
@@ -738,6 +738,18 @@ public final class WebDashboard implements EnsembleDashboard {
                 // Parse options from the raw options map
                 RunOptions options = parseRunOptions(msg.options());
 
+                // Reject requests where the level indicator is present but empty --
+                // they would otherwise silently fall through to Level 1 and run the
+                // template unexpectedly, masking client-side mistakes.
+                if (msg.tasks() != null && msg.tasks().isEmpty()) {
+                    throw new IllegalArgumentException("The 'tasks' field is present but empty; "
+                            + "provide a non-empty task list for Level 3, or omit the field.");
+                }
+                if (msg.taskOverrides() != null && msg.taskOverrides().isEmpty()) {
+                    throw new IllegalArgumentException("The 'taskOverrides' field is present but empty; "
+                            + "provide at least one override for Level 2, or omit the field.");
+                }
+
                 // Build RunConfiguration based on what was provided (Level 1/2/3)
                 RunRequestParser.RunConfiguration config;
                 if (msg.tasks() != null && !msg.tasks().isEmpty()) {
@@ -776,11 +788,15 @@ public final class WebDashboard implements EnsembleDashboard {
                             }
                         });
 
-                // Send run_ack immediately to the originating session
+                // Send run_ack immediately to the originating session.
+                // getInitialStatus() is used rather than getStatus() because the run may have
+                // already transitioned to RUNNING or COMPLETED by the time we reach this line
+                // (handler tasks complete synchronously and near-instantly). The ack must
+                // reflect the SUBMISSION status (ACCEPTED or REJECTED), not the live status.
                 RunAckMessage ack = new RunAckMessage(
                         msg.requestId(),
                         state.getRunId(),
-                        state.getStatus().name(),
+                        state.getInitialStatus().name(),
                         state.getTaskCount(),
                         state.getWorkflow());
                 connectionManager.send(sessionId, serializer.toJson(ack));

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebDashboard.java
@@ -18,6 +18,7 @@ import net.agentensemble.dashboard.RequestHandler;
 import net.agentensemble.directive.Directive;
 import net.agentensemble.directive.DirectiveStore;
 import net.agentensemble.ensemble.EnsembleLifecycleState;
+import net.agentensemble.execution.RunOptions;
 import net.agentensemble.review.OnTimeoutAction;
 import net.agentensemble.review.ReviewHandler;
 import net.agentensemble.trace.export.ExecutionTraceExporter;
@@ -29,6 +30,8 @@ import net.agentensemble.web.protocol.EnsembleCompletedMessage;
 import net.agentensemble.web.protocol.EnsembleStartedMessage;
 import net.agentensemble.web.protocol.MessageSerializer;
 import net.agentensemble.web.protocol.ReviewDecisionMessage;
+import net.agentensemble.web.protocol.RunAckMessage;
+import net.agentensemble.web.protocol.RunRequestMessage;
 import net.agentensemble.web.protocol.TaskAcceptedMessage;
 import net.agentensemble.web.protocol.TaskRequestMessage;
 import net.agentensemble.web.protocol.TaskResponseMessage;
@@ -289,6 +292,8 @@ public final class WebDashboard implements EnsembleDashboard {
                 handleToolRequest(sessionId, trm);
             } else if (msg instanceof DirectiveMessage dm) {
                 handleDirective(sessionId, dm);
+            } else if (msg instanceof RunRequestMessage rrm) {
+                handleRunRequest(sessionId, rrm);
             }
         });
 
@@ -704,6 +709,124 @@ public final class WebDashboard implements EnsembleDashboard {
         } catch (Exception e) {
             log.warn("Failed to handle directive from '{}': {}", dm.from(), e.getMessage(), e);
         }
+    }
+
+    // ========================
+    // WebSocket run submission (Phase 2: Level 1/2/3)
+    // ========================
+
+    /**
+     * Handles an incoming {@link RunRequestMessage} from a WebSocket client.
+     *
+     * <p>Parses the request to determine the run level (Level 1/2/3), builds the
+     * appropriate {@link RunRequestParser.RunConfiguration}, submits the run to
+     * {@link RunManager}, and sends a {@link RunAckMessage} immediately to the originating
+     * session. On run completion, sends a {@link net.agentensemble.web.protocol.RunResultMessage}
+     * targeted to the same originating session only.
+     */
+    private void handleRunRequest(String sessionId, RunRequestMessage msg) {
+        Ensemble templateEnsemble = this.ensemble;
+        if (templateEnsemble == null) {
+            log.warn("Received run_request from session {} but no template ensemble is configured", sessionId);
+            sendRejectedAck(sessionId, msg.requestId());
+            return;
+        }
+
+        // Execute asynchronously so the WS handler thread is not blocked during parsing
+        requestExecutor.submit(() -> {
+            try {
+                // Parse options from the raw options map
+                RunOptions options = parseRunOptions(msg.options());
+
+                // Build RunConfiguration based on what was provided (Level 1/2/3)
+                RunRequestParser.RunConfiguration config;
+                if (msg.tasks() != null && !msg.tasks().isEmpty()) {
+                    // Level 3: fully dynamic task list
+                    config = runRequestParser.buildFromDynamicTasks(
+                            templateEnsemble, msg.tasks(), msg.inputs(), options);
+                } else if (msg.taskOverrides() != null && !msg.taskOverrides().isEmpty()) {
+                    // Level 2: per-task overrides applied to the template
+                    config = runRequestParser.buildFromTemplateWithOverrides(
+                            templateEnsemble, msg.inputs(), options, msg.taskOverrides());
+                } else {
+                    // Level 1: template as-is with input substitution
+                    config = runRequestParser.buildFromTemplate(templateEnsemble, msg.inputs(), options);
+                }
+
+                // For Level 2/3, build a modified ensemble via withTasks(); Level 1 uses the
+                // template as-is so that all its settings (including the dashboard listener)
+                // are already in place.
+                Ensemble executionEnsemble = config.overrideTasks() != null
+                        ? templateEnsemble.withTasks(config.overrideTasks())
+                        : config.template();
+
+                // Convert String tags to Object tags (RunManager uses Map<String, Object>)
+                java.util.Map<String, Object> tags = null;
+                if (msg.tags() != null && !msg.tags().isEmpty()) {
+                    tags = new java.util.HashMap<>(msg.tags());
+                }
+
+                // Submit run; on completion send run_result targeted to originating session only
+                RunState state = runManager.submitRun(
+                        executionEnsemble, config.inputs(), tags, config.options(), sessionId, resultMsg -> {
+                            try {
+                                connectionManager.send(sessionId, serializer.toJson(resultMsg));
+                            } catch (Exception e) {
+                                log.warn("Failed to send run_result to session {}: {}", sessionId, e.getMessage());
+                            }
+                        });
+
+                // Send run_ack immediately to the originating session
+                RunAckMessage ack = new RunAckMessage(
+                        msg.requestId(),
+                        state.getRunId(),
+                        state.getStatus().name(),
+                        state.getTaskCount(),
+                        state.getWorkflow());
+                connectionManager.send(sessionId, serializer.toJson(ack));
+
+            } catch (Exception e) {
+                log.warn("Failed to handle run_request from session {}: {}", sessionId, e.getMessage(), e);
+                sendRejectedAck(sessionId, msg.requestId());
+            }
+        });
+    }
+
+    /**
+     * Sends a REJECTED {@link RunAckMessage} to the given session, used when a
+     * {@code run_request} cannot be processed.
+     */
+    private void sendRejectedAck(String sessionId, String requestId) {
+        try {
+            RunAckMessage ack = new RunAckMessage(requestId, null, "REJECTED", 0, null);
+            connectionManager.send(sessionId, serializer.toJson(ack));
+        } catch (Exception ex) {
+            log.warn("Failed to send REJECTED run_ack to session {}: {}", sessionId, ex.getMessage());
+        }
+    }
+
+    /**
+     * Converts the raw options map from a {@link RunRequestMessage} to a {@link RunOptions}
+     * instance. Recognises {@code maxToolOutputLength} and {@code toolLogTruncateLength}.
+     *
+     * @param optionsMap the options map from the message; may be null
+     * @return effective {@link RunOptions}; falls back to {@link RunOptions#DEFAULT} when
+     *         the map is null, empty, or contains no recognised keys
+     */
+    private static RunOptions parseRunOptions(java.util.Map<String, Object> optionsMap) {
+        if (optionsMap == null || optionsMap.isEmpty()) {
+            return RunOptions.DEFAULT;
+        }
+        var builder = RunOptions.builder();
+        Object maxLen = optionsMap.get("maxToolOutputLength");
+        if (maxLen instanceof Number n) {
+            builder.maxToolOutputLength(n.intValue());
+        }
+        Object logLen = optionsMap.get("toolLogTruncateLength");
+        if (logLen instanceof Number n) {
+            builder.toolLogTruncateLength(n.intValue());
+        }
+        return builder.build();
     }
 
     // ========================

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
@@ -83,10 +83,9 @@ class WebSocketServer {
     private volatile RunManager runManager;
 
     /**
-     * Parser configuration retained for Phase 2+ use; request parsing is currently
-     * performed inline in the route handlers.
+     * Parser for Level 2/3 run request bodies. Used by {@code POST /api/runs} to
+     * resolve execution ensembles with task overrides or dynamic task definitions.
      */
-    @SuppressWarnings("unused")
     private volatile RunRequestParser runRequestParser;
 
     /** Tool registry for the capabilities endpoint. Null when not configured. */
@@ -345,7 +344,7 @@ class WebSocketServer {
             // Ensemble Control API endpoints (Phase 1)
             // ========================
 
-            // POST /api/runs -- submit a Level 1 run (template + variable inputs)
+            // POST /api/runs -- submit a run (Level 1/2/3 parameterization)
             config.routes.post("/api/runs", ctx -> {
                 // RunManager is always created by WebDashboard; use it directly.
                 RunManager rm = runManager;
@@ -401,7 +400,21 @@ class WebSocketServer {
                                     tags.put(entry.getKey(), entry.getValue().asText()));
                 }
 
-                RunState state = rm.submitRun(template, inputs, tags, null, null, null);
+                // Determine execution ensemble (Level 1/2/3)
+                net.agentensemble.Ensemble executionEnsemble;
+                try {
+                    executionEnsemble = resolveExecutionEnsemble(template, body, runRequestParser);
+                } catch (IllegalArgumentException e) {
+                    ctx.status(400);
+                    ctx.json(Map.of("error", "BAD_REQUEST", "message", e.getMessage()));
+                    return;
+                } catch (IllegalStateException e) {
+                    ctx.status(503);
+                    ctx.json(Map.of("error", "NOT_CONFIGURED", "message", e.getMessage()));
+                    return;
+                }
+
+                RunState state = rm.submitRun(executionEnsemble, inputs, tags, null, null, null);
 
                 if (state.getStatus() == RunState.Status.REJECTED) {
                     ctx.status(429);
@@ -585,6 +598,9 @@ class WebSocketServer {
                     java.util.List<Map<String, Object>> tasksList = new java.util.ArrayList<>();
                     for (net.agentensemble.Task t : template.getTasks()) {
                         Map<String, Object> taskInfo = new java.util.LinkedHashMap<>();
+                        if (t.getName() != null) {
+                            taskInfo.put("name", t.getName());
+                        }
                         taskInfo.put("description", t.getDescription());
                         tasksList.add(taskInfo);
                     }
@@ -853,6 +869,54 @@ class WebSocketServer {
             log.warn("Received review_decision but no client message handler is registered. "
                     + "Register WebDashboard via Ensemble.builder().webDashboard(dashboard).");
         }
+    }
+
+    /**
+     * Resolves the execution ensemble from the request body, applying Level 1/2/3 parsing.
+     *
+     * <p>Level detection (first match wins):
+     * <ol>
+     *   <li>If {@code tasks} array is present and non-empty: Level 3 (dynamic tasks).</li>
+     *   <li>If {@code taskOverrides} object is present and non-empty: Level 2 (per-task overrides).</li>
+     *   <li>Otherwise: Level 1 (template as-is).</li>
+     * </ol>
+     *
+     * @throws IllegalArgumentException if task/tool/model references are invalid
+     * @throws IllegalStateException    if a catalog is required but not configured
+     */
+    @SuppressWarnings("unchecked")
+    private static net.agentensemble.Ensemble resolveExecutionEnsemble(
+            net.agentensemble.Ensemble template,
+            com.fasterxml.jackson.databind.JsonNode body,
+            RunRequestParser parser) {
+        // Shared ObjectMapper for converting JsonNode to typed collections
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+
+        com.fasterxml.jackson.databind.JsonNode tasksNode = body.get("tasks");
+        com.fasterxml.jackson.databind.JsonNode overridesNode = body.get("taskOverrides");
+
+        RunRequestParser.RunConfiguration config;
+
+        if (tasksNode != null && tasksNode.isArray() && !tasksNode.isEmpty()) {
+            // Level 3: dynamic task list
+            java.util.List<java.util.Map<String, Object>> taskDefs = mapper.convertValue(
+                    tasksNode,
+                    new com.fasterxml.jackson.core.type.TypeReference<
+                            java.util.List<java.util.Map<String, Object>>>() {});
+            config = parser.buildFromDynamicTasks(template, taskDefs, null, null);
+        } else if (overridesNode != null && overridesNode.isObject() && !overridesNode.isEmpty()) {
+            // Level 2: per-task overrides
+            java.util.Map<String, java.util.Map<String, Object>> taskOverrides = mapper.convertValue(
+                    overridesNode,
+                    new com.fasterxml.jackson.core.type.TypeReference<
+                            java.util.Map<String, java.util.Map<String, Object>>>() {});
+            config = parser.buildFromTemplateWithOverrides(template, null, null, taskOverrides);
+        } else {
+            // Level 1: template as-is
+            config = parser.buildFromTemplate(template, null, null);
+        }
+
+        return config.overrideTasks() != null ? template.withTasks(config.overrideTasks()) : config.template();
     }
 
     // ========================

--- a/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/WebSocketServer.java
@@ -895,6 +895,17 @@ class WebSocketServer {
         com.fasterxml.jackson.databind.JsonNode tasksNode = body.get("tasks");
         com.fasterxml.jackson.databind.JsonNode overridesNode = body.get("taskOverrides");
 
+        // Reject requests where a level indicator is present but empty -- they would
+        // silently fall through to Level 1 and run the template unexpectedly.
+        if (tasksNode != null && tasksNode.isArray() && tasksNode.isEmpty()) {
+            throw new IllegalArgumentException("The 'tasks' field is present but empty; "
+                    + "provide a non-empty task list for Level 3, or omit the field.");
+        }
+        if (overridesNode != null && overridesNode.isObject() && overridesNode.isEmpty()) {
+            throw new IllegalArgumentException("The 'taskOverrides' field is present but empty; "
+                    + "provide at least one override for Level 2, or omit the field.");
+        }
+
         RunRequestParser.RunConfiguration config;
 
         if (tasksNode != null && tasksNode.isArray() && !tasksNode.isEmpty()) {

--- a/agentensemble-web/src/main/java/net/agentensemble/web/protocol/ClientMessage.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/protocol/ClientMessage.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * <ul>
  *   <li>{@link ReviewDecisionMessage} -- browser's response to a {@link ReviewRequestedMessage}</li>
  *   <li>{@link PingMessage} -- keepalive; server responds with {@link PongMessage}</li>
+ *   <li>{@link RunRequestMessage} -- submit an ensemble run (Level 1/2/3 parameterization)</li>
  * </ul>
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.PROPERTY)
@@ -20,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = ToolRequestMessage.class, name = "tool_request"),
     @JsonSubTypes.Type(value = DirectiveMessage.class, name = "directive"),
     @JsonSubTypes.Type(value = CapabilityQueryMessage.class, name = "capability_query"),
+    @JsonSubTypes.Type(value = RunRequestMessage.class, name = "run_request"),
 })
 public sealed interface ClientMessage
         permits ReviewDecisionMessage,
@@ -27,4 +29,5 @@ public sealed interface ClientMessage
                 TaskRequestMessage,
                 ToolRequestMessage,
                 DirectiveMessage,
-                CapabilityQueryMessage {}
+                CapabilityQueryMessage,
+                RunRequestMessage {}

--- a/agentensemble-web/src/main/java/net/agentensemble/web/protocol/RunRequestMessage.java
+++ b/agentensemble-web/src/main/java/net/agentensemble/web/protocol/RunRequestMessage.java
@@ -1,0 +1,41 @@
+package net.agentensemble.web.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Client-to-server WebSocket message for submitting an ensemble run.
+ *
+ * <p>Supports three levels of parameterization (matching {@code POST /api/runs}):
+ * <ul>
+ *   <li><strong>Level 1</strong> -- {@code inputs} only; the template ensemble runs as-is with
+ *       variable substitution.</li>
+ *   <li><strong>Level 2</strong> -- {@code inputs} + {@code taskOverrides}; override specific
+ *       task fields (description, model, tools, maxIterations, etc.) at runtime.</li>
+ *   <li><strong>Level 3</strong> -- {@code inputs} + {@code tasks}; define an entirely new task
+ *       list without modifying Java code.</li>
+ * </ul>
+ *
+ * <p>The server responds immediately with a {@link RunAckMessage} ({@code run_ack}) and, on
+ * completion, sends a {@link RunResultMessage} ({@code run_result}) targeted to the originating
+ * WebSocket session only.
+ *
+ * @param requestId     caller-assigned identifier echoed in {@link RunAckMessage}; may be null
+ * @param inputs        template variable substitutions ({@code {variable}} placeholders); may be null
+ * @param tasks         Level 3 dynamic task definitions; when present, {@code taskOverrides} is
+ *                      ignored and the template's task list is fully replaced
+ * @param taskOverrides Level 2 per-task override fields keyed by task name or description prefix;
+ *                      ignored when {@code tasks} is present
+ * @param options       per-run execution overrides (e.g. {@code maxToolOutputLength}); may be null
+ * @param tags          arbitrary key-value tags attached to the run state; may be null
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RunRequestMessage(
+        String requestId,
+        Map<String, String> inputs,
+        List<Map<String, Object>> tasks,
+        Map<String, Map<String, Object>> taskOverrides,
+        Map<String, Object> options,
+        Map<String, String> tags)
+        implements ClientMessage {}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestMessageTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestMessageTest.java
@@ -1,0 +1,205 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import net.agentensemble.web.protocol.ClientMessage;
+import net.agentensemble.web.protocol.MessageSerializer;
+import net.agentensemble.web.protocol.RunRequestMessage;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link RunRequestMessage}: serialization, deserialization, and type dispatch.
+ */
+class RunRequestMessageTest {
+
+    private final MessageSerializer serializer = new MessageSerializer();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // ========================
+    // Serialization round-trip
+    // ========================
+
+    @Test
+    void serialize_withAllFields_includesTypeDiscriminator() throws Exception {
+        var msg = new RunRequestMessage("req-1", Map.of("topic", "AI safety"), null, null, null, Map.of("env", "test"));
+
+        String json = serializer.toJson(msg);
+
+        assertThat(json).contains("\"type\":\"run_request\"");
+        assertThat(json).contains("\"requestId\":\"req-1\"");
+        assertThat(json).contains("\"topic\"");
+        assertThat(json).contains("\"AI safety\"");
+    }
+
+    @Test
+    void deserialize_asClientMessage_givesRunRequestMessage() throws Exception {
+        String json =
+                """
+                {
+                  "type": "run_request",
+                  "requestId": "req-42",
+                  "inputs": {"topic": "EU regulation"}
+                }
+                """;
+
+        ClientMessage msg = serializer.fromJson(json, ClientMessage.class);
+
+        assertThat(msg).isInstanceOf(RunRequestMessage.class);
+        RunRequestMessage rrm = (RunRequestMessage) msg;
+        assertThat(rrm.requestId()).isEqualTo("req-42");
+        assertThat(rrm.inputs()).containsEntry("topic", "EU regulation");
+        assertThat(rrm.tasks()).isNull();
+        assertThat(rrm.taskOverrides()).isNull();
+    }
+
+    @Test
+    void deserialize_withTasks_parsesTaskList() throws Exception {
+        String json =
+                """
+                {
+                  "type": "run_request",
+                  "requestId": "req-3",
+                  "inputs": {"product": "AgentEnsemble"},
+                  "tasks": [
+                    {
+                      "name": "researcher",
+                      "description": "Research {product} competitors",
+                      "expectedOutput": "Competitor analysis",
+                      "maxIterations": 20
+                    },
+                    {
+                      "name": "writer",
+                      "description": "Write executive brief",
+                      "expectedOutput": "Brief",
+                      "context": ["$researcher"]
+                    }
+                  ]
+                }
+                """;
+
+        ClientMessage msg = serializer.fromJson(json, ClientMessage.class);
+        RunRequestMessage rrm = (RunRequestMessage) msg;
+
+        assertThat(rrm.requestId()).isEqualTo("req-3");
+        assertThat(rrm.tasks()).hasSize(2);
+        assertThat(rrm.tasks().get(0)).containsEntry("name", "researcher");
+        assertThat(rrm.tasks().get(0)).containsEntry("maxIterations", 20);
+        assertThat(rrm.tasks().get(1).get("context")).isEqualTo(List.of("$researcher"));
+    }
+
+    @Test
+    void deserialize_withTaskOverrides_parsesOverrideMap() throws Exception {
+        String json =
+                """
+                {
+                  "type": "run_request",
+                  "requestId": "req-4",
+                  "inputs": {"topic": "AI safety"},
+                  "taskOverrides": {
+                    "researcher": {
+                      "description": "Research {topic} focusing on EU regulation",
+                      "maxIterations": 15,
+                      "model": "opus"
+                    }
+                  }
+                }
+                """;
+
+        ClientMessage msg = serializer.fromJson(json, ClientMessage.class);
+        RunRequestMessage rrm = (RunRequestMessage) msg;
+
+        assertThat(rrm.taskOverrides()).containsKey("researcher");
+        Map<String, Object> researcherOverride = rrm.taskOverrides().get("researcher");
+        assertThat(researcherOverride).containsEntry("model", "opus");
+        assertThat(researcherOverride.get("maxIterations")).isEqualTo(15);
+    }
+
+    @Test
+    void deserialize_withOptions_parsesOptionsMap() throws Exception {
+        String json =
+                """
+                {
+                  "type": "run_request",
+                  "inputs": {},
+                  "options": {
+                    "maxToolOutputLength": 5000,
+                    "toolLogTruncateLength": 100
+                  }
+                }
+                """;
+
+        ClientMessage msg = serializer.fromJson(json, ClientMessage.class);
+        RunRequestMessage rrm = (RunRequestMessage) msg;
+
+        assertThat(rrm.options()).containsEntry("maxToolOutputLength", 5000);
+        assertThat(rrm.options()).containsEntry("toolLogTruncateLength", 100);
+    }
+
+    @Test
+    void deserialize_withTags_parsesTagsMap() throws Exception {
+        String json =
+                """
+                {
+                  "type": "run_request",
+                  "inputs": {},
+                  "tags": {"env": "staging", "requestedBy": "ci-pipeline"}
+                }
+                """;
+
+        ClientMessage msg = serializer.fromJson(json, ClientMessage.class);
+        RunRequestMessage rrm = (RunRequestMessage) msg;
+
+        assertThat(rrm.tags()).containsEntry("env", "staging");
+        assertThat(rrm.tags()).containsEntry("requestedBy", "ci-pipeline");
+    }
+
+    @Test
+    void deserialize_minimalMessage_onlyRequiredFieldsNull() throws Exception {
+        String json = "{\"type\": \"run_request\"}";
+
+        ClientMessage msg = serializer.fromJson(json, ClientMessage.class);
+        RunRequestMessage rrm = (RunRequestMessage) msg;
+
+        assertThat(rrm.requestId()).isNull();
+        assertThat(rrm.inputs()).isNull();
+        assertThat(rrm.tasks()).isNull();
+        assertThat(rrm.taskOverrides()).isNull();
+        assertThat(rrm.options()).isNull();
+        assertThat(rrm.tags()).isNull();
+    }
+
+    @Test
+    void serialize_nullFieldsOmitted() throws Exception {
+        var msg = new RunRequestMessage("req-99", Map.of("k", "v"), null, null, null, null);
+
+        String json = serializer.toJson(msg);
+
+        assertThat(json).doesNotContain("tasks");
+        assertThat(json).doesNotContain("taskOverrides");
+        assertThat(json).doesNotContain("options");
+        assertThat(json).doesNotContain("tags");
+    }
+
+    @Test
+    void roundTrip_level3TaskDefs_preservedExactly() throws Exception {
+        var taskDef = Map.<String, Object>of(
+                "name", "writer",
+                "description", "Write a report",
+                "expectedOutput", "A report",
+                "context", List.of("$researcher"));
+
+        var original = new RunRequestMessage("req-100", Map.of("topic", "AI"), List.of(taskDef), null, null, null);
+
+        String json = serializer.toJson(original);
+        ClientMessage parsed = serializer.fromJson(json, ClientMessage.class);
+        RunRequestMessage restored = (RunRequestMessage) parsed;
+
+        assertThat(restored.requestId()).isEqualTo("req-100");
+        assertThat(restored.tasks()).hasSize(1);
+        assertThat(restored.tasks().get(0)).containsEntry("name", "writer");
+        assertThat(restored.tasks().get(0).get("context")).isEqualTo(List.of("$researcher"));
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestParserTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestParserTest.java
@@ -3,25 +3,102 @@ package net.agentensemble.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import dev.langchain4j.model.chat.ChatModel;
+import java.util.List;
 import java.util.Map;
 import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
 import net.agentensemble.execution.RunOptions;
+import net.agentensemble.tool.AgentTool;
+import net.agentensemble.tool.ToolResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for {@link RunRequestParser}: Level 1 configuration building.
+ * Unit tests for {@link RunRequestParser}: Level 1 and Level 2 configuration building.
  */
 class RunRequestParserTest {
 
     private RunRequestParser parser;
     private Ensemble template;
 
+    // Catalog-configured parser for Level 2 tests
+    private RunRequestParser parserWithCatalogs;
+    private ToolCatalog toolCatalog;
+    private ModelCatalog modelCatalog;
+
+    // Named task and unnamed task for override matching tests
+    private Task namedTask;
+    private Task unnamedTask;
+    private AgentTool webSearchTool;
+    private AgentTool calculatorTool;
+    private ChatModel mockModel;
+
     @BeforeEach
     void setUp() {
         parser = new RunRequestParser(null, null);
         template = mock(Ensemble.class);
+
+        // Build real tools for catalog
+        webSearchTool = new AgentTool() {
+            @Override
+            public String name() {
+                return "web_search";
+            }
+
+            @Override
+            public String description() {
+                return "Search the web";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success("results");
+            }
+        };
+
+        calculatorTool = new AgentTool() {
+            @Override
+            public String name() {
+                return "calculator";
+            }
+
+            @Override
+            public String description() {
+                return "Math operations";
+            }
+
+            @Override
+            public ToolResult execute(String input) {
+                return ToolResult.success("42");
+            }
+        };
+
+        mockModel = mock(ChatModel.class);
+
+        toolCatalog = ToolCatalog.builder()
+                .tool("web_search", webSearchTool)
+                .tool("calculator", calculatorTool)
+                .build();
+
+        modelCatalog = ModelCatalog.builder().model("sonnet", mockModel).build();
+
+        parserWithCatalogs = new RunRequestParser(toolCatalog, modelCatalog);
+
+        // Named task: has name field set
+        namedTask = Task.builder()
+                .name("researcher")
+                .description("Research AI trends in enterprise software")
+                .expectedOutput("A detailed report")
+                .build();
+
+        // Unnamed task: no name, matched by description prefix
+        unnamedTask = Task.builder()
+                .description("Summarize the key findings from research")
+                .expectedOutput("An executive summary")
+                .build();
     }
 
     // ========================
@@ -107,5 +184,753 @@ class RunRequestParserTest {
 
         assertThat(parserWithCatalogs.getToolCatalog()).isSameAs(tc);
         assertThat(parserWithCatalogs.getModelCatalog()).isSameAs(mc);
+    }
+
+    // ========================
+    // buildFromTemplate -- overrideTasks is null (Level 1 backward compat)
+    // ========================
+
+    @Test
+    void buildFromTemplate_overrideTasks_isNull() {
+        RunRequestParser.RunConfiguration config = parser.buildFromTemplate(template, Map.of(), null);
+        assertThat(config.overrideTasks()).isNull();
+    }
+
+    // ========================
+    // Level 2: buildFromTemplateWithOverrides -- null/empty overrides
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_nullTemplate_throws() {
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromTemplateWithOverrides(null, Map.of(), null, Map.of()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("template ensemble must not be null");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_emptyOverrides_returnsSameTaskList() {
+        when(template.getTasks()).thenReturn(List.of(namedTask, unnamedTask));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of("topic", "AI"), null, Map.of());
+
+        assertThat(config.overrideTasks()).hasSize(2);
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo(namedTask.getDescription());
+        assertThat(config.overrideTasks().get(1).getDescription()).isEqualTo(unnamedTask.getDescription());
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_nullOverrides_returnsSameTaskList() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of(), null, null);
+
+        assertThat(config.overrideTasks()).hasSize(1);
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo(namedTask.getDescription());
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_preservesInputsAndOptions() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+        RunOptions options = RunOptions.builder().maxToolOutputLength(3000).build();
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of("topic", "AI"), options, Map.of());
+
+        assertThat(config.inputs()).containsEntry("topic", "AI");
+        assertThat(config.options()).isSameAs(options);
+        assertThat(config.template()).isSameAs(template);
+    }
+
+    // ========================
+    // Level 2: override matching -- by name
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_matchByExactName_updatesDescription() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        Map<String, Map<String, Object>> overrides =
+                Map.of("researcher", Map.of("description", "Research EU AI regulation"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of(), null, overrides);
+
+        assertThat(config.overrideTasks()).hasSize(1);
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo("Research EU AI regulation");
+        assertThat(config.overrideTasks().get(0).getName()).isEqualTo("researcher");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_matchByExactName_caseInsensitive() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        Map<String, Map<String, Object>> overrides =
+                Map.of("RESEARCHER", Map.of("description", "Research EU AI regulation"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of(), null, overrides);
+
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo("Research EU AI regulation");
+    }
+
+    // ========================
+    // Level 2: override matching -- by description prefix
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_matchByDescriptionPrefix_updatesDescription() {
+        when(template.getTasks()).thenReturn(List.of(unnamedTask));
+
+        // Override key is the description prefix (first 50 chars)
+        String prefix = unnamedTask
+                .getDescription()
+                .substring(0, Math.min(50, unnamedTask.getDescription().length()));
+        Map<String, Map<String, Object>> overrides = Map.of(prefix, Map.of("description", "Write a concise summary"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of(), null, overrides);
+
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo("Write a concise summary");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_matchByDescriptionPrefix_caseInsensitive() {
+        when(template.getTasks()).thenReturn(List.of(unnamedTask));
+
+        String prefix = unnamedTask
+                .getDescription()
+                .substring(0, Math.min(50, unnamedTask.getDescription().length()))
+                .toUpperCase();
+        Map<String, Map<String, Object>> overrides = Map.of(prefix, Map.of("expectedOutput", "A brief summary"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of(), null, overrides);
+
+        assertThat(config.overrideTasks().get(0).getExpectedOutput()).isEqualTo("A brief summary");
+    }
+
+    // ========================
+    // Level 2: unknown override key
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_unknownOverrideKey_throws() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        Map<String, Map<String, Object>> overrides = Map.of("nonexistent-task", Map.of("description", "Updated"));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromTemplateWithOverrides(template, Map.of(), null, overrides))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nonexistent-task");
+    }
+
+    // ========================
+    // Level 2: override fields -- description and expectedOutput
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideDescription_replaced() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template,
+                Map.of(),
+                null,
+                Map.of("researcher", Map.of("description", "Research {topic} focusing on EU regulation")));
+
+        assertThat(config.overrideTasks().get(0).getDescription())
+                .isEqualTo("Research {topic} focusing on EU regulation");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideExpectedOutput_replaced() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template,
+                Map.of(),
+                null,
+                Map.of("researcher", Map.of("expectedOutput", "A regulatory analysis report")));
+
+        assertThat(config.overrideTasks().get(0).getExpectedOutput()).isEqualTo("A regulatory analysis report");
+        // Original description unchanged
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo(namedTask.getDescription());
+    }
+
+    // ========================
+    // Level 2: override fields -- maxIterations
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideMaxIterations_replaced() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("maxIterations", 15)));
+
+        assertThat(config.overrideTasks().get(0).getMaxIterations()).isEqualTo(15);
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideMaxIterations_fromString() {
+        // maxIterations may arrive as a String from JSON deserialization
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("maxIterations", "20")));
+
+        assertThat(config.overrideTasks().get(0).getMaxIterations()).isEqualTo(20);
+    }
+
+    // ========================
+    // Level 2: override fields -- model
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideModel_resolvedFromCatalog() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("model", "sonnet")));
+
+        assertThat(config.overrideTasks().get(0).getChatLanguageModel()).isSameAs(mockModel);
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideModel_unknownAlias_throws() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromTemplateWithOverrides(
+                        template, Map.of(), null, Map.of("researcher", Map.of("model", "unknown-model"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown-model");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideModel_noCatalog_throws() {
+        // Parser without model catalog cannot resolve model aliases
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        assertThatThrownBy(() -> parser.buildFromTemplateWithOverrides(
+                        template, Map.of(), null, Map.of("researcher", Map.of("model", "sonnet"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ModelCatalog");
+    }
+
+    // ========================
+    // Level 2: override fields -- additionalContext (appended to description)
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideAdditionalContext_appendedToDescription() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template,
+                Map.of(),
+                null,
+                Map.of("researcher", Map.of("additionalContext", "The EU AI Act passed in 2024.")));
+
+        String description = config.overrideTasks().get(0).getDescription();
+        assertThat(description).startsWith(namedTask.getDescription());
+        assertThat(description).contains("The EU AI Act passed in 2024.");
+    }
+
+    // ========================
+    // Level 2: override fields -- tools.add and tools.remove
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_toolsAdd_appendsToolToTaskList() {
+        Task taskWithCalculator = Task.builder()
+                .name("analyst")
+                .description("Analyse data using tools")
+                .expectedOutput("Analysis result")
+                .tools(List.of(calculatorTool))
+                .build();
+        when(template.getTasks()).thenReturn(List.of(taskWithCalculator));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("analyst", Map.of("tools", Map.of("add", List.of("web_search")))));
+
+        List<Object> tools = config.overrideTasks().get(0).getTools();
+        assertThat(tools).hasSize(2);
+        assertThat(tools).contains(calculatorTool, webSearchTool);
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_toolsRemove_removesToolFromTaskList() {
+        Task taskWithBothTools = Task.builder()
+                .name("analyst")
+                .description("Analyse data")
+                .expectedOutput("Analysis result")
+                .tools(List.of(calculatorTool, webSearchTool))
+                .build();
+        when(template.getTasks()).thenReturn(List.of(taskWithBothTools));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("analyst", Map.of("tools", Map.of("remove", List.of("calculator")))));
+
+        List<Object> tools = config.overrideTasks().get(0).getTools();
+        assertThat(tools).hasSize(1);
+        assertThat(tools).contains(webSearchTool);
+        assertThat(tools).doesNotContain(calculatorTool);
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_toolsAdd_unknownTool_throws() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromTemplateWithOverrides(
+                        template,
+                        Map.of(),
+                        null,
+                        Map.of("researcher", Map.of("tools", Map.of("add", List.of("nonexistent_tool"))))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nonexistent_tool");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_toolsAdd_noCatalog_throws() {
+        // Parser without tool catalog cannot resolve tool names
+        Task aTask = Task.builder()
+                .name("researcher")
+                .description("Research")
+                .expectedOutput("Report")
+                .build();
+        when(template.getTasks()).thenReturn(List.of(aTask));
+
+        assertThatThrownBy(() -> parser.buildFromTemplateWithOverrides(
+                        template,
+                        Map.of(),
+                        null,
+                        Map.of("researcher", Map.of("tools", Map.of("add", List.of("web_search"))))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ToolCatalog");
+    }
+
+    // ========================
+    // Level 2: combined overrides on same task
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_combinedOverrides_allApplied() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template,
+                Map.of(),
+                null,
+                Map.of(
+                        "researcher",
+                        Map.of(
+                                "description", "Research {topic} focusing on EU regulation",
+                                "expectedOutput", "A regulatory analysis report",
+                                "maxIterations", 15,
+                                "model", "sonnet")));
+
+        Task overridden = config.overrideTasks().get(0);
+        assertThat(overridden.getDescription()).isEqualTo("Research {topic} focusing on EU regulation");
+        assertThat(overridden.getExpectedOutput()).isEqualTo("A regulatory analysis report");
+        assertThat(overridden.getMaxIterations()).isEqualTo(15);
+        assertThat(overridden.getChatLanguageModel()).isSameAs(mockModel);
+    }
+
+    // ========================
+    // Level 2: multiple tasks, only some overridden
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_multipleTasksOneOverridden_onlyMatchingTaskUpdated() {
+        when(template.getTasks()).thenReturn(List.of(namedTask, unnamedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("description", "Research EU regulation")));
+
+        assertThat(config.overrideTasks()).hasSize(2);
+        // Named task updated
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo("Research EU regulation");
+        // Unnamed task unchanged
+        assertThat(config.overrideTasks().get(1).getDescription()).isEqualTo(unnamedTask.getDescription());
+    }
+
+    // ========================
+    // Level 2: original tasks not mutated
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_originalTasksNotMutated() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+        String originalDescription = namedTask.getDescription();
+
+        parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("description", "New description")));
+
+        assertThat(namedTask.getDescription()).isEqualTo(originalDescription);
+    }
+
+    // ========================
+    // Level 3: buildFromDynamicTasks
+    // ========================
+
+    @Test
+    void buildFromDynamicTasks_nullTemplate_throws() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "writer",
+                "description", "Write a report",
+                "expectedOutput", "A report"));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(null, taskDefs, Map.of(), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("template ensemble must not be null");
+    }
+
+    @Test
+    void buildFromDynamicTasks_nullTaskDefs_throws() {
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, null, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tasks");
+    }
+
+    @Test
+    void buildFromDynamicTasks_emptyTaskDefs_throws() {
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, List.of(), Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tasks");
+    }
+
+    @Test
+    void buildFromDynamicTasks_singleTask_buildsCorrectTask() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research {topic} trends",
+                "expectedOutput", "A detailed report"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of("topic", "AI"), null);
+
+        assertThat(config.template()).isSameAs(template);
+        assertThat(config.inputs()).containsEntry("topic", "AI");
+        assertThat(config.overrideTasks()).hasSize(1);
+
+        Task task = config.overrideTasks().get(0);
+        assertThat(task.getName()).isEqualTo("researcher");
+        assertThat(task.getDescription()).isEqualTo("Research {topic} trends");
+        assertThat(task.getExpectedOutput()).isEqualTo("A detailed report");
+    }
+
+    @Test
+    void buildFromDynamicTasks_taskWithTools_toolsResolvedFromCatalog() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI",
+                "expectedOutput", "Report",
+                "tools", List.of("web_search", "calculator")));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        Task task = config.overrideTasks().get(0);
+        assertThat(task.getTools()).hasSize(2);
+        assertThat(task.getTools()).contains(webSearchTool, calculatorTool);
+    }
+
+    @Test
+    void buildFromDynamicTasks_taskWithModel_modelResolvedFromCatalog() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI",
+                "expectedOutput", "Report",
+                "model", "sonnet"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        assertThat(config.overrideTasks().get(0).getChatLanguageModel()).isSameAs(mockModel);
+    }
+
+    @Test
+    void buildFromDynamicTasks_taskWithMaxIterations_applied() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI",
+                "expectedOutput", "Report",
+                "maxIterations", 20));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        assertThat(config.overrideTasks().get(0).getMaxIterations()).isEqualTo(20);
+    }
+
+    @Test
+    void buildFromDynamicTasks_contextByName_resolvesCorrectTask() {
+        // writer depends on researcher via $researcher
+        List<Map<String, Object>> taskDefs = List.of(
+                Map.of(
+                        "name", "researcher",
+                        "description", "Research AI trends",
+                        "expectedOutput", "Research findings"),
+                Map.of(
+                        "name", "writer",
+                        "description", "Write executive brief",
+                        "expectedOutput", "Executive brief",
+                        "context", List.of("$researcher")));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        assertThat(config.overrideTasks()).hasSize(2);
+        Task researcher = config.overrideTasks().get(0);
+        Task writer = config.overrideTasks().get(1);
+
+        assertThat(writer.getContext()).hasSize(1);
+        assertThat(writer.getContext().get(0)).isSameAs(researcher);
+    }
+
+    @Test
+    void buildFromDynamicTasks_contextByIndex_resolvesCorrectTask() {
+        // writer depends on researcher via $0 (index 0)
+        List<Map<String, Object>> taskDefs = List.of(
+                Map.of(
+                        "name", "researcher",
+                        "description", "Research AI trends",
+                        "expectedOutput", "Research findings"),
+                Map.of(
+                        "name", "writer",
+                        "description", "Write report",
+                        "expectedOutput", "Report",
+                        "context", List.of("$0")));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        Task researcher = config.overrideTasks().get(0);
+        Task writer = config.overrideTasks().get(1);
+
+        assertThat(writer.getContext()).hasSize(1);
+        assertThat(writer.getContext().get(0)).isSameAs(researcher);
+    }
+
+    @Test
+    void buildFromDynamicTasks_circularDependency_throws() {
+        // A depends on B, B depends on A -- circular
+        List<Map<String, Object>> taskDefs = List.of(
+                Map.of(
+                        "name", "taskA",
+                        "description", "Task A",
+                        "expectedOutput", "Output A",
+                        "context", List.of("$taskB")),
+                Map.of(
+                        "name", "taskB",
+                        "description", "Task B",
+                        "expectedOutput", "Output B",
+                        "context", List.of("$taskA")));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("circular");
+    }
+
+    @Test
+    void buildFromDynamicTasks_unknownContextName_throws() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "writer",
+                "description", "Write report",
+                "expectedOutput", "Report",
+                "context", List.of("$nonexistent")));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void buildFromDynamicTasks_outOfBoundsContextIndex_throws() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "writer",
+                "description", "Write report",
+                "expectedOutput", "Report",
+                "context", List.of("$99")));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("$99");
+    }
+
+    @Test
+    void buildFromDynamicTasks_unknownTool_throws() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI",
+                "expectedOutput", "Report",
+                "tools", List.of("nonexistent_tool")));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nonexistent_tool");
+    }
+
+    @Test
+    void buildFromDynamicTasks_unknownModel_throws() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI",
+                "expectedOutput", "Report",
+                "model", "unknown-model"));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown-model");
+    }
+
+    @Test
+    void buildFromDynamicTasks_outputSchema_injectedIntoExpectedOutput() {
+        // outputSchema as a map representing JSON Schema
+        Map<String, Object> schema =
+                Map.of("type", "object", "properties", Map.of("competitors", Map.of("type", "array")));
+
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research competitors",
+                "expectedOutput", "A structured analysis",
+                "outputSchema", schema));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        Task task = config.overrideTasks().get(0);
+        // outputSchema should be reflected in the expectedOutput (schema injected)
+        assertThat(task.getExpectedOutput()).contains("A structured analysis");
+        assertThat(task.getExpectedOutput()).contains("competitors");
+    }
+
+    @Test
+    void buildFromDynamicTasks_missingDescription_throws() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "expectedOutput", "A report"
+                // no "description"
+                ));
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("description");
+    }
+
+    @Test
+    void buildFromDynamicTasks_preservesInputsAndOptions() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research {topic}",
+                "expectedOutput", "Report"));
+        RunOptions options = RunOptions.builder().maxToolOutputLength(5000).build();
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of("topic", "AI"), options);
+
+        assertThat(config.inputs()).containsEntry("topic", "AI");
+        assertThat(config.options()).isSameAs(options);
+    }
+
+    @Test
+    void buildFromDynamicTasks_multipleTasksNoContext_allBuilt() {
+        List<Map<String, Object>> taskDefs = List.of(
+                Map.of("name", "task1", "description", "Do task 1", "expectedOutput", "Output 1"),
+                Map.of("name", "task2", "description", "Do task 2", "expectedOutput", "Output 2"),
+                Map.of("name", "task3", "description", "Do task 3", "expectedOutput", "Output 3"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        assertThat(config.overrideTasks()).hasSize(3);
+        assertThat(config.overrideTasks().get(0).getName()).isEqualTo("task1");
+        assertThat(config.overrideTasks().get(1).getName()).isEqualTo("task2");
+        assertThat(config.overrideTasks().get(2).getName()).isEqualTo("task3");
+    }
+
+    @Test
+    void buildFromDynamicTasks_taskWithAdditionalContext_appendedToDescription() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI",
+                "expectedOutput", "Report",
+                "additionalContext", "Focus on EU regulation."));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        Task task = config.overrideTasks().get(0);
+        assertThat(task.getDescription()).startsWith("Research AI");
+        assertThat(task.getDescription()).contains("Focus on EU regulation.");
+    }
+
+    @Test
+    void buildFromDynamicTasks_taskWithoutExpectedOutput_usesDefault() {
+        // When expectedOutput is omitted, Task.DEFAULT_EXPECTED_OUTPUT is used
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "researcher",
+                "description", "Research AI"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        assertThat(config.overrideTasks().get(0).getExpectedOutput())
+                .isEqualTo(net.agentensemble.Task.DEFAULT_EXPECTED_OUTPUT);
+    }
+
+    // ========================
+    // Level 2: maxIterations with numeric types
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_overrideMaxIterations_fromLongValue() {
+        // Ensure toInt() handles Long correctly (occurs when JSON integer is large)
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        // We pass the value via the override map using Long.valueOf to simulate what
+        // might arrive from custom deserialization paths
+        java.util.Map<String, Object> overrideFields = new java.util.LinkedHashMap<>();
+        overrideFields.put("maxIterations", Long.valueOf(25));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", overrideFields));
+
+        assertThat(config.overrideTasks().get(0).getMaxIterations()).isEqualTo(25);
+    }
+
+    // ========================
+    // Level 2: unknown override fields silently ignored
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_unknownField_silentlyIgnored() {
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        // "unknownField" is not a recognized override key; it should be ignored
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("unknownField", "some-value")));
+
+        // Task is unchanged except for the known fields; no exception thrown
+        assertThat(config.overrideTasks().get(0).getDescription()).isEqualTo(namedTask.getDescription());
+    }
+
+    // ========================
+    // Opportunistic coverage: RunOptions parsing via null options
+    // ========================
+
+    @Test
+    void buildFromDynamicTasks_nullOptions_usesDefault() {
+        List<Map<String, Object>> taskDefs = List.of(Map.of(
+                "name", "t1",
+                "description", "Do something",
+                "expectedOutput", "Output"));
+
+        RunRequestParser.RunConfiguration config =
+                parserWithCatalogs.buildFromDynamicTasks(template, taskDefs, Map.of(), null);
+
+        assertThat(config.options()).isSameAs(net.agentensemble.execution.RunOptions.DEFAULT);
     }
 }

--- a/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestParserTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/RunRequestParserTest.java
@@ -933,4 +933,187 @@ class RunRequestParserTest {
 
         assertThat(config.options()).isSameAs(net.agentensemble.execution.RunOptions.DEFAULT);
     }
+
+    // ========================
+    // Level 3: type validation for expectedOutput field
+    // ========================
+
+    @Test
+    void buildFromDynamicTasks_invalidExpectedOutputType_throwsIllegalArgumentException() {
+        // expectedOutput must be a String; passing an integer should throw with a useful message
+        java.util.Map<String, Object> def = new java.util.LinkedHashMap<>();
+        def.put("description", "Some task");
+        def.put("expectedOutput", 42); // integer, not a string
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, List.of(def), null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedOutput")
+                .hasMessageContaining("non-null string");
+    }
+
+    @Test
+    void buildFromDynamicTasks_nullExpectedOutputValue_throwsIllegalArgumentException() {
+        java.util.Map<String, Object> def = new java.util.LinkedHashMap<>();
+        def.put("description", "Some task");
+        def.put("expectedOutput", null);
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, List.of(def), null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedOutput");
+    }
+
+    // ========================
+    // Level 3: type validation for tool names
+    // ========================
+
+    @Test
+    void buildFromDynamicTasks_invalidToolNameType_throwsIllegalArgumentException() {
+        // Tool names must be non-blank strings; passing an integer should throw
+        java.util.Map<String, Object> def = new java.util.LinkedHashMap<>();
+        def.put("description", "Some task");
+        def.put("tools", java.util.List.of(123)); // integer, not a string
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, List.of(def), null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Tool names must be non-blank strings");
+    }
+
+    // ========================
+    // Level 3: type validation for context field
+    // ========================
+
+    @Test
+    void buildFromDynamicTasks_invalidContextType_throwsIllegalArgumentException() {
+        // 'context' must be an array; passing a string should throw
+        java.util.Map<String, Object> def = new java.util.LinkedHashMap<>();
+        def.put("description", "Some task");
+        def.put("context", "not-an-array");
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, List.of(def), null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("context")
+                .hasMessageContaining("array");
+    }
+
+    @Test
+    void buildFromDynamicTasks_contextWithNonStringEntry_throwsIllegalArgumentException() {
+        // Context entries must be strings ($name or $N); passing an integer should throw
+        java.util.Map<String, Object> def = new java.util.LinkedHashMap<>();
+        def.put("description", "Some task");
+        def.put("context", java.util.List.of(42)); // integer, not a string
+
+        assertThatThrownBy(() -> parserWithCatalogs.buildFromDynamicTasks(template, List.of(def), null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("context")
+                .hasMessageContaining("strings");
+    }
+
+    // ========================
+    // Level 2: additionalContext + description deterministic ordering
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_descriptionAndAdditionalContext_descriptionFirst() {
+        // When both 'description' and 'additionalContext' are provided, the result must be:
+        // [overridden description] + newline + [additionalContext]
+        // This must hold regardless of Map iteration order.
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        java.util.Map<String, Object> fields = new java.util.LinkedHashMap<>();
+        fields.put("description", "New description");
+        fields.put("additionalContext", "Extra context");
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", fields));
+
+        String desc = config.overrideTasks().get(0).getDescription();
+        assertThat(desc).startsWith("New description");
+        assertThat(desc).endsWith("Extra context");
+        assertThat(desc).contains("\n\n");
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_additionalContextOnly_appendsToOriginal() {
+        // When only 'additionalContext' is provided (no 'description' override), the result
+        // must be [original description] + newline + [additionalContext].
+        when(template.getTasks()).thenReturn(List.of(namedTask));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("additionalContext", "Appended context")));
+
+        String desc = config.overrideTasks().get(0).getDescription();
+        assertThat(desc).startsWith(namedTask.getDescription());
+        assertThat(desc).endsWith("Appended context");
+    }
+
+    // ========================
+    // Level 2: tool removal by name (not reference equality)
+    // ========================
+
+    @Test
+    void buildFromTemplateWithOverrides_removeToolByName_removesFromTaskToolList() {
+        // The tool on the task and the catalog tool share the same name but are different
+        // instances. Name-based removal must succeed.
+        net.agentensemble.tool.AgentTool catalogTool =
+                toolCatalog.find("calculator").orElseThrow();
+        // Build a task whose tools list contains a DIFFERENT instance with the same name,
+        // simulating a tool that was constructed outside the catalog.
+        net.agentensemble.tool.AgentTool externalInstance = new net.agentensemble.tool.AgentTool() {
+            @Override
+            public String name() {
+                return "calculator";
+            }
+
+            @Override
+            public String description() {
+                return "A calculator (external)";
+            }
+
+            @Override
+            public net.agentensemble.tool.ToolResult execute(String input) {
+                return net.agentensemble.tool.ToolResult.success("0");
+            }
+        };
+
+        net.agentensemble.Task taskWithTool = net.agentensemble.Task.builder()
+                .name("researcher")
+                .description("Research task")
+                .expectedOutput("Output")
+                .tools(java.util.List.of(externalInstance))
+                .build();
+        when(template.getTasks()).thenReturn(java.util.List.of(taskWithTool));
+
+        java.util.Map<String, Object> toolsOverride = new java.util.LinkedHashMap<>();
+        toolsOverride.put("remove", java.util.List.of("calculator"));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("tools", toolsOverride)));
+
+        // Tool was removed even though the instance was different from the catalog instance
+        assertThat(config.overrideTasks().get(0).getTools()).isEmpty();
+    }
+
+    @Test
+    void buildFromTemplateWithOverrides_addToolDeduplicated_doesNotAddDuplicate() {
+        // Adding a tool that is already present (by name) must not result in duplicates.
+        net.agentensemble.tool.AgentTool calcTool =
+                toolCatalog.find("calculator").orElseThrow();
+
+        net.agentensemble.Task taskWithTool = net.agentensemble.Task.builder()
+                .name("researcher")
+                .description("Research task")
+                .expectedOutput("Output")
+                .tools(java.util.List.of(calcTool))
+                .build();
+        when(template.getTasks()).thenReturn(java.util.List.of(taskWithTool));
+
+        java.util.Map<String, Object> toolsOverride = new java.util.LinkedHashMap<>();
+        toolsOverride.put("add", java.util.List.of("calculator"));
+
+        RunRequestParser.RunConfiguration config = parserWithCatalogs.buildFromTemplateWithOverrides(
+                template, Map.of(), null, Map.of("researcher", Map.of("tools", toolsOverride)));
+
+        // Should still have exactly one tool (no duplicate added)
+        assertThat(config.overrideTasks().get(0).getTools()).hasSize(1);
+    }
 }

--- a/agentensemble-web/src/test/java/net/agentensemble/web/WebDashboardRunRequestTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/WebDashboardRunRequestTest.java
@@ -1,0 +1,305 @@
+package net.agentensemble.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import net.agentensemble.Ensemble;
+import net.agentensemble.Task;
+import net.agentensemble.review.OnTimeoutAction;
+import net.agentensemble.tool.ToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for WebSocket {@code run_request} handling in {@link WebDashboard}.
+ *
+ * <p>Connects via real WebSocket and exercises the {@code handleRunRequest} path.
+ */
+class WebDashboardRunRequestTest {
+
+    private WebDashboard dashboard;
+    private WebSocket ws;
+
+    @BeforeEach
+    void setUp() {
+        dashboard = WebDashboard.builder()
+                .port(0)
+                .host("localhost")
+                .reviewTimeout(Duration.ofMillis(100))
+                .onTimeout(OnTimeoutAction.CONTINUE)
+                .build();
+        dashboard.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            if (ws != null) ws.sendClose(WebSocket.NORMAL_CLOSURE, "done").get(2, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+        }
+        if (dashboard != null) dashboard.stop();
+    }
+
+    /**
+     * When no template ensemble is configured via {@code setEnsemble()}, a {@code run_request}
+     * must be immediately rejected with a {@code run_ack} carrying {@code status: "REJECTED"}.
+     */
+    @Test
+    void runRequest_noEnsembleConfigured_receivesRejectedAck() throws Exception {
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        CountDownLatch ackLatch = new CountDownLatch(1);
+
+        HttpClient client = HttpClient.newHttpClient();
+        ws = client.newWebSocketBuilder()
+                .header("Origin", "http://localhost")
+                .buildAsync(URI.create("ws://localhost:" + dashboard.actualPort() + "/ws"), new WebSocket.Listener() {
+                    @Override
+                    public void onOpen(WebSocket webSocket) {
+                        webSocket.request(20);
+                    }
+
+                    @Override
+                    public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                        if (last) {
+                            String msg = data.toString();
+                            received.add(msg);
+                            if (msg.contains("\"type\":\"run_ack\"")) {
+                                ackLatch.countDown();
+                            }
+                        }
+                        webSocket.request(1);
+                        return null;
+                    }
+                })
+                .get(5, TimeUnit.SECONDS);
+
+        // Wait for the hello message before sending the run_request
+        Thread.sleep(200);
+
+        // Send a run_request; no ensemble is configured so it should be REJECTED
+        String runRequest =
+                """
+                {
+                  "type": "run_request",
+                  "requestId": "test-req-1",
+                  "inputs": {"topic": "AI safety"}
+                }
+                """;
+        ws.sendText(runRequest, true).get(3, TimeUnit.SECONDS);
+
+        // Wait for run_ack
+        assertThat(ackLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Verify the ack is REJECTED
+        String ackMessage = received.stream()
+                .filter(m -> m.contains("\"type\":\"run_ack\""))
+                .findFirst()
+                .orElse("");
+        assertThat(ackMessage).contains("\"status\":\"REJECTED\"");
+        assertThat(ackMessage).contains("\"requestId\":\"test-req-1\"");
+    }
+
+    /**
+     * With a template ensemble configured, a Level 1 {@code run_request} (inputs only) must
+     * be accepted and eventually produce a {@code run_result}. Uses a deterministic
+     * handler-only task that completes synchronously without an LLM model.
+     */
+    @Test
+    void runRequest_level1_withEnsemble_receivesAcceptedAckAndResult() throws Exception {
+        // Build a deterministic ensemble -- no LLM needed; handler returns instantly
+        Task handlerTask = Task.builder()
+                .name("greeter")
+                .description("Say hello to {name}")
+                .expectedOutput("A greeting")
+                .handler(ctx -> ToolResult.success("Hello, " + ctx.description()))
+                .build();
+        Ensemble templateEnsemble = Ensemble.builder().task(handlerTask).build();
+        dashboard.setEnsemble(templateEnsemble);
+
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        CountDownLatch ackLatch = new CountDownLatch(1);
+        CountDownLatch resultLatch = new CountDownLatch(1);
+
+        HttpClient client = HttpClient.newHttpClient();
+        ws = client.newWebSocketBuilder()
+                .header("Origin", "http://localhost")
+                .buildAsync(URI.create("ws://localhost:" + dashboard.actualPort() + "/ws"), new WebSocket.Listener() {
+                    @Override
+                    public void onOpen(WebSocket webSocket) {
+                        webSocket.request(30);
+                    }
+
+                    @Override
+                    public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                        if (last) {
+                            String msg = data.toString();
+                            received.add(msg);
+                            if (msg.contains("\"type\":\"run_ack\"")) {
+                                ackLatch.countDown();
+                            }
+                            if (msg.contains("\"type\":\"run_result\"")) {
+                                resultLatch.countDown();
+                            }
+                        }
+                        webSocket.request(1);
+                        return null;
+                    }
+                })
+                .get(5, TimeUnit.SECONDS);
+
+        Thread.sleep(200);
+
+        // Send a Level 1 run_request (inputs only, no tasks or overrides)
+        ws.sendText("{\"type\":\"run_request\",\"requestId\":\"l1-req\",\"inputs\":{\"name\":\"World\"}}", true)
+                .get(3, TimeUnit.SECONDS);
+
+        // Wait for ack
+        assertThat(ackLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        String ackMsg = received.stream()
+                .filter(m -> m.contains("\"type\":\"run_ack\""))
+                .findFirst()
+                .orElse("");
+        assertThat(ackMsg).contains("\"requestId\":\"l1-req\"");
+        // Status should be ACCEPTED (not REJECTED); concurrency limit not reached
+        assertThat(ackMsg).contains("\"status\":\"ACCEPTED\"");
+
+        // Wait for the run_result
+        assertThat(resultLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        String resultMsg = received.stream()
+                .filter(m -> m.contains("\"type\":\"run_result\""))
+                .findFirst()
+                .orElse("");
+        assertThat(resultMsg).contains("\"status\":\"COMPLETED\"");
+    }
+
+    /**
+     * A Level 3 {@code run_request} with {@code tasks} defined must use the dynamic task
+     * list. Covers the Level 3 dispatch branch of {@code handleRunRequest}.
+     */
+    @Test
+    void runRequest_level3_withDynamicTasks_receivesAcceptedAck() throws Exception {
+        Task baseTask = Task.builder()
+                .name("base")
+                .description("Base task")
+                .expectedOutput("Base output")
+                .handler(ctx -> ToolResult.success("base-done"))
+                .build();
+        Ensemble templateEnsemble = Ensemble.builder().task(baseTask).build();
+        dashboard.setEnsemble(templateEnsemble);
+
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        CountDownLatch ackLatch = new CountDownLatch(1);
+
+        HttpClient client = HttpClient.newHttpClient();
+        ws = client.newWebSocketBuilder()
+                .header("Origin", "http://localhost")
+                .buildAsync(URI.create("ws://localhost:" + dashboard.actualPort() + "/ws"), new WebSocket.Listener() {
+                    @Override
+                    public void onOpen(WebSocket webSocket) {
+                        webSocket.request(20);
+                    }
+
+                    @Override
+                    public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                        if (last) {
+                            String msg = data.toString();
+                            received.add(msg);
+                            if (msg.contains("\"type\":\"run_ack\"")) {
+                                ackLatch.countDown();
+                            }
+                        }
+                        webSocket.request(1);
+                        return null;
+                    }
+                })
+                .get(5, TimeUnit.SECONDS);
+
+        Thread.sleep(200);
+
+        // Level 3: provide a dynamic task list
+        String runRequest =
+                """
+                {
+                  "type": "run_request",
+                  "requestId": "l3-req",
+                  "tasks": [
+                    {
+                      "name": "dynamic-task",
+                      "description": "A dynamic task",
+                      "expectedOutput": "Dynamic output"
+                    }
+                  ]
+                }
+                """;
+
+        ws.sendText(runRequest, true).get(3, TimeUnit.SECONDS);
+
+        // Wait for ack -- could be ACCEPTED or REJECTED (depends on whether handler-only
+        // ensemble can execute dynamic LLM-backed tasks). Either way the dispatch branch runs.
+        assertThat(ackLatch.await(8, TimeUnit.SECONDS)).isTrue();
+
+        String ackMsg = received.stream()
+                .filter(m -> m.contains("\"type\":\"run_ack\""))
+                .findFirst()
+                .orElse("");
+        assertThat(ackMsg).contains("\"requestId\":\"l3-req\"");
+    }
+
+    /**
+     * Sending a malformed run_request (missing required fields that cause a parsing error)
+     * when no ensemble is configured should still result in a REJECTED ack being returned
+     * to the originator without crashing the server.
+     */
+    @Test
+    void runRequest_serverRemainsStableAfterError() throws Exception {
+        CountDownLatch ackLatch = new CountDownLatch(1);
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+
+        HttpClient client = HttpClient.newHttpClient();
+        ws = client.newWebSocketBuilder()
+                .header("Origin", "http://localhost")
+                .buildAsync(URI.create("ws://localhost:" + dashboard.actualPort() + "/ws"), new WebSocket.Listener() {
+                    @Override
+                    public void onOpen(WebSocket webSocket) {
+                        webSocket.request(20);
+                    }
+
+                    @Override
+                    public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                        if (last) {
+                            String msg = data.toString();
+                            received.add(msg);
+                            if (msg.contains("\"type\":\"run_ack\"")) {
+                                ackLatch.countDown();
+                            }
+                        }
+                        webSocket.request(1);
+                        return null;
+                    }
+                })
+                .get(5, TimeUnit.SECONDS);
+
+        Thread.sleep(200);
+
+        // Send a run_request with empty tasks list (will fail validation in parser)
+        // No ensemble is configured, so the no-ensemble path fires first
+        ws.sendText("{\"type\":\"run_request\",\"requestId\":\"err-req\",\"tasks\":[]}", true)
+                .get(3, TimeUnit.SECONDS);
+
+        // Wait for run_ack (REJECTED due to no ensemble or error)
+        assertThat(ackLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Server must still be running
+        assertThat(dashboard.isRunning()).isTrue();
+    }
+}

--- a/agentensemble-web/src/test/java/net/agentensemble/web/WebDashboardRunRequestTest.java
+++ b/agentensemble-web/src/test/java/net/agentensemble/web/WebDashboardRunRequestTest.java
@@ -55,6 +55,7 @@ class WebDashboardRunRequestTest {
     @Test
     void runRequest_noEnsembleConfigured_receivesRejectedAck() throws Exception {
         CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        CountDownLatch helloLatch = new CountDownLatch(1);
         CountDownLatch ackLatch = new CountDownLatch(1);
 
         HttpClient client = HttpClient.newHttpClient();
@@ -69,6 +70,8 @@ class WebDashboardRunRequestTest {
                     @Override
                     public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
                         if (last) {
+                            // First message from server signals ready (hello/connected)
+                            helloLatch.countDown();
                             String msg = data.toString();
                             received.add(msg);
                             if (msg.contains("\"type\":\"run_ack\"")) {
@@ -81,8 +84,8 @@ class WebDashboardRunRequestTest {
                 })
                 .get(5, TimeUnit.SECONDS);
 
-        // Wait for the hello message before sending the run_request
-        Thread.sleep(200);
+        // Wait for the server to send its first message (hello) before sending the run_request
+        assertThat(helloLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
         // Send a run_request; no ensemble is configured so it should be REJECTED
         String runRequest =
@@ -125,6 +128,7 @@ class WebDashboardRunRequestTest {
         dashboard.setEnsemble(templateEnsemble);
 
         CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        CountDownLatch helloLatch = new CountDownLatch(1);
         CountDownLatch ackLatch = new CountDownLatch(1);
         CountDownLatch resultLatch = new CountDownLatch(1);
 
@@ -140,6 +144,8 @@ class WebDashboardRunRequestTest {
                     @Override
                     public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
                         if (last) {
+                            // First message from server signals ready (hello/connected)
+                            helloLatch.countDown();
                             String msg = data.toString();
                             received.add(msg);
                             if (msg.contains("\"type\":\"run_ack\"")) {
@@ -155,7 +161,8 @@ class WebDashboardRunRequestTest {
                 })
                 .get(5, TimeUnit.SECONDS);
 
-        Thread.sleep(200);
+        // Wait for the server hello before sending the run_request
+        assertThat(helloLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
         // Send a Level 1 run_request (inputs only, no tasks or overrides)
         ws.sendText("{\"type\":\"run_request\",\"requestId\":\"l1-req\",\"inputs\":{\"name\":\"World\"}}", true)
@@ -169,7 +176,9 @@ class WebDashboardRunRequestTest {
                 .findFirst()
                 .orElse("");
         assertThat(ackMsg).contains("\"requestId\":\"l1-req\"");
-        // Status should be ACCEPTED (not REJECTED); concurrency limit not reached
+        // Status should be ACCEPTED (not REJECTED); concurrency limit not reached.
+        // getInitialStatus() is used to avoid a race where the run transitions to RUNNING
+        // before the ack message is serialized.
         assertThat(ackMsg).contains("\"status\":\"ACCEPTED\"");
 
         // Wait for the run_result
@@ -187,7 +196,7 @@ class WebDashboardRunRequestTest {
      * list. Covers the Level 3 dispatch branch of {@code handleRunRequest}.
      */
     @Test
-    void runRequest_level3_withDynamicTasks_receivesAcceptedAck() throws Exception {
+    void runRequest_level3_withDynamicTasks_receivesAck() throws Exception {
         Task baseTask = Task.builder()
                 .name("base")
                 .description("Base task")
@@ -198,6 +207,7 @@ class WebDashboardRunRequestTest {
         dashboard.setEnsemble(templateEnsemble);
 
         CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        CountDownLatch helloLatch = new CountDownLatch(1);
         CountDownLatch ackLatch = new CountDownLatch(1);
 
         HttpClient client = HttpClient.newHttpClient();
@@ -212,6 +222,7 @@ class WebDashboardRunRequestTest {
                     @Override
                     public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
                         if (last) {
+                            helloLatch.countDown();
                             String msg = data.toString();
                             received.add(msg);
                             if (msg.contains("\"type\":\"run_ack\"")) {
@@ -224,7 +235,7 @@ class WebDashboardRunRequestTest {
                 })
                 .get(5, TimeUnit.SECONDS);
 
-        Thread.sleep(200);
+        assertThat(helloLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
         // Level 3: provide a dynamic task list
         String runRequest =
@@ -262,6 +273,7 @@ class WebDashboardRunRequestTest {
      */
     @Test
     void runRequest_serverRemainsStableAfterError() throws Exception {
+        CountDownLatch helloLatch = new CountDownLatch(1);
         CountDownLatch ackLatch = new CountDownLatch(1);
         CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
 
@@ -277,6 +289,7 @@ class WebDashboardRunRequestTest {
                     @Override
                     public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
                         if (last) {
+                            helloLatch.countDown();
                             String msg = data.toString();
                             received.add(msg);
                             if (msg.contains("\"type\":\"run_ack\"")) {
@@ -289,7 +302,7 @@ class WebDashboardRunRequestTest {
                 })
                 .get(5, TimeUnit.SECONDS);
 
-        Thread.sleep(200);
+        assertThat(helloLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
         // Send a run_request with empty tasks list (will fail validation in parser)
         // No ensemble is configured, so the no-ensemble path fires first

--- a/docs/design/28-ensemble-control-api.md
+++ b/docs/design/28-ensemble-control-api.md
@@ -1,9 +1,19 @@
 # Design Doc: Ensemble Control API
 
-**Status:** Draft
+**Status:** Phase 2 Implemented
 **Author:** Claude / Matt
 **Module:** `agentensemble-web`
 **Related:** v3 Network features (NetworkTask, NetworkTool, federation)
+
+**Implementation status:**
+
+| Phase | Scope | Status |
+|---|---|---|
+| Phase 1 | ToolCatalog, ModelCatalog, RunManager, Level 1 REST (`POST /api/runs`) | Implemented |
+| Phase 2 | Task naming (`Task.name`), Level 2 overrides, Level 3 dynamic tasks, WS `run_request` | Implemented |
+| Phase 3 | Run control endpoints (`DELETE /api/runs/{id}`, `POST /api/runs/{id}/cancel`) | Planned |
+| Phase 4 | SSE streaming alternative | Planned |
+| Phase 5 | REST review decisions | Planned |
 
 ---
 

--- a/docs/guides/ensemble-control-api.md
+++ b/docs/guides/ensemble-control-api.md
@@ -1,12 +1,16 @@
 # Ensemble Control API
 
-The Ensemble Control API adds HTTP-based run management to the live dashboard. External systems
-(CI pipelines, orchestrators, custom UIs) can submit ensemble runs, query their status, and
-discover available capabilities -- all without compiling Java code.
+The Ensemble Control API adds HTTP-based and WebSocket run management to the live dashboard.
+External systems (CI pipelines, orchestrators, custom UIs) can submit ensemble runs, query their
+status, and discover available capabilities -- all without compiling Java code.
 
-This guide covers **Phase 1**: Level 1 run submission (template + input variables), state queries,
-and capabilities discovery. Phases 2-5 add per-task overrides, dynamic task creation, run control,
-SSE streaming, and REST review decisions.
+This guide covers **Phases 1 and 2**:
+
+- **Phase 1**: Level 1 run submission (template + input variables), state queries, capabilities discovery.
+- **Phase 2**: Task naming (`Task.name`), Level 2 per-task overrides, Level 3 dynamic task creation,
+  WebSocket `run_request` message.
+
+Phases 3-5 add run control (cancel, model switch), SSE streaming, and REST review decisions.
 
 ## Overview
 
@@ -259,11 +263,201 @@ While a run executes, the existing WebSocket dashboard continues to stream all e
 (`task_started`, `tool_called`, `token`, `llm_iteration_started`, etc.) to connected browsers.
 This is unchanged -- the REST Control API and WebSocket dashboard work together transparently.
 
-## Phase 1 limitations
+---
 
-- **Level 1 only**: input variable substitution into the existing template ensemble's tasks.
-  Level 2 (per-task overrides) and Level 3 (dynamic task creation) are planned for Phase 2.
+## Task naming (Phase 2)
+
+Give tasks an optional logical name so they can be referenced in Level 2 overrides and Level 3
+context expressions:
+
+```java
+Task.builder()
+    .name("researcher")            // new -- optional but recommended for API use
+    .description("Research {topic} developments in {year}")
+    .expectedOutput("A detailed report")
+    .tools(webSearchTool)
+    .build()
+```
+
+- Names must be non-blank when set.
+- `GET /api/capabilities` returns task names alongside descriptions.
+- Level 2 override keys match by **exact name** first, then by **description prefix** (first
+  50 chars, case-insensitive).
+- Level 3 context references use `$name` syntax.
+
+---
+
+## Level 2: Per-task overrides (Phase 2)
+
+Override specific fields of the template ensemble's tasks at runtime -- no recompilation needed:
+
+```json
+POST /api/runs
+{
+  "inputs": { "topic": "AI safety" },
+  "taskOverrides": {
+    "researcher": {
+      "description": "Research {topic} focusing on EU AI Act compliance",
+      "expectedOutput": "A regulatory analysis report with citations",
+      "model": "sonnet",
+      "maxIterations": 15,
+      "additionalContext": "The EU AI Act was formally adopted in March 2024.",
+      "tools": {
+        "add": ["web_search"],
+        "remove": ["calculator"]
+      }
+    }
+  }
+}
+```
+
+The override key (`"researcher"`) is matched against the template ensemble's task names. If no task
+with that name exists, the request is rejected with 400.
+
+**Supported override fields:**
+
+| Field | Type | Semantics |
+|---|---|---|
+| `description` | string | Replaces task description. Supports `{variable}` templates. |
+| `expectedOutput` | string | Replaces expected output. |
+| `model` | string | Model alias resolved from `ModelCatalog`. Replaces `chatLanguageModel`. |
+| `maxIterations` | int | Replaces max tool-call iteration count. |
+| `additionalContext` | string | Appended to the task description (not replacing). |
+| `tools.add` | string[] | Tool names resolved from `ToolCatalog` and added to the task's tool list. |
+| `tools.remove` | string[] | Tool names resolved from `ToolCatalog` and removed from the task's tool list. |
+
+**Task matching rules:**
+
+1. Exact `name` match (case-insensitive).
+2. Fallback: first 50 characters of task `description` compared case-insensitively.
+
+The original task objects are never mutated -- `Task.toBuilder()` creates modified copies.
+
+---
+
+## Level 3: Dynamic task creation (Phase 2)
+
+Define an entirely new task list at runtime without changing any Java code:
+
+```json
+POST /api/runs
+{
+  "tasks": [
+    {
+      "name": "researcher",
+      "description": "Research the competitive landscape for {product}",
+      "expectedOutput": "A competitive analysis identifying 5 key competitors",
+      "tools": ["web_search"],
+      "model": "sonnet",
+      "maxIterations": 20
+    },
+    {
+      "name": "writer",
+      "description": "Write an executive brief based on the research",
+      "expectedOutput": "A 1-page executive summary suitable for C-suite",
+      "context": ["$researcher"],
+      "model": "sonnet"
+    }
+  ],
+  "inputs": { "product": "AgentEnsemble" }
+}
+```
+
+When `tasks` is provided, the template ensemble's task list is replaced with the dynamic list.
+The template's model, catalogs, and other settings (rate limits, workflow, etc.) are preserved.
+
+**Task definition fields:**
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | No | Logical name. Used for `$name` context references. |
+| `description` | **Yes** | What the agent should do. Supports `{variable}` templates. |
+| `expectedOutput` | No | Expected output. Defaults to `Task.DEFAULT_EXPECTED_OUTPUT`. |
+| `tools` | No | Tool names resolved from `ToolCatalog`. |
+| `model` | No | Model alias resolved from `ModelCatalog`. Falls back to template default. |
+| `maxIterations` | No | Max ReAct loop iterations. Default: 25. |
+| `context` | No | `$name` or `$N` (0-based index) references to predecessor tasks. |
+| `outputSchema` | No | JSON Schema injected as structured output instructions into `expectedOutput`. |
+| `additionalContext` | No | Extra text appended to the task description. |
+
+**Context DAG (`context` field):**
+
+```json
+"context": ["$researcher"]   // by name
+"context": ["$0"]            // by index (0-based position in the tasks array)
+```
+
+- Circular dependencies are detected and rejected (400).
+- Unknown names or out-of-bounds indices are rejected (400).
+- When context dependencies exist and no explicit workflow is set, `PARALLEL` (DAG-based) is
+  automatically inferred.
+
+---
+
+## WebSocket run submission (Phase 2)
+
+As an alternative to REST, WebSocket clients can submit runs using the `run_request` message.
+This lets browser-based UIs and long-lived WS clients kick off runs without an additional HTTP
+round-trip.
+
+**Client sends:**
+
+```json
+{
+  "type": "run_request",
+  "requestId": "req-1",
+  "inputs": { "topic": "AI safety" },
+  "tasks": [...],
+  "taskOverrides": {...},
+  "options": { "maxToolOutputLength": 5000 },
+  "tags": { "env": "staging" }
+}
+```
+
+All fields except `type` are optional. Level detection: if `tasks` is present, Level 3 is used;
+else if `taskOverrides` is present, Level 2 is used; otherwise Level 1.
+
+**Server responds immediately (`run_ack`):**
+
+```json
+{
+  "type": "run_ack",
+  "requestId": "req-1",
+  "runId": "run-7f3a2b",
+  "status": "ACCEPTED",
+  "tasks": 2,
+  "workflow": "SEQUENTIAL"
+}
+```
+
+**On completion, the server sends `run_result` to the originating session only:**
+
+```json
+{
+  "type": "run_result",
+  "runId": "run-7f3a2b",
+  "status": "COMPLETED",
+  "outputs": [
+    { "taskName": "researcher", "output": "...", "durationMs": 8200 },
+    { "taskName": "writer", "output": "...", "durationMs": 3100 }
+  ],
+  "durationMs": 11340,
+  "metrics": { "totalTokens": 15230, "totalToolCalls": 7 }
+}
+```
+
+The `run_result` is targeted to the submitting session only. The existing `ensemble_completed`
+broadcast continues to go to all connected clients (backwards compatible).
+
+When no template ensemble is configured (`setEnsemble()` has not been called), the server
+immediately responds with a `run_ack` carrying `status: "REJECTED"`.
+
+---
+
+## Current limitations (Phases 3-5 planned)
+
 - **No run cancellation**: mid-run cancel is planned for Phase 3.
+- **No model switch mid-run**: planned for Phase 3.
 - **No SSE streaming**: event streaming for HTTP clients is planned for Phase 4.
 - **No REST review decisions**: REST-based human review is planned for Phase 5.
 

--- a/docs/reference/task-configuration.md
+++ b/docs/reference/task-configuration.md
@@ -16,6 +16,7 @@ the synthesized agent when no explicit `agent` is set.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
+| `name` | `String` | No | `null` | Optional logical name for this task. Used by the Ensemble Control API (Phase 2+) for Level 2 task-override matching and Level 3 `$name` context references. Also exposed via `GET /api/capabilities`. Names must be non-blank when set. |
 | `description` | `String` | Yes | -- | What the agent should do. Supports `{variable}` template placeholders. |
 | `expectedOutput` | `String` | Yes | `"Produce a complete and accurate response to the task."` (when using `Task.of(String)`) | What the output should look like. Included in the agent's prompt. Supports `{variable}` placeholders. |
 | `agent` | `Agent` | No | `null` | Explicit agent assigned to this task. When null, an agent is synthesized from the description using the ensemble's `AgentSynthesizer`. |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,6 +3,55 @@
 
 ## Current Work
 
+**Ensemble Control API Phase 2 (GH #300)** -- Level 2/3 parameterization and WebSocket run submission.
+
+### What was implemented
+
+Four areas of new functionality across `agentensemble-core` and `agentensemble-web`:
+
+**Task naming (`agentensemble-core`):**
+- Added optional `String name` field to `Task` (first field in declaration, before `description`).
+- Non-blank validation when set; null default preserves all existing code paths.
+- `toBuilder()` correctly carries `name` through.
+
+**Level 2: Per-task overrides (`agentensemble-web`):**
+- `RunRequestParser.buildFromTemplateWithOverrides()` applies runtime overrides to the template
+  ensemble's task list using `Task.toBuilder()`. Original tasks are never mutated.
+- Override key matching: exact `Task.name` first (case-insensitive), then description prefix
+  (first 50 chars, case-insensitive).
+- Override fields: `description`, `expectedOutput`, `model` (ModelCatalog), `maxIterations`,
+  `additionalContext` (appended to description), `tools.add`/`tools.remove` (ToolCatalog).
+- `RunConfiguration` record gained `List<Task> overrideTasks` (null for Level 1).
+
+**Level 3: Dynamic task creation (`agentensemble-web`):**
+- `RunRequestParser.buildFromDynamicTasks()` builds a full task list from JSON definitions.
+- Context DAG resolution: `$name` and `$N` (0-based index) references.
+- Circular dependency detection using Kahn's topological sort algorithm.
+- `outputSchema` (JSON Schema) injected as structured output instructions into `expectedOutput`.
+
+**WebSocket run submission (`agentensemble-web`):**
+- New `RunRequestMessage` protocol record (Level 1/2/3 in one message).
+- `ClientMessage` sealed interface updated (added `RunRequestMessage`).
+- `WebDashboard.handleRunRequest()` dispatches to Level 1/2/3 parser, calls
+  `RunManager.submitRun()`, sends `run_ack` immediately, sends `run_result` on completion
+  targeted to originating session only.
+- `Ensemble.withTasks(List<Task>)` -- new method that copies the template ensemble's key execution
+  settings but replaces the task list. Used by `handleRunRequest` for Level 2/3 runs.
+- `WebDashboard.parseRunOptions()` -- converts raw options map to `RunOptions`.
+
+**Tests added:**
+- `TaskTest` -- 8 new tests for `Task.name` field
+- `RunRequestParserTest` -- 58 tests total (Level 1/2/3, all override fields, DAG, error cases)
+- `RunRequestMessageTest` -- 10 serialization/deserialization tests
+- `WebDashboardRunRequestTest` -- 4 WS integration tests (no-ensemble REJECTED, Level 1 ACCEPTED,
+  Level 3 dispatch, server stability)
+
+**Build:** All tests pass. Coverage meets thresholds. Spotless formatting clean.
+
+---
+
+## Previous Work
+
 **`agentensemble-executor` module** -- direct in-process invocation from external workflow engines.
 
 ### What was implemented

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,6 +3,53 @@
 
 ## Current Work
 
+**PR #308 review feedback addressed** -- fixing CI failure and all 11 Copilot review comments.
+
+### PR #308 fixes (on branch `feat/300-ensemble-control-api-phase2`)
+
+**Failing test fix (RunState race condition):**
+- `WebDashboardRunRequestTest#runRequest_level1_withEnsemble_receivesAcceptedAckAndResult` was
+  failing because handler tasks complete near-instantaneously, causing `state.getStatus()` to
+  return `RUNNING` by the time the run_ack was serialized.
+- Fix: added `private final Status initialStatus` (immutable) to `RunState` + `getInitialStatus()`.
+- `WebDashboard.handleRunRequest()` now uses `state.getInitialStatus().name()` for the ack.
+
+**RunRequestParser fixes (7 Copilot comments):**
+- `additionalContext` ordering: pre-computed description deterministically (description override
+  first, then additionalContext appended) before the switch loop, eliminating Map iteration
+  order dependency.
+- Tool removal by name: changed from reference equality (`t == resolved`) to
+  `t instanceof AgentTool at && at.name().equals(toolName)`. Resolves failures when the task's
+  tool was constructed outside the catalog.
+- Tool add de-duplication: added name-based pre-check before adding to prevent duplicates.
+- `expectedOutput` type validation: explicit `instanceof String` check with clear error message.
+- Tool name type validation: explicit `instanceof String && !isBlank()` check.
+- `context` field validation: validates it's a List before casting; validates each entry is String.
+- `findTaskIndex` Locale: all `toLowerCase()` calls updated to `toLowerCase(Locale.ROOT)`.
+- Added `import java.util.Locale`.
+
+**Ensemble.withTasks() (1 Copilot comment):**
+- Added empty list check (`IAE`) and null element check (per-index NPE) with useful messages.
+- Updated Javadoc `@param`/`@throws` to document new contracts.
+
+**WebDashboard + WebSocketServer (2 Copilot comments):**
+- Both `handleRunRequest` (WS) and `resolveExecutionEnsemble` (REST) now reject requests where
+  `tasks` is present-but-empty or `taskOverrides` is present-but-empty (IAE / REJECTED ack).
+
+**Test improvements (2 Copilot comments):**
+- `WebDashboardRunRequestTest`: replaced all `Thread.sleep(200)` with latch-based `helloLatch`
+  waiting for the first server message (eliminates fixed-time flakiness on CI).
+- Renamed L3 test to `runRequest_level3_withDynamicTasks_receivesAck` (matches actual assertions).
+
+**Coverage (Codecov comment):**
+- Added 9 `withTasks()` tests in `EnsembleTest` covering happy path, preserving settings, and
+  the three new validation error cases.
+- Added 14 new tests in `RunRequestParserTest` covering all the new validations and behavior
+  fixes (expectedOutput type, tool name type, context type, additionalContext ordering, tool
+  removal by name, dedup on add).
+
+---
+
 **Ensemble Control API Phase 2 (GH #300)** -- Level 2/3 parameterization and WebSocket run submission.
 
 ### What was implemented

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased] -- 2026-04-10
+### Added
+- **Ensemble Control API Phase 2 (GH #300)**
+  - `Task.name` -- optional logical name field on `Task` for API task matching and context references
+  - `RunRequestParser.buildFromTemplateWithOverrides()` -- Level 2 per-task overrides at runtime
+    (description, expectedOutput, model, maxIterations, additionalContext, tools add/remove)
+  - `RunRequestParser.buildFromDynamicTasks()` -- Level 3 fully dynamic task list from JSON;
+    context DAG via `$name`/`$N` references; circular dependency detection (Kahn's algorithm)
+  - `RunRequestMessage` -- new `ClientMessage` for WebSocket run submission (Level 1/2/3)
+  - `WebDashboard.handleRunRequest()` -- WS handler dispatches Level 1/2/3; sends `run_ack`
+    immediately and `run_result` on completion to originating session only
+  - `Ensemble.withTasks(List<Task>)` -- copies template ensemble settings with a new task list
+  - `RunConfiguration.overrideTasks` -- new field (null for Level 1, non-null for Level 2/3)
+  - Tests: `TaskTest` (8 name field tests), `RunRequestParserTest` (58 tests covering all
+    override fields, DAG resolution, error cases), `RunRequestMessageTest` (10 serde tests),
+    `WebDashboardRunRequestTest` (4 WS integration tests)
+  - Docs: updated `docs/design/28-ensemble-control-api.md` (Phase 2 Implemented status),
+    `docs/guides/ensemble-control-api.md` (Phase 2 sections), `docs/reference/task-configuration.md`
+    (`name` field entry)
+
 ## [Unreleased] -- 2026-04-09
 ### Added
 - **`agentensemble-executor` module**: Orchestrator-agnostic direct in-process invocation

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -2620,6 +2620,31 @@ Key design decisions:
 
 ## [Unreleased]
 
+### Fixed (PR #308 review feedback)
+- **RunState race condition**: `handleRunRequest` ack was serialized with `state.getStatus()` which
+  could read `RUNNING` if the handler task completed before the ack was sent. Fixed by adding
+  immutable `initialStatus` field and `getInitialStatus()` to `RunState`; ack now uses
+  `state.getInitialStatus().name()` (always `ACCEPTED` or `REJECTED`).
+- **RunRequestParser -- additionalContext ordering**: pre-computed final description (description
+  override + additionalContext) before the switch loop to eliminate Map iteration order dependency.
+- **RunRequestParser -- tool removal by name**: changed `t == resolved` to name-based
+  `AgentTool.name()` equality; also added de-duplication on tool add.
+- **RunRequestParser -- type validation**: added explicit `instanceof String` checks for
+  `expectedOutput`, tool names, and context entries with useful error messages instead of
+  `ClassCastException`.
+- **RunRequestParser -- Locale.ROOT**: all `toLowerCase()` calls in `findTaskIndex` use
+  `Locale.ROOT`.
+- **Ensemble.withTasks()**: added empty list check (`IAE`) and null element check (NPE).
+- **WebDashboard + WebSocketServer**: reject `tasks: []` and `taskOverrides: {}` as malformed
+  (return REJECTED ack / 400 instead of silently falling through to Level 1).
+
+### Tests
+- `WebDashboardRunRequestTest`: replaced `Thread.sleep(200)` with `helloLatch` (waits for
+  first server message); renamed L3 test to `receivesAck`.
+- Added 9 `withTasks()` tests to `EnsembleTest` for coverage.
+- Added 14 new tests to `RunRequestParserTest` covering new validations.
+
+
 ### Added (Issue #179, PR #180)
 - `EnsembleDashboard.traceExporter()` default method in core SPI
 - `WebDashboard.builder().traceExportDir(Path)` -- convenience shortcut; auto-wires `JsonTraceExporter` via `Ensemble.builder().webDashboard()`

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,29 @@
 # Progress
 
+## What Works (as of 2026-04-10 -- Ensemble Control API Phase 2, GH #300)
+
+**Ensemble Control API Phase 2:**
+- `Task.name` -- optional logical name; non-blank validation; preserved by `toBuilder()`
+- `RunRequestParser.buildFromTemplateWithOverrides()` -- Level 2 per-task runtime overrides:
+  description, expectedOutput, model (ModelCatalog), maxIterations, additionalContext (appended),
+  tools.add / tools.remove (ToolCatalog); task matching by exact name then description prefix
+- `RunRequestParser.buildFromDynamicTasks()` -- Level 3 dynamic task list from JSON; `$name`
+  and `$N` context references; Kahn's topological sort for circular dependency detection;
+  outputSchema injected into expectedOutput
+- `RunConfiguration.overrideTasks` -- null for Level 1, non-null List for Level 2/3
+- `RunRequestMessage` -- new `ClientMessage` for WebSocket run submission (all three levels)
+- `ClientMessage` sealed interface updated to include `RunRequestMessage`
+- `WebDashboard.handleRunRequest()` -- WS handler; Level 1/2/3 dispatch; `run_ack` sent
+  immediately; `run_result` targeted to originating session on completion
+- `Ensemble.withTasks(List<Task>)` -- copy of template ensemble with replacement task list;
+  used by WS handler for Level 2/3 execution
+- `WebDashboard.parseRunOptions()` -- converts raw options map to `RunOptions`
+- Tests: 80+ new tests across `TaskTest`, `RunRequestParserTest`, `RunRequestMessageTest`,
+  `WebDashboardRunRequestTest`
+- Build: all modules pass, coverage meets thresholds, Spotless clean
+- Docs: design doc updated, guide extended with Phase 2 sections, task-configuration reference
+  updated with `name` field
+
 ## What Works (as of 2026-03-09 -- "Why AgentEnsemble?" comparison content)
 
 **Landing page, README, and docs comparison section:**


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the Ensemble Control API (GH #300), adding Level 2 per-task runtime overrides, Level 3 dynamic task creation, and WebSocket run submission.

Depends on: #299 (Phase 1, merged)

---

## Changes

### Task Naming (`agentensemble-core`)

- Added optional `Task.name` field (non-blank validation, preserved by `toBuilder()`)
- `GET /api/capabilities` now includes task names in `preconfiguredTasks`

### Level 2: Per-Task Overrides (`agentensemble-web`)

- `RunRequestParser.buildFromTemplateWithOverrides()`: match tasks by exact name (case-insensitive) or description prefix (50 chars); apply description, expectedOutput, model, maxIterations, additionalContext, tools.add/remove
- `RunConfiguration` record gains `overrideTasks` field (null for Level 1)
- `POST /api/runs` REST endpoint now accepts `taskOverrides` body field

### Level 3: Dynamic Task Creation (`agentensemble-web`)

- `RunRequestParser.buildFromDynamicTasks()`: build full task list from JSON; `$name`/`$N` context references; Kahn's topological sort for circular dependency detection; `outputSchema` injected as structured output instruction
- `POST /api/runs` REST endpoint now accepts `tasks` body field

### WebSocket Run Submission (`agentensemble-web`)

- New `RunRequestMessage` protocol record (Level 1/2/3 in one message type)
- `ClientMessage` sealed interface updated with `RunRequestMessage`
- `WebDashboard.handleRunRequest()`: Level 1/2/3 dispatch, sends `run_ack` immediately, sends `run_result` targeted to originating session on completion
- `Ensemble.withTasks(List<Task>)`: copy of template ensemble with replacement task list (used for Level 2/3 execution)

---

## Tests Added

| Test file | New tests | Coverage |
|-----------|-----------|----------|
| `TaskTest` | 8 | `Task.name` field |
| `RunRequestParserTest` | 50+ | L1/2/3 override fields, DAG resolution, error cases |
| `RunRequestMessageTest` | 10 | Serialization round-trips |
| `WebDashboardRunRequestTest` | 4 | WS integration (no-ensemble REJECTED, L1 ACCEPTED + result, L3 dispatch) |

All 17 files changed, 2600 insertions. Build: **all tests pass**, coverage thresholds met, Spotless clean.

---

## Documentation

- `docs/design/28-ensemble-control-api.md` -- Phase 2 Implemented status + implementation table
- `docs/guides/ensemble-control-api.md` -- Phase 2 sections: task naming, Level 2, Level 3, WS submission
- `docs/reference/task-configuration.md` -- `name` field entry

Closes #300