### PR TITLE
docs: correct release notes from v4.0.0 to v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Unreleased — v4.0.0 (Loop & Graph)
+## Unreleased — v3.5.0 (Loop & Graph)
 
-> Major release: two new top-level workflow constructs (`Loop` and `Graph`) plus the
-> shared `WorkflowNode` infrastructure they sit on. No breaking changes; both are
-> additive. See the [v4.0.0 release notes](docs/release-notes/v4.0.0.md) for the full
-> story.
+> Two new top-level workflow constructs (`Loop` and `Graph`) plus the shared
+> `WorkflowNode` infrastructure they sit on. No breaking changes; both are additive.
+> See the [v3.5.0 release notes](docs/release-notes/v3.5.0.md) for the full story.
 
 ### Features
 

--- a/docs/release-notes/v3.5.0.md
+++ b/docs/release-notes/v3.5.0.md
@@ -1,4 +1,4 @@
-# v4.0.0 — Loop & Graph
+# v3.5.0 — Loop & Graph
 
 > **Headline**: AgentEnsemble gains two new top-level workflow constructs — **`Loop`** for
 > bounded iteration and **`Graph`** for state-machine flows with arbitrary back-edges. Full

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,7 @@ nav:
     - Long-Running Ensemble: examples/long-running-ensemble.md
     - Cross-Ensemble Delegation: examples/cross-ensemble-delegation.md
   - Release notes:
-    - v4.0.0 (Loop & Graph): release-notes/v4.0.0.md
+    - v3.5.0 (Loop & Graph): release-notes/v3.5.0.md
   - Migration:
     - v1.x to v2.0: migration/v1-to-v2.md
     - Typed Tool Inputs: migration/typed-tool-inputs.md


### PR DESCRIPTION
## Summary

Follow-up to #324. The Loop + Graph release ships as **3.5.0** (minor bump from `feat:`, no breaking changes), not 4.0.0. The release-notes file landed mislabelled.

- Renamed `docs/release-notes/v4.0.0.md` → `docs/release-notes/v3.5.0.md`
- Updated the file's heading
- Updated `mkdocs.yml` nav entry
- Updated `CHANGELOG.md` heading + inline link

## Test plan

- [x] `mkdocs build --strict` clean