### PR TITLE
fix: revivable MCP lifecycle + Ensemble.managedResource() binding

### DIFF
--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -45,6 +45,7 @@ import net.agentensemble.ensemble.BroadcastHandler;
 import net.agentensemble.ensemble.EnsembleLifecycleState;
 import net.agentensemble.ensemble.EnsembleOutput;
 import net.agentensemble.ensemble.EnsembleScheduler;
+import net.agentensemble.ensemble.ManagedResource;
 import net.agentensemble.ensemble.ScheduledTask;
 import net.agentensemble.ensemble.SharedCapability;
 import net.agentensemble.ensemble.SharedCapabilityType;
@@ -601,6 +602,38 @@ public class Ensemble {
     private final BroadcastHandler broadcastHandler;
 
     /**
+     * External resources whose lifecycle is bound to this ensemble.
+     *
+     * <p>Each entry is a {@link ManagedResource} (typically an MCP server lifecycle) that
+     * the ensemble starts before its first run -- and before transitioning to {@code READY}
+     * in long-running mode -- and closes on {@link #stop()} when the ensemble owns the
+     * resource. Ownership is decided at registration time: a resource that was already
+     * running when {@link EnsembleBuilder#managedResource(ManagedResource)} was called is
+     * treated as caller-owned and is never closed by the ensemble.
+     *
+     * <p>Resources are NOT closed at the end of one-shot {@link #run()} calls -- they are
+     * intended to outlive individual runs so the same MCP subprocess can be reused across
+     * many invocations from the same long-running process. This is the entire point of the
+     * facility; closing per-run would just reproduce the bug it exists to fix.
+     *
+     * <p>Not annotated with {@code @Singular} or {@code @Builder.Default} because the
+     * builder method needs to record ownership alongside the resource itself. Managed
+     * identically to {@link #scheduledTasks} and {@link #sharedCapabilities}.
+     *
+     * @see ManagedResource
+     * @see EnsembleBuilder#managedResource(ManagedResource)
+     */
+    private final List<ManagedResource> managedResources;
+
+    /**
+     * Set of {@link ManagedResource} instances (by identity) that this ensemble owns and
+     * therefore must close on {@link #stop()}. Populated in parallel with
+     * {@link #managedResources} by the builder. Resources that were already running when
+     * registered are absent from this set and survive ensemble shutdown.
+     */
+    private final java.util.Set<ManagedResource> ownedManagedResources;
+
+    /**
      * Optional audit policy for leveled audit trail with dynamic rules.
      *
      * <p>When set alongside {@link #auditSinks}, an {@link AuditingListener} is automatically
@@ -783,6 +816,10 @@ public class Ensemble {
                 dashboard.start();
             }
 
+            // Start any managed resources (e.g. MCP server subprocesses) before the
+            // ensemble is reachable from the network. Failures are logged, not fatal.
+            startManagedResources();
+
             // Wire lifecycle state, drain action, request handler, and directive store into the dashboard
             dashboard.setLifecycleStateProvider(this::getLifecycleState);
             dashboard.setDrainAction(this::stop);
@@ -838,6 +875,59 @@ public class Ensemble {
     }
 
     /**
+     * Start every registered {@link ManagedResource} that is not already running.
+     *
+     * <p>Called from both {@link #runWithInputs} (so one-shot runs benefit) and
+     * {@link #start(int)} (so long-running mode benefits). Safe to call repeatedly --
+     * each resource's own {@link ManagedResource#start()} is required to be idempotent for
+     * the running case, and revivable for the closed case.
+     *
+     * <p>Failures are logged but do not abort the ensemble: a managed resource startup
+     * failure typically surfaces as a tool execution failure later, which the agent can
+     * report back to the LLM. Aborting the run here would be over-eager because not every
+     * task may actually use the failing resource.
+     */
+    private void startManagedResources() {
+        if (managedResources == null || managedResources.isEmpty()) {
+            return;
+        }
+        for (ManagedResource resource : managedResources) {
+            try {
+                if (!resource.isRunning()) {
+                    resource.start();
+                }
+            } catch (Exception e) {
+                if (log.isWarnEnabled()) {
+                    log.warn("Failed to start managed resource {}: {}", resource, e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Close every owned managed resource. Called from {@link #stop()} during long-running
+     * shutdown. Caller-owned resources (those that were already running at registration
+     * time) are deliberately left alone -- the caller retains lifecycle responsibility.
+     */
+    private void closeOwnedManagedResources() {
+        if (managedResources == null || managedResources.isEmpty() || ownedManagedResources == null) {
+            return;
+        }
+        for (ManagedResource resource : managedResources) {
+            if (!ownedManagedResources.contains(resource)) {
+                continue;
+            }
+            try {
+                resource.close();
+            } catch (Exception e) {
+                if (log.isWarnEnabled()) {
+                    log.warn("Failed to close managed resource {}: {}", resource, e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    /**
      * Initiate shutdown of a long-running ensemble.
      *
      * <p>The ensemble transitions to {@link EnsembleLifecycleState#DRAINING}, stops the
@@ -888,6 +978,10 @@ public class Ensemble {
                 dashboard.stop();
             }
         } finally {
+            // Close any managed resources we own (e.g. MCP server subprocesses started by
+            // the builder). Caller-owned resources -- those that were already running when
+            // registered -- are deliberately left alone.
+            closeOwnedManagedResources();
             lifecycleStateRef.set(EnsembleLifecycleState.STOPPED);
             log.info("Ensemble stopped");
         }
@@ -1368,6 +1462,12 @@ public class Ensemble {
                     }
                 }
             }
+
+            // Ensure registered managed resources (e.g. MCP server subprocesses) are
+            // running before tasks fire. ManagedResource.start() must be safe to call when
+            // already running, so this is cheap on subsequent runs and revives any
+            // resource that was closed in between.
+            startManagedResources();
 
             // Wire directive store into the dashboard so incoming directives are routed
             // to the ensemble's store regardless of how the dashboard was started.
@@ -2593,6 +2693,13 @@ public class Ensemble {
         // Audit sinks accumulator (same pattern as phases and sharedCapabilities).
         private List<AuditSink> auditSinks = List.of();
 
+        // Managed resources accumulator. Same pattern as scheduledTasks: a custom builder
+        // method records the resource alongside its ownership. Field types match the
+        // outer Ensemble class so Lombok wires them through the generated build().
+        private List<ManagedResource> managedResources = List.of();
+        private java.util.Set<ManagedResource> ownedManagedResources =
+                Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+
         // Auto-directive rules accumulator (same pattern as phases and sharedCapabilities).
         private List<AutoDirectiveRule> autoDirectiveRules = List.of();
 
@@ -2623,6 +2730,73 @@ public class Ensemble {
          */
         public EnsembleBuilder broadcastHandler(BroadcastHandler broadcastHandler) {
             this.broadcastHandler = broadcastHandler;
+            return this;
+        }
+
+        /**
+         * Bind an external resource to this ensemble's lifecycle.
+         *
+         * <p>The canonical use is wiring an MCP server subprocess so it lives across many
+         * runs of the same long-running process and is cleaned up when the ensemble stops:
+         * <pre>
+         * McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);
+         * Ensemble kitchen = Ensemble.builder()
+         *     .chatLanguageModel(model)
+         *     .webDashboard(WebDashboard.onPort(7329))
+         *     .managedResource(fs)
+         *     .scheduledTask(ScheduledTask.builder()
+         *         .name("hourly-report")
+         *         .task(Task.builder().description("...").tools(fs.tools()).build())
+         *         .schedule(Schedule.every(Duration.ofHours(1)))
+         *         .build())
+         *     .build();
+         *
+         * kitchen.start(7329);  // ensemble starts fs
+         * // ... fs stays up across every scheduled firing ...
+         * kitchen.stop();       // ensemble closes fs (it owns the lifecycle)
+         * </pre>
+         *
+         * <p>Ownership is decided by whether the resource is already running at registration
+         * time. A not-yet-running resource is owned by the ensemble: it is started during
+         * {@link Ensemble#run()} or {@link Ensemble#start(int)} and closed during
+         * {@link Ensemble#stop()}. A resource that is already running is treated as
+         * caller-owned and is never closed by the ensemble.
+         *
+         * <p>Resources are NOT closed at the end of one-shot {@link Ensemble#run()} calls --
+         * they outlive individual runs by design, so the same MCP subprocess can serve
+         * many invocations from the same long-running process. Closing per-run would
+         * recreate the bug this facility exists to fix.
+         *
+         * <p>May be called multiple times; each call adds another resource. Resources are
+         * started in registration order and closed in registration order (not reverse) on
+         * shutdown.
+         *
+         * @param resource the resource to bind to this ensemble; must not be null
+         * @return this builder
+         */
+        public EnsembleBuilder managedResource(ManagedResource resource) {
+            Objects.requireNonNull(resource, "managedResource must not be null");
+            // Decide ownership before potentially starting it -- mirrors webDashboard()'s
+            // contract. A resource that was already running when registered is caller-owned
+            // and will NOT be closed by the ensemble's stop().
+            boolean alreadyRunning = resource.isRunning();
+            if (!alreadyRunning) {
+                // Start immediately so callers can do .managedResource(fs).agent(... fs.tools() ...)
+                // without an explicit fs.start() call. The runWithInputs/start hooks will
+                // re-start later only if it has been closed by then (start() must be a
+                // safe no-op when already running, per the ManagedResource contract).
+                resource.start();
+            }
+            List<ManagedResource> updated = new ArrayList<>(this.managedResources);
+            updated.add(resource);
+            this.managedResources = List.copyOf(updated);
+            if (!alreadyRunning) {
+                java.util.Set<ManagedResource> updatedOwned =
+                        Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+                updatedOwned.addAll(this.ownedManagedResources);
+                updatedOwned.add(resource);
+                this.ownedManagedResources = updatedOwned;
+            }
             return this;
         }
 

--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -605,11 +605,13 @@ public class Ensemble {
      * External resources whose lifecycle is bound to this ensemble.
      *
      * <p>Each entry is a {@link ManagedResource} (typically an MCP server lifecycle) that
-     * the ensemble starts before its first run -- and before transitioning to {@code READY}
-     * in long-running mode -- and closes on {@link #stop()} when the ensemble owns the
-     * resource. Ownership is decided at registration time: a resource that was already
-     * running when {@link EnsembleBuilder#managedResource(ManagedResource)} was called is
-     * treated as caller-owned and is never closed by the ensemble.
+     * was started by {@link EnsembleBuilder#managedResource(ManagedResource)} at
+     * registration time (a synchronous side effect of that builder method, not deferred to
+     * {@code build()}). On every subsequent {@link #run()} and {@link #start(int)} call,
+     * any owned resource that has been closed in the meantime is revived; the ensemble
+     * closes owned resources on {@link #stop()}. Ownership is decided at registration
+     * time: a resource that was already running when registered is treated as
+     * caller-owned and is never started or closed by the ensemble.
      *
      * <p>Resources are NOT closed at the end of one-shot {@link #run()} calls -- they are
      * intended to outlive individual runs so the same MCP subprocess can be reused across
@@ -620,9 +622,15 @@ public class Ensemble {
      * builder method needs to record ownership alongside the resource itself. Managed
      * identically to {@link #scheduledTasks} and {@link #sharedCapabilities}.
      *
+     * <p>{@code @Getter(NONE)}: this is internal lifecycle bookkeeping. Exposing the
+     * raw list via a Lombok getter would let external callers mutate it and change
+     * which resources {@link #stop()} closes. Use the dedicated read-only accessor
+     * {@link #getManagedResources()} below for inspection.
+     *
      * @see ManagedResource
      * @see EnsembleBuilder#managedResource(ManagedResource)
      */
+    @Getter(lombok.AccessLevel.NONE)
     private final List<ManagedResource> managedResources;
 
     /**
@@ -630,8 +638,23 @@ public class Ensemble {
      * therefore must close on {@link #stop()}. Populated in parallel with
      * {@link #managedResources} by the builder. Resources that were already running when
      * registered are absent from this set and survive ensemble shutdown.
+     *
+     * <p>{@code @Getter(NONE)}: ownership is an implementation detail; exposing the
+     * mutable identity-keyed set would let callers silently flip a caller-owned resource
+     * to ensemble-owned (or vice versa), which would cause unintended shutdowns or leaks.
      */
+    @Getter(lombok.AccessLevel.NONE)
     private final java.util.Set<ManagedResource> ownedManagedResources;
+
+    /**
+     * Read-only view of the {@link ManagedResource} instances registered on this ensemble.
+     * Returns an unmodifiable list; the underlying registration order is preserved.
+     *
+     * @return registered managed resources, never null
+     */
+    public List<ManagedResource> getManagedResources() {
+        return managedResources != null ? managedResources : List.of();
+    }
 
     /**
      * Optional audit policy for leveled audit trail with dynamic rules.
@@ -1327,7 +1350,18 @@ public class Ensemble {
                 throw new NullPointerException("newTasks must not contain null elements (at index " + i + ")");
             }
         }
-        return Ensemble.builder()
+        EnsembleBuilder withTasksBuilder = Ensemble.builder();
+        // Re-register every managed resource so child runs can still see the MCP tools'
+        // backing lifecycle. The template owns the lifecycle and the resources are
+        // already running, so managedResource() correctly classifies each as caller-owned
+        // -- the child never starts or closes them, matching the dashboard ownership
+        // pattern (ownsDashboardLifecycle=false) used below.
+        if (managedResources != null) {
+            for (ManagedResource r : managedResources) {
+                withTasksBuilder.managedResource(r);
+            }
+        }
+        return withTasksBuilder
                 // Replace the task list; phases are intentionally not copied
                 // (API-submitted runs always use the flat task list)
                 .tasks(newTasks)
@@ -1404,6 +1438,14 @@ public class Ensemble {
             }
         } else {
             b.tasks(tasks);
+        }
+        // Re-register managed resources so child runs see the same MCP-backing lifecycles
+        // as the template. The resources are already running, so managedResource() classifies
+        // each as caller-owned -- the child never starts or closes them.
+        if (managedResources != null) {
+            for (ManagedResource r : managedResources) {
+                b.managedResource(r);
+            }
         }
         return b.chatLanguageModel(chatLanguageModel)
                 .streamingChatLanguageModel(streamingChatLanguageModel)
@@ -2742,6 +2784,16 @@ public class Ensemble {
         /**
          * Bind an external resource to this ensemble's lifecycle.
          *
+         * <p><strong>Side effect:</strong> this method calls {@link ManagedResource#start()}
+         * synchronously when the resource is not already running. That is intentional --
+         * it lets callers chain {@code .managedResource(fs).agent(... fs.tools() ...)}
+         * in a single builder expression without an explicit {@code fs.start()} -- but it
+         * also means {@code managedResource(...)} can launch a subprocess <em>before</em>
+         * {@code build()} is reached. If the start fails, the exception propagates and no
+         * {@link Ensemble} is constructed. Pre-start the resource yourself if you want
+         * registration to be side-effect-free; the builder will then classify it as
+         * caller-owned.
+         *
          * <p>The canonical use is wiring an MCP server subprocess so it lives across many
          * runs of the same long-running process and is cleaned up when the ensemble stops:
          * <pre>
@@ -2749,7 +2801,7 @@ public class Ensemble {
          * Ensemble kitchen = Ensemble.builder()
          *     .chatLanguageModel(model)
          *     .webDashboard(WebDashboard.onPort(7329))
-         *     .managedResource(fs)
+         *     .managedResource(fs)             // starts fs right here
          *     .scheduledTask(ScheduledTask.builder()
          *         .name("hourly-report")
          *         .task(Task.builder().description("...").tools(fs.tools()).build())
@@ -2757,16 +2809,17 @@ public class Ensemble {
          *         .build())
          *     .build();
          *
-         * kitchen.start(7329);  // ensemble starts fs
+         * kitchen.start(7329);  // fs already running; re-checked + revived if closed
          * // ... fs stays up across every scheduled firing ...
          * kitchen.stop();       // ensemble closes fs (it owns the lifecycle)
          * </pre>
          *
          * <p>Ownership is decided by whether the resource is already running at registration
-         * time. A not-yet-running resource is owned by the ensemble: it is started during
-         * {@link Ensemble#run()} or {@link Ensemble#start(int)} and closed during
+         * time. A not-yet-running resource is owned by the ensemble: it is started
+         * immediately here, revived during {@link Ensemble#run()} or
+         * {@link Ensemble#start(int)} if it has since been closed, and closed during
          * {@link Ensemble#stop()}. A resource that is already running is treated as
-         * caller-owned and is never closed by the ensemble.
+         * caller-owned and is never started or closed by the ensemble.
          *
          * <p>Resources are NOT closed at the end of one-shot {@link Ensemble#run()} calls --
          * they outlive individual runs by design, so the same MCP subprocess can serve

--- a/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/Ensemble.java
@@ -875,31 +875,37 @@ public class Ensemble {
     }
 
     /**
-     * Start every registered {@link ManagedResource} that is not already running.
+     * Start every owned {@link ManagedResource} that is not already running.
      *
      * <p>Called from both {@link #runWithInputs} (so one-shot runs benefit) and
      * {@link #start(int)} (so long-running mode benefits). Safe to call repeatedly --
      * each resource's own {@link ManagedResource#start()} is required to be idempotent for
      * the running case, and revivable for the closed case.
      *
-     * <p>Failures are logged but do not abort the ensemble: a managed resource startup
-     * failure typically surfaces as a tool execution failure later, which the agent can
-     * report back to the LLM. Aborting the run here would be over-eager because not every
-     * task may actually use the failing resource.
+     * <p>Caller-owned resources (those that were already running at registration time)
+     * are deliberately skipped: ownership is symmetric -- we don't close them on
+     * {@link #stop()}, and we don't restart them here either. If the caller closes such a
+     * resource externally, that's their problem, and downstream tool calls will surface
+     * the failure.
+     *
+     * <p>Failures propagate. A misconfigured managed resource that fails to start is a
+     * loud-fail condition: in long-running mode, {@link #start(int)} catches the exception
+     * and transitions to {@code STOPPED} (consistent with how dashboard failures are
+     * handled); in one-shot mode, the run fails before any task fires. Both modes are
+     * preferable to silently transitioning to {@code READY} with a broken tool backend
+     * that only surfaces hours later when a scheduled task fires.
      */
     private void startManagedResources() {
         if (managedResources == null || managedResources.isEmpty()) {
             return;
         }
         for (ManagedResource resource : managedResources) {
-            try {
-                if (!resource.isRunning()) {
-                    resource.start();
-                }
-            } catch (Exception e) {
-                if (log.isWarnEnabled()) {
-                    log.warn("Failed to start managed resource {}: {}", resource, e.getMessage(), e);
-                }
+            if (ownedManagedResources == null || !ownedManagedResources.contains(resource)) {
+                // Caller-owned -- never touch it, even if it appears stopped.
+                continue;
+            }
+            if (!resource.isRunning()) {
+                resource.start();
             }
         }
     }

--- a/agentensemble-core/src/main/java/net/agentensemble/ensemble/ManagedResource.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/ensemble/ManagedResource.java
@@ -4,11 +4,20 @@ package net.agentensemble.ensemble;
  * A long-lived external resource (subprocess, connection, server) whose lifecycle can be
  * tied to an {@link net.agentensemble.Ensemble}.
  *
- * <p>Register via {@code Ensemble.builder().managedResource(...)}. The ensemble starts the
- * resource (if not already running) before the first run or before transitioning to
- * {@code READY}, and closes any resource it owns when {@link net.agentensemble.Ensemble#stop()}
- * fires. A resource that was already running when registered is treated as caller-owned and
- * is never closed by the ensemble.
+ * <p>Register via {@code Ensemble.builder().managedResource(...)}. <strong>The builder
+ * starts the resource immediately on registration</strong> (if it is not already
+ * running), so callers can chain {@code .managedResource(fs).agent(... fs.tools() ...)}
+ * in a single fluent call. This is a side effect of {@code managedResource(...)} itself,
+ * not of {@code build()}, {@code run()}, or {@code start(int)} -- registration can
+ * launch a subprocess. Subsequent calls to {@link net.agentensemble.Ensemble#run()} and
+ * {@link net.agentensemble.Ensemble#start(int)} call {@link #start()} again on every
+ * owned resource that is not currently running, which is how the lifecycle is revived if
+ * something has closed the resource in the meantime.
+ *
+ * <p>Resources the ensemble owns are closed when
+ * {@link net.agentensemble.Ensemble#stop()} fires. A resource that was already running
+ * when registered is treated as caller-owned and is never started or closed by the
+ * ensemble.
  *
  * <p>Implementations must make {@link #close()} idempotent and {@link #isRunning()} cheap
  * and side-effect-free.

--- a/agentensemble-core/src/main/java/net/agentensemble/ensemble/ManagedResource.java
+++ b/agentensemble-core/src/main/java/net/agentensemble/ensemble/ManagedResource.java
@@ -1,0 +1,39 @@
+package net.agentensemble.ensemble;
+
+/**
+ * A long-lived external resource (subprocess, connection, server) whose lifecycle can be
+ * tied to an {@link net.agentensemble.Ensemble}.
+ *
+ * <p>Register via {@code Ensemble.builder().managedResource(...)}. The ensemble starts the
+ * resource (if not already running) before the first run or before transitioning to
+ * {@code READY}, and closes any resource it owns when {@link net.agentensemble.Ensemble#stop()}
+ * fires. A resource that was already running when registered is treated as caller-owned and
+ * is never closed by the ensemble.
+ *
+ * <p>Implementations must make {@link #close()} idempotent and {@link #isRunning()} cheap
+ * and side-effect-free.
+ *
+ * <p>The canonical implementation is
+ * {@code net.agentensemble.mcp.McpServerLifecycle}, which manages an MCP server subprocess.
+ */
+public interface ManagedResource extends AutoCloseable {
+
+    /**
+     * Start the resource. Implementations should be tolerant of being called when the
+     * resource is already running (no-op or idempotent), and should support restarting
+     * after a prior {@link #close()} so callers can recover from a stopped state.
+     */
+    void start();
+
+    /**
+     * @return true when the resource is started and not yet closed
+     */
+    boolean isRunning();
+
+    /**
+     * Release the resource. Must be idempotent; subsequent calls after the first must
+     * be safe no-ops. Implementations should not throw checked exceptions.
+     */
+    @Override
+    void close();
+}

--- a/agentensemble-core/src/test/java/net/agentensemble/EnsembleManagedResourceTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/EnsembleManagedResourceTest.java
@@ -158,6 +158,61 @@ class EnsembleManagedResourceTest {
     }
 
     @Test
+    void ensembleWithNoManagedResource_doesNotNpeOnStop() {
+        // The managedResources / ownedManagedResources fields default to non-null empty
+        // collections via the custom builder's shadow-field pattern. This test locks that
+        // in -- if Lombok ever stops honoring the override and the fields go null,
+        // startManagedResources()/closeOwnedManagedResources() would NPE in stop().
+        Ensemble ensemble = baseBuilder().build();
+
+        ensemble.start(7329);
+        ensemble.stop(); // must not throw NPE
+
+        assertThat(ensemble.getLifecycleState()).isNotNull();
+    }
+
+    @Test
+    void start_propagatesResourceFailureAsAgentEnsembleException() {
+        // A managed resource that fails to start during ensemble.start(int) must surface
+        // the failure loudly, not silently transition to READY with a broken tool backend.
+        ManagedResource exploding = mock(ManagedResource.class);
+        when(exploding.isRunning()).thenReturn(false, false); // false at builder time, still false at start(int)
+        org.mockito.Mockito.doNothing() // builder's start() succeeds...
+                .doThrow(new RuntimeException("transport failed")) // ...but start(int)'s revive fails
+                .when(exploding)
+                .start();
+        Ensemble ensemble = baseBuilder().managedResource(exploding).build();
+
+        // Manually flip isRunning back to false to simulate the resource dying between
+        // build() and start(int).
+        when(exploding.isRunning()).thenReturn(false);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> ensemble.start(7329))
+                .isInstanceOf(net.agentensemble.exception.AgentEnsembleException.class)
+                .hasMessageContaining("Failed to start ensemble");
+    }
+
+    @Test
+    void callerOwnedResource_isNotRevivedIfClosedExternally() {
+        // Caller-owned semantics are symmetric: the ensemble doesn't close it on stop(),
+        // and it also doesn't restart it. If the caller closes their own resource between
+        // ensemble.start() and a run, the framework leaves it alone -- that's the
+        // contract.
+        TestResource caller = new TestResource(true);
+        Ensemble ensemble = baseBuilder().managedResource(caller).build();
+
+        // Caller closes their resource externally.
+        caller.close();
+        assertThat(caller.running).isFalse();
+
+        ensemble.start(7329);
+
+        // start() must NOT have revived the caller-owned resource.
+        assertThat(caller.starts).isEqualTo(0);
+        assertThat(caller.running).isFalse();
+    }
+
+    @Test
     void mockResource_isStartedAndClosedThroughLifecycle() {
         // Belt-and-braces: also verify with a Mockito mock so we catch any signature drift
         // (e.g. someone adding new methods to ManagedResource without wiring them in).

--- a/agentensemble-core/src/test/java/net/agentensemble/EnsembleManagedResourceTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/EnsembleManagedResourceTest.java
@@ -213,6 +213,63 @@ class EnsembleManagedResourceTest {
     }
 
     @Test
+    void withTasks_copiesManagedResourcesAsCallerOwned() {
+        // The Ensemble Control API rebuilds the ensemble via withTasks() for every
+        // Level 2/3 run. The copy must see the same managedResources so child runs
+        // can still reach MCP-backed tools, but it must NOT take ownership -- the
+        // template still owns the lifecycle and will close it.
+        TestResource fs = new TestResource(false);
+        Ensemble template = baseBuilder().managedResource(fs).build();
+        assertThat(fs.starts).isEqualTo(1);
+
+        Ensemble child = template.withTasks(java.util.List.of(Task.of("child task")));
+
+        // Child sees the resource list.
+        assertThat(child.getManagedResources()).containsExactly(fs);
+
+        // Child must NOT have started the resource again (it was already running, so
+        // managedResource() correctly classified it as caller-owned for the child).
+        assertThat(fs.starts).isEqualTo(1);
+
+        // Child.stop() must NOT close the template's resource.
+        child.start(7329);
+        child.stop();
+        assertThat(fs.closes).isEqualTo(0);
+        assertThat(fs.running).isTrue();
+
+        // Template still owns the resource and closes it on its own stop.
+        template.start(7329);
+        template.stop();
+        assertThat(fs.closes).isEqualTo(1);
+    }
+
+    @Test
+    void withAdditionalListener_copiesManagedResourcesAsCallerOwned() {
+        TestResource fs = new TestResource(false);
+        Ensemble template = baseBuilder().managedResource(fs).build();
+
+        Ensemble child = template.withAdditionalListener(mock(EnsembleListener.class));
+
+        assertThat(child.getManagedResources()).containsExactly(fs);
+        assertThat(fs.starts).isEqualTo(1);
+
+        child.start(7329);
+        child.stop();
+        assertThat(fs.closes).isEqualTo(0);
+        assertThat(fs.running).isTrue();
+    }
+
+    @Test
+    void getManagedResources_returnsImmutableList() {
+        TestResource fs = new TestResource(false);
+        Ensemble ensemble = baseBuilder().managedResource(fs).build();
+
+        java.util.List<ManagedResource> exposed = ensemble.getManagedResources();
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> exposed.add(new TestResource(false)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
     void mockResource_isStartedAndClosedThroughLifecycle() {
         // Belt-and-braces: also verify with a Mockito mock so we catch any signature drift
         // (e.g. someone adding new methods to ManagedResource without wiring them in).

--- a/agentensemble-core/src/test/java/net/agentensemble/EnsembleManagedResourceTest.java
+++ b/agentensemble-core/src/test/java/net/agentensemble/EnsembleManagedResourceTest.java
@@ -1,0 +1,176 @@
+package net.agentensemble;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.model.chat.ChatModel;
+import net.agentensemble.callback.EnsembleListener;
+import net.agentensemble.dashboard.EnsembleDashboard;
+import net.agentensemble.ensemble.ManagedResource;
+import net.agentensemble.review.ReviewHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link Ensemble.EnsembleBuilder#managedResource(ManagedResource)} wiring.
+ *
+ * <p>Verifies the ownership contract (owned vs caller-owned), that owned resources are
+ * started by the builder and closed by {@link Ensemble#stop()}, and that caller-owned
+ * resources survive ensemble shutdown.
+ */
+class EnsembleManagedResourceTest {
+
+    private ChatModel model;
+    private EnsembleDashboard dashboard;
+
+    @BeforeEach
+    void setUp() {
+        model = mock(ChatModel.class);
+        dashboard = mock(EnsembleDashboard.class);
+        when(dashboard.isRunning()).thenReturn(true);
+        when(dashboard.streamingListener()).thenReturn(mock(EnsembleListener.class));
+        when(dashboard.reviewHandler()).thenReturn(mock(ReviewHandler.class));
+    }
+
+    /** A controllable test resource that records start/close call counts. */
+    private static final class TestResource implements ManagedResource {
+        boolean running;
+        int starts;
+        int closes;
+
+        TestResource(boolean initiallyRunning) {
+            this.running = initiallyRunning;
+        }
+
+        @Override
+        public void start() {
+            starts++;
+            running = true;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public void close() {
+            closes++;
+            running = false;
+        }
+    }
+
+    private Ensemble.EnsembleBuilder baseBuilder() {
+        return Ensemble.builder()
+                .chatLanguageModel(model)
+                .task(Task.of("main task"))
+                .dashboard(dashboard)
+                .ownsDashboardLifecycle(false);
+    }
+
+    @Test
+    void ownedResource_isStartedByBuilder() {
+        TestResource fs = new TestResource(false);
+
+        baseBuilder().managedResource(fs).build();
+
+        // Builder must start the resource immediately so callers can do
+        // `.managedResource(fs).agent(... fs.tools() ...)` in a single chain.
+        assertThat(fs.starts).isEqualTo(1);
+        assertThat(fs.running).isTrue();
+    }
+
+    @Test
+    void callerOwnedResource_isNotStartedByBuilder() {
+        // Resource is already running -- caller retains ownership.
+        TestResource fs = new TestResource(true);
+
+        baseBuilder().managedResource(fs).build();
+
+        // Builder must NOT call start() on a resource the caller is already managing.
+        assertThat(fs.starts).isEqualTo(0);
+    }
+
+    @Test
+    void ownedResource_isClosedByStop() {
+        TestResource fs = new TestResource(false);
+        Ensemble ensemble = baseBuilder().managedResource(fs).build();
+
+        ensemble.start(7329);
+        ensemble.stop();
+
+        // Owned resource is closed when the ensemble stops.
+        assertThat(fs.closes).isEqualTo(1);
+        assertThat(fs.running).isFalse();
+    }
+
+    @Test
+    void callerOwnedResource_survivesStop() {
+        TestResource fs = new TestResource(true); // already running -> caller-owned
+        Ensemble ensemble = baseBuilder().managedResource(fs).build();
+
+        ensemble.start(7329);
+        ensemble.stop();
+
+        // Caller-owned resource must NOT be closed by ensemble.stop() -- the caller
+        // retains lifecycle responsibility, exactly like the dashboard ownership contract.
+        assertThat(fs.closes).isEqualTo(0);
+        assertThat(fs.running).isTrue();
+    }
+
+    @Test
+    void start_revivesClosedOwnedResource() {
+        TestResource fs = new TestResource(false);
+        Ensemble ensemble = baseBuilder().managedResource(fs).build();
+
+        // Builder started it once.
+        assertThat(fs.starts).isEqualTo(1);
+
+        // Simulate something closing the resource between the build and start(int) calls
+        // (e.g. a previous Ensemble.stop() in a test, or external interference).
+        fs.close();
+        assertThat(fs.running).isFalse();
+
+        ensemble.start(7329);
+
+        // start(int) must revive the resource so tasks have a working tool backend.
+        assertThat(fs.starts).isEqualTo(2);
+        assertThat(fs.running).isTrue();
+    }
+
+    @Test
+    void multipleResources_areAllStartedAndOnlyOwnedAreClosed() {
+        TestResource owned = new TestResource(false);
+        TestResource caller = new TestResource(true);
+        Ensemble ensemble =
+                baseBuilder().managedResource(owned).managedResource(caller).build();
+
+        ensemble.start(7329);
+        ensemble.stop();
+
+        assertThat(owned.starts).isEqualTo(1);
+        assertThat(owned.closes).isEqualTo(1);
+        assertThat(caller.starts).isEqualTo(0);
+        assertThat(caller.closes).isEqualTo(0);
+    }
+
+    @Test
+    void mockResource_isStartedAndClosedThroughLifecycle() {
+        // Belt-and-braces: also verify with a Mockito mock so we catch any signature drift
+        // (e.g. someone adding new methods to ManagedResource without wiring them in).
+        ManagedResource mocked = mock(ManagedResource.class);
+        when(mocked.isRunning()).thenReturn(false);
+        Ensemble ensemble = baseBuilder().managedResource(mocked).build();
+
+        verify(mocked).start();
+
+        when(mocked.isRunning()).thenReturn(true);
+        ensemble.start(7329);
+        ensemble.stop();
+
+        verify(mocked, times(1)).close();
+    }
+}

--- a/agentensemble-examples/src/main/java/net/agentensemble/examples/McpCodingExample.java
+++ b/agentensemble-examples/src/main/java/net/agentensemble/examples/McpCodingExample.java
@@ -20,6 +20,27 @@ import net.agentensemble.mcp.McpToolFactory;
  * into a single agent, and runs a coding task. The MCP servers are managed with
  * try-with-resources so they are automatically shut down when the task completes.
  *
+ * <p><strong>This is a one-shot pattern</strong>: try-with-resources around a single
+ * {@link Ensemble#run()}. If you call {@code run()} more than once -- inside a loop, a
+ * request handler, or a scheduled task in a long-running ensemble -- do NOT wrap the
+ * lifecycle in try-with-resources around each run, because that would close the MCP
+ * subprocess at end of every iteration and pay the {@code npx} cold-start cost on the
+ * next one. For long-running callers, register the lifecycle on the ensemble:
+ * <pre>
+ *   McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);
+ *   Ensemble ensemble = Ensemble.builder()
+ *       .managedResource(fs)            // started by builder, closed by ensemble.stop()
+ *       .agent(Agent.builder().tools(fs.tools()).build())
+ *       ...
+ *       .build();
+ *
+ *   ensemble.start(7329);               // long-running mode
+ *   // ... many runs / scheduled firings against the same fs ...
+ *   ensemble.stop();                    // fs closed here
+ * </pre>
+ * See the <a href="../../../../../../../docs/guides/mcp.md">MCP guide</a>'s
+ * "Binding the Lifecycle to an Ensemble" section for the full pattern.
+ *
  * <p>Requires Node.js ({@code npx}) to be installed and available on the system PATH.
  *
  * <p>Run with:

--- a/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpAgentTool.java
+++ b/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpAgentTool.java
@@ -4,6 +4,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.function.Supplier;
 import net.agentensemble.tool.CustomSchemaAgentTool;
 import net.agentensemble.tool.ToolResult;
 import org.slf4j.Logger;
@@ -17,6 +18,12 @@ import org.slf4j.LoggerFactory;
  * {@link net.agentensemble.tool.LangChain4jToolAdapter#toSpecification} -- no
  * intermediate Java record is needed.
  *
+ * <p>The MCP client is resolved through a {@link Supplier} on every call to
+ * {@link #execute(String)}, not captured at construction time. This lets tool instances
+ * survive a {@link McpServerLifecycle#close()}/{@link McpServerLifecycle#start()} cycle
+ * transparently: the same {@code McpAgentTool} (and the same Agent that holds it) routes
+ * to whatever client the lifecycle currently owns.
+ *
  * <p>Instances are created by {@link McpToolFactory} or {@link McpServerLifecycle#tools()};
  * the constructor is package-private.
  */
@@ -24,23 +31,35 @@ public final class McpAgentTool implements CustomSchemaAgentTool {
 
     private static final Logger log = LoggerFactory.getLogger(McpAgentTool.class);
 
-    private final McpClient client;
+    private final Supplier<McpClient> clientSupplier;
     private final String toolName;
     private final String toolDescription;
     private final JsonObjectSchema parameters;
 
     McpAgentTool(McpClient client, String toolName, String toolDescription, JsonObjectSchema parameters) {
-        if (client == null) {
+        this(toFixedSupplier(client), toolName, toolDescription, parameters);
+    }
+
+    McpAgentTool(
+            Supplier<McpClient> clientSupplier, String toolName, String toolDescription, JsonObjectSchema parameters) {
+        if (clientSupplier == null) {
             throw new IllegalArgumentException("client must not be null");
         }
         if (toolName == null || toolName.isBlank()) {
             throw new IllegalArgumentException("toolName must not be null or blank");
         }
-        this.client = client;
+        this.clientSupplier = clientSupplier;
         this.toolName = toolName;
         this.toolDescription = toolDescription != null ? toolDescription : "";
         this.parameters =
                 parameters != null ? parameters : JsonObjectSchema.builder().build();
+    }
+
+    private static Supplier<McpClient> toFixedSupplier(McpClient client) {
+        if (client == null) {
+            throw new IllegalArgumentException("client must not be null");
+        }
+        return () -> client;
     }
 
     @Override
@@ -67,6 +86,8 @@ public final class McpAgentTool implements CustomSchemaAgentTool {
     @Override
     public ToolResult execute(String input) {
         try {
+            McpClient client = clientSupplier.get();
+
             ToolExecutionRequest request = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments(input != null ? input : "{}")

--- a/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpAgentTool.java
+++ b/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpAgentTool.java
@@ -43,7 +43,7 @@ public final class McpAgentTool implements CustomSchemaAgentTool {
     McpAgentTool(
             Supplier<McpClient> clientSupplier, String toolName, String toolDescription, JsonObjectSchema parameters) {
         if (clientSupplier == null) {
-            throw new IllegalArgumentException("client must not be null");
+            throw new IllegalArgumentException("clientSupplier must not be null");
         }
         if (toolName == null || toolName.isBlank()) {
             throw new IllegalArgumentException("toolName must not be null or blank");

--- a/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpServerLifecycle.java
+++ b/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpServerLifecycle.java
@@ -5,6 +5,8 @@ import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
+import net.agentensemble.ensemble.ManagedResource;
 import net.agentensemble.tool.AgentTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +14,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Manages the lifecycle of an MCP server subprocess and its associated tools.
  *
- * <p>Implements {@link AutoCloseable} for use with try-with-resources:
+ * <p>Implements {@link ManagedResource} so it can be wired into an
+ * {@link net.agentensemble.Ensemble} via {@code Ensemble.builder().managedResource(...)},
+ * and {@link AutoCloseable} for use with try-with-resources:
  *
  * <pre>
  * try (McpServerLifecycle server = McpToolFactory.filesystem(baseDir)) {
@@ -22,10 +26,15 @@ import org.slf4j.LoggerFactory;
  * }
  * </pre>
  *
+ * <p>The lifecycle is revivable: calling {@link #start()} after {@link #close()} spawns a
+ * fresh subprocess and rebuilds the underlying MCP client. Tool instances returned by
+ * {@link #tools()} reference the lifecycle indirectly through a supplier, so they survive
+ * a close/restart cycle without needing to be rebuilt.
+ *
  * <p>Instances are created by {@link McpToolFactory#filesystem(java.nio.file.Path)}
  * and {@link McpToolFactory#git(java.nio.file.Path)}.
  */
-public final class McpServerLifecycle implements AutoCloseable {
+public final class McpServerLifecycle implements ManagedResource {
 
     private static final Logger log = LoggerFactory.getLogger(McpServerLifecycle.class);
 
@@ -36,8 +45,16 @@ public final class McpServerLifecycle implements AutoCloseable {
     private volatile boolean closed;
     private volatile List<AgentTool> cachedTools;
 
+    /**
+     * Whether {@link #client} was injected via the test constructor and therefore must not
+     * be replaced when the lifecycle is restarted after a close. Test-only code paths keep
+     * their original mock; production code paths build a new client on each revive.
+     */
+    private final boolean clientPreInjected;
+
     McpServerLifecycle(List<String> command) {
         this.command = command != null ? List.copyOf(command) : List.of();
+        this.clientPreInjected = false;
     }
 
     /**
@@ -46,48 +63,73 @@ public final class McpServerLifecycle implements AutoCloseable {
     McpServerLifecycle(McpClient client, List<String> command) {
         this.command = command != null ? List.copyOf(command) : List.of();
         this.client = client;
+        this.clientPreInjected = client != null;
     }
 
     /**
      * Start the MCP server subprocess and initialize the connection.
      *
-     * <p>This creates the stdio transport, builds the MCP client, and validates
-     * the connection with a health check. After this method returns,
-     * {@link #tools()} can be called.
+     * <p>This creates the stdio transport, builds the MCP client, and validates the
+     * connection with a health check. After this method returns, {@link #tools()} can be
+     * called.
      *
-     * <p>If initialization or health check fails, any partially created resources
-     * are cleaned up before the exception propagates.
+     * <p>Behavior by current state:
+     * <ul>
+     *   <li><b>not started</b>: builds the client (if needed) and runs the health check.</li>
+     *   <li><b>already started</b>: no-op (idempotent). Useful so callers can defensively
+     *       call {@code start()} on every iteration of a long-running loop.</li>
+     *   <li><b>previously closed</b>: revives the lifecycle. The state flips back to
+     *       started, a fresh transport+client is built (unless the client was pre-injected
+     *       in tests), the tool cache is cleared, and the health check runs against the
+     *       new connection.</li>
+     * </ul>
      *
-     * @throws IllegalStateException if already started or closed
+     * <p>If initialization or health check fails, any partially created resources are
+     * cleaned up before the exception propagates and the lifecycle is left in the
+     * pre-call state.
      */
-    public void start() {
-        if (closed) {
-            throw new IllegalStateException("Cannot start a closed McpServerLifecycle");
+    @Override
+    public synchronized void start() {
+        if (started && !closed) {
+            // Already running -- no-op so callers can call start() defensively each iteration.
+            return;
         }
-        if (started) {
-            throw new IllegalStateException("McpServerLifecycle is already started");
-        }
-        log.info("Starting MCP server: {}", String.join(" ", command));
+        boolean reviving = closed;
+        log.info(reviving ? "Restarting MCP server: {}" : "Starting MCP server: {}", String.join(" ", command));
         try {
+            if (reviving && !clientPreInjected) {
+                // Old client (if any) was already closed by close(); drop the reference so we
+                // build a fresh transport and client below.
+                client = null;
+            }
             if (client == null) {
                 StdioMcpTransport transport =
                         new StdioMcpTransport.Builder().command(command).build();
                 client = new DefaultMcpClient.Builder().transport(transport).build();
             }
             client.checkHealth();
+            // Clear any stale cache from a prior session so tools() relists from the new client.
+            cachedTools = null;
+            closed = false;
             started = true;
-            log.info("MCP server started successfully");
+            log.info(reviving ? "MCP server restarted successfully" : "MCP server started successfully");
         } catch (Exception e) {
-            // Clean up partially initialized resources on failure
+            // Clean up partially initialized resources on failure -- always close the
+            // client (whether pre-injected for tests or freshly built) so callers see a
+            // deterministic shutdown. Only null the reference when not pre-injected so
+            // tests that supply a mock can still inspect it after the failure.
             if (client != null) {
                 try {
                     client.close();
                 } catch (Exception closeEx) {
                     log.warn("Error closing MCP client after failed start: {}", closeEx.getMessage(), closeEx);
-                } finally {
+                }
+                if (!clientPreInjected) {
                     client = null;
                 }
             }
+            // Leave state as it was before this start() attempt: if reviving from closed, stay closed;
+            // if starting fresh, stay un-started.
             throw e;
         }
     }
@@ -96,13 +138,18 @@ public final class McpServerLifecycle implements AutoCloseable {
      * Shut down the MCP client and close the transport.
      *
      * <p>This method is idempotent; calling it multiple times has no additional effect.
+     * After {@code close()}, the lifecycle can be restarted via {@link #start()} -- a fresh
+     * subprocess and client will be created, and tool instances returned by {@link #tools()}
+     * (or any prior call to it) automatically pick up the new client through the supplier
+     * indirection in {@link McpAgentTool}.
      */
     @Override
-    public void close() {
+    public synchronized void close() {
         if (closed) {
             return;
         }
         closed = true;
+        started = false;
         log.info("Closing MCP server lifecycle");
         if (client != null) {
             try {
@@ -123,32 +170,67 @@ public final class McpServerLifecycle implements AutoCloseable {
     }
 
     /**
+     * Alias for {@link #isAlive()}, satisfying the {@link ManagedResource} contract.
+     */
+    @Override
+    public boolean isRunning() {
+        return isAlive();
+    }
+
+    /**
      * List all tools from the MCP server as {@link AgentTool} instances.
      *
-     * <p>The tool list is cached after the first call; subsequent calls return
-     * the same list without re-querying the server. This method is thread-safe.
+     * <p>The tool list is cached after the first call; subsequent calls return the same
+     * list without re-querying the server. The cache is cleared on close so that calling
+     * {@link #start()} again followed by {@code tools()} relists against the fresh
+     * connection. Tool instances themselves are stable across restart cycles -- they
+     * resolve the active client through a supplier each time they execute.
      *
      * @return an unmodifiable list of AgentTool instances
-     * @throws IllegalStateException if not yet started or already closed
+     * @throws IllegalStateException if not yet started or currently closed
      */
     public List<AgentTool> tools() {
-        if (!started) {
-            throw new IllegalStateException("McpServerLifecycle has not been started");
-        }
+        // Check closed before started so a started-then-closed lifecycle reports the
+        // correct "closed" message (close() also clears the started flag for the
+        // restart path).
         if (closed) {
             throw new IllegalStateException("McpServerLifecycle is closed");
+        }
+        if (!started) {
+            throw new IllegalStateException("McpServerLifecycle has not been started");
         }
         List<AgentTool> tools = cachedTools;
         if (tools == null) {
             synchronized (this) {
                 tools = cachedTools;
                 if (tools == null) {
-                    tools = Collections.unmodifiableList(McpToolFactory.fromClient(client));
+                    tools = Collections.unmodifiableList(McpToolFactory.fromClientSupplier(this::currentClient));
                     cachedTools = tools;
                 }
             }
         }
         return tools;
+    }
+
+    /**
+     * Returns the current underlying {@link McpClient} for use by tool instances. Throws
+     * if the lifecycle is not currently running, so {@link McpAgentTool#execute} surfaces
+     * a clear failure instead of silently passing the call to a dead client.
+     */
+    McpClient currentClient() {
+        if (!started || closed) {
+            throw new IllegalStateException("MCP server is not running");
+        }
+        return client;
+    }
+
+    /**
+     * Returns a supplier that always resolves to the lifecycle's current
+     * {@link McpClient}. Used so tool instances captured before a restart pick up the new
+     * client transparently after revive.
+     */
+    Supplier<McpClient> clientSupplier() {
+        return this::currentClient;
     }
 
     /**

--- a/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpServerLifecycle.java
+++ b/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpServerLifecycle.java
@@ -189,27 +189,21 @@ public final class McpServerLifecycle implements ManagedResource {
      * @return an unmodifiable list of AgentTool instances
      * @throws IllegalStateException if not yet started or currently closed
      */
-    public List<AgentTool> tools() {
-        // Check closed before started so a started-then-closed lifecycle reports the
-        // correct "closed" message (close() also clears the started flag for the
-        // restart path).
+    public synchronized List<AgentTool> tools() {
+        // Synchronized as a whole so the closed/started check is atomic with a
+        // concurrent start()/close() (which also sync on this). Without this, a thread
+        // could read closed=false, then close() races in, then we'd cache tools backed
+        // by a dead client. Cache fill is cheap; this is not a hot path.
         if (closed) {
             throw new IllegalStateException("McpServerLifecycle is closed");
         }
         if (!started) {
             throw new IllegalStateException("McpServerLifecycle has not been started");
         }
-        List<AgentTool> tools = cachedTools;
-        if (tools == null) {
-            synchronized (this) {
-                tools = cachedTools;
-                if (tools == null) {
-                    tools = Collections.unmodifiableList(McpToolFactory.fromClientSupplier(this::currentClient));
-                    cachedTools = tools;
-                }
-            }
+        if (cachedTools == null) {
+            cachedTools = Collections.unmodifiableList(McpToolFactory.fromClientSupplier(this::currentClient));
         }
-        return tools;
+        return cachedTools;
     }
 
     /**

--- a/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpServerLifecycle.java
+++ b/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpServerLifecycle.java
@@ -108,8 +108,6 @@ public final class McpServerLifecycle implements ManagedResource {
                 client = new DefaultMcpClient.Builder().transport(transport).build();
             }
             client.checkHealth();
-            // Clear any stale cache from a prior session so tools() relists from the new client.
-            cachedTools = null;
             closed = false;
             started = true;
             log.info(reviving ? "MCP server restarted successfully" : "MCP server started successfully");
@@ -141,7 +139,9 @@ public final class McpServerLifecycle implements ManagedResource {
      * After {@code close()}, the lifecycle can be restarted via {@link #start()} -- a fresh
      * subprocess and client will be created, and tool instances returned by {@link #tools()}
      * (or any prior call to it) automatically pick up the new client through the supplier
-     * indirection in {@link McpAgentTool}.
+     * indirection in {@link McpAgentTool}. {@code close()} also drops the internal tools
+     * cache; the captured tool instances stay valid, but the next {@link #tools()} after a
+     * revive will relist against the new session.
      */
     @Override
     public synchronized void close() {
@@ -150,6 +150,10 @@ public final class McpServerLifecycle implements ManagedResource {
         }
         closed = true;
         started = false;
+        // Drop the tools cache so a future start() forces a relist against the new
+        // session. Tool *instances* the caller has already taken from tools() stay
+        // valid -- McpAgentTool resolves the live client through a supplier.
+        cachedTools = null;
         log.info("Closing MCP server lifecycle");
         if (client != null) {
             try {
@@ -180,11 +184,11 @@ public final class McpServerLifecycle implements ManagedResource {
     /**
      * List all tools from the MCP server as {@link AgentTool} instances.
      *
-     * <p>The tool list is cached after the first call; subsequent calls return the same
-     * list without re-querying the server. The cache is cleared on close so that calling
-     * {@link #start()} again followed by {@code tools()} relists against the fresh
-     * connection. Tool instances themselves are stable across restart cycles -- they
-     * resolve the active client through a supplier each time they execute.
+     * <p>The tool list is cached within a session; subsequent calls return the same list
+     * without re-querying the server. The cache is dropped inside {@link #close()} so
+     * that a {@code close()} -> {@code start()} -> {@code tools()} sequence relists from
+     * the fresh connection. Tool instances themselves are stable across restart cycles --
+     * they resolve the active client through a supplier each time they execute.
      *
      * @return an unmodifiable list of AgentTool instances
      * @throws IllegalStateException if not yet started or currently closed

--- a/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpToolFactory.java
+++ b/agentensemble-mcp/src/main/java/net/agentensemble/mcp/McpToolFactory.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import net.agentensemble.tool.AgentTool;
 
@@ -122,6 +123,20 @@ public final class McpToolFactory {
         List<AgentTool> tools = new ArrayList<>(specs.size());
         for (ToolSpecification spec : specs) {
             tools.add(new McpAgentTool(client, spec.name(), spec.description(), spec.parameters()));
+        }
+        return tools;
+    }
+
+    /**
+     * Convert all tools to AgentTool instances backed by a client supplier. Used by
+     * {@link McpServerLifecycle#tools()} so tool instances follow the lifecycle's current
+     * client across close/restart cycles.
+     */
+    static List<AgentTool> fromClientSupplier(Supplier<McpClient> clientSupplier) {
+        List<ToolSpecification> specs = clientSupplier.get().listTools();
+        List<AgentTool> tools = new ArrayList<>(specs.size());
+        for (ToolSpecification spec : specs) {
+            tools.add(new McpAgentTool(clientSupplier, spec.name(), spec.description(), spec.parameters()));
         }
         return tools;
     }

--- a/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpAgentToolTest.java
+++ b/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpAgentToolTest.java
@@ -13,6 +13,7 @@ import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import net.agentensemble.tool.CustomSchemaAgentTool;
 import net.agentensemble.tool.LangChain4jToolAdapter;
 import net.agentensemble.tool.ToolResult;
@@ -67,7 +68,7 @@ class McpAgentToolTest {
 
     @Test
     void constructor_nullClient_throws() {
-        assertThatThrownBy(() -> new McpAgentTool(null, "tool", "desc", schema))
+        assertThatThrownBy(() -> new McpAgentTool((McpClient) null, "tool", "desc", schema))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("client");
     }
@@ -239,6 +240,46 @@ class McpAgentToolTest {
         assertThat(spec.parameters().properties()).containsKey("content");
         assertThat(spec.parameters().properties()).doesNotContainKey("input");
         assertThat(spec.parameters().required()).contains("path");
+    }
+
+    // ========================
+    // Supplier-indirected client (survives lifecycle restart)
+    // ========================
+
+    @Test
+    void execute_resolvesClientFromSupplierEachCall() {
+        // The tool must look up the McpClient via the supplier on every execute(), not
+        // capture it at construction. This is the mechanism that lets a tool instance
+        // survive a McpServerLifecycle close + restart cycle.
+        AtomicReference<McpClient> swappable = new AtomicReference<>(mockClient);
+        McpAgentTool indirectTool = new McpAgentTool(swappable::get, "lookup", "Look up", schema);
+
+        when(mockClient.executeTool(any()))
+                .thenReturn(ToolExecutionResult.builder().resultText("first").build());
+        ToolResult first = indirectTool.execute("{}");
+        assertThat(first.isSuccess()).isTrue();
+        assertThat(first.getOutput()).isEqualTo("first");
+
+        // Swap in a new client (simulating a lifecycle restart producing a fresh McpClient).
+        McpClient secondClient = mock(McpClient.class);
+        when(secondClient.executeTool(any()))
+                .thenReturn(ToolExecutionResult.builder().resultText("second").build());
+        swappable.set(secondClient);
+
+        ToolResult second = indirectTool.execute("{}");
+        assertThat(second.isSuccess()).isTrue();
+        assertThat(second.getOutput()).isEqualTo("second");
+        // Original client must NOT have been called for the second execute.
+        verify(mockClient, org.mockito.Mockito.times(1)).executeTool(any());
+        verify(secondClient, org.mockito.Mockito.times(1)).executeTool(any());
+    }
+
+    @Test
+    void constructor_nullSupplier_throws() {
+        assertThatThrownBy(
+                        () -> new McpAgentTool((java.util.function.Supplier<McpClient>) null, "tool", "desc", schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("client");
     }
 
     @Test

--- a/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpServerLifecycleTest.java
+++ b/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpServerLifecycleTest.java
@@ -98,6 +98,30 @@ class McpServerLifecycleTest {
     }
 
     @Test
+    void close_clearsCachedTools() {
+        // Documented contract: close() drops the cache so that the next start() + tools()
+        // re-lists. The cache MUST be dropped in close(), not deferred to the next start(),
+        // so that close-without-restart never holds a stale list referencing a dead client.
+        when(mockClient.listTools())
+                .thenReturn(List.of(ToolSpecification.builder()
+                        .name("tool1")
+                        .description("Tool 1")
+                        .parameters(JsonObjectSchema.builder().build())
+                        .build()));
+
+        lifecycle.start();
+        lifecycle.tools(); // populate cache
+        verify(mockClient, times(1)).listTools();
+        lifecycle.close();
+        lifecycle.start();
+        lifecycle.tools();
+
+        // listTools must have run twice: the second call cannot have served from a cache
+        // surviving the close().
+        verify(mockClient, times(2)).listTools();
+    }
+
+    @Test
     void start_whenClosed_clearsCachedTools() {
         when(mockClient.listTools())
                 .thenReturn(List.of(ToolSpecification.builder()

--- a/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpServerLifecycleTest.java
+++ b/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpServerLifecycleTest.java
@@ -71,21 +71,52 @@ class McpServerLifecycleTest {
     }
 
     @Test
-    void start_whenAlreadyStarted_throws() {
+    void start_whenAlreadyStarted_isNoOp() {
+        lifecycle.start();
+        // Second start() must not throw -- callers in long-running loops are expected to
+        // call start() defensively each iteration.
         lifecycle.start();
 
-        assertThatThrownBy(() -> lifecycle.start())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("already started");
+        assertThat(lifecycle.isAlive()).isTrue();
+        // Health check still only runs on the first start, since the second is a no-op.
+        verify(mockClient, times(1)).checkHealth();
     }
 
     @Test
-    void start_whenClosed_throws() {
+    void start_whenClosed_revivesLifecycle() {
+        lifecycle.start();
         lifecycle.close();
 
-        assertThatThrownBy(() -> lifecycle.start())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("closed");
+        // Calling start() after close() must succeed (revive). This is the explicit fix
+        // for the original bug: long-running processes can recover a closed MCP server
+        // instead of being permanently broken.
+        lifecycle.start();
+
+        assertThat(lifecycle.isAlive()).isTrue();
+        // Health check ran twice -- once for the original start, once for the revive.
+        verify(mockClient, times(2)).checkHealth();
+    }
+
+    @Test
+    void start_whenClosed_clearsCachedTools() {
+        when(mockClient.listTools())
+                .thenReturn(List.of(ToolSpecification.builder()
+                        .name("tool1")
+                        .description("Tool 1")
+                        .parameters(JsonObjectSchema.builder().build())
+                        .build()));
+
+        lifecycle.start();
+        var firstTools = lifecycle.tools();
+        lifecycle.close();
+        lifecycle.start();
+        var secondTools = lifecycle.tools();
+
+        // Cache must be invalidated across restart so tools() re-lists from the new
+        // session. Tool *instances* are still safe to keep around (they look up the
+        // current client via supplier in McpAgentTool).
+        assertThat(secondTools).isNotSameAs(firstTools);
+        verify(mockClient, times(2)).listTools();
     }
 
     @Test
@@ -230,6 +261,24 @@ class McpServerLifecycleTest {
         // close without start should be safe (client is null)
         lc.close();
         assertThat(lc.isAlive()).isFalse();
+    }
+
+    // ========================
+    // ManagedResource contract
+    // ========================
+
+    @Test
+    void implementsManagedResource() {
+        assertThat(lifecycle).isInstanceOf(net.agentensemble.ensemble.ManagedResource.class);
+    }
+
+    @Test
+    void isRunning_aliasesIsAlive() {
+        assertThat(lifecycle.isRunning()).isFalse();
+        lifecycle.start();
+        assertThat(lifecycle.isRunning()).isTrue();
+        lifecycle.close();
+        assertThat(lifecycle.isRunning()).isFalse();
     }
 
     // ========================

--- a/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpServerLifecycleTest.java
+++ b/agentensemble-mcp/src/test/java/net/agentensemble/mcp/McpServerLifecycleTest.java
@@ -264,6 +264,71 @@ class McpServerLifecycleTest {
     }
 
     // ========================
+    // End-to-end: tool obtained before close still works after restart
+    // ========================
+
+    @Test
+    void toolCapturedBeforeRestart_executesAgainstNewClientAfterRestart() {
+        // The whole point of supplier indirection in McpAgentTool: a tool obtained
+        // from lifecycle.tools() before a close()/start() cycle should keep working,
+        // because it resolves the current client through the lifecycle on every call.
+        when(mockClient.listTools())
+                .thenReturn(List.of(ToolSpecification.builder()
+                        .name("read_file")
+                        .description("Read a file")
+                        .parameters(JsonObjectSchema.builder().build())
+                        .build()));
+        when(mockClient.executeTool(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                        .resultText("ok")
+                        .build());
+
+        lifecycle.start();
+        var tools = lifecycle.tools();
+        net.agentensemble.tool.AgentTool readFile = tools.get(0);
+
+        // First execution -- baseline.
+        net.agentensemble.tool.ToolResult firstResult = readFile.execute("{\"path\":\"a.txt\"}");
+        assertThat(firstResult.isSuccess()).isTrue();
+        assertThat(firstResult.getOutput()).isEqualTo("ok");
+
+        // Close and restart the lifecycle. Because the test injects a mock client, the
+        // same mock is reused after revive (production code path builds a fresh one).
+        lifecycle.close();
+        lifecycle.start();
+
+        // The captured tool reference must still resolve to a working client via the
+        // supplier indirection -- no rebuild required by the caller.
+        net.agentensemble.tool.ToolResult secondResult = readFile.execute("{\"path\":\"b.txt\"}");
+        assertThat(secondResult.isSuccess()).isTrue();
+        assertThat(secondResult.getOutput()).isEqualTo("ok");
+        verify(mockClient, times(2)).executeTool(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void toolCapturedBeforeClose_failsCleanlyIfUsedWhileClosed() {
+        // Counterpart to the above: if the lifecycle is closed and not yet restarted,
+        // a captured tool must surface a clean failure (ToolResult.failure) rather than
+        // throwing or silently routing to a dead client. This is what protects an Agent
+        // mid-loop from a transiently down MCP server.
+        when(mockClient.listTools())
+                .thenReturn(List.of(ToolSpecification.builder()
+                        .name("read_file")
+                        .description("Read a file")
+                        .parameters(JsonObjectSchema.builder().build())
+                        .build()));
+
+        lifecycle.start();
+        net.agentensemble.tool.AgentTool readFile = lifecycle.tools().get(0);
+        lifecycle.close();
+
+        net.agentensemble.tool.ToolResult result = readFile.execute("{}");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("not running");
+    }
+
+    // ========================
     // ManagedResource contract
     // ========================
 

--- a/docs/examples/mcp-coding.md
+++ b/docs/examples/mcp-coding.md
@@ -79,6 +79,34 @@ The MCP reference servers are installed automatically via `npx --yes` on first r
 - **CodingTask**: The `CodingTask.fix()` convenience method provides a pre-configured
   task description and expected output for bug-fix workflows.
 
+## When NOT to Use This Pattern
+
+The try-with-resources around `Ensemble.run()` shown above is correct for a **one-shot**
+invocation. Do not transplant it into a long-running process that calls `run()` more than
+once -- each iteration would spawn a new `npx` subprocess and pay the cold-start cost.
+
+For loops, request handlers, or long-running ensembles with scheduled tasks, bind the
+lifecycle to the ensemble instead:
+
+```java
+McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);
+Ensemble ensemble = Ensemble.builder()
+    .chatLanguageModel(model)
+    .managedResource(fs)               // started here; closed by ensemble.stop()
+    .agent(Agent.builder().tools(fs.tools()).build())
+    .task(task)
+    .build();
+
+// One-shot: fs stays up across many run() calls
+for (var input : inputs) ensemble.run(input);
+
+// Or long-running with scheduled tasks: fs is closed on ensemble.stop()
+ensemble.start(7329);
+```
+
+See the [Binding the Lifecycle to an Ensemble](../guides/mcp.md#binding-the-lifecycle-to-an-ensemble)
+section of the MCP guide for the full pattern.
+
 ## MCP Tools Available
 
 The exact tool names are defined by the MCP reference servers. You can discover them

--- a/docs/guides/long-running-ensembles.md
+++ b/docs/guides/long-running-ensembles.md
@@ -215,8 +215,9 @@ See the [Cross-Ensemble Delegation](cross-ensemble-delegation.md) guide for deta
 
 Long-running ensembles can take ownership of external resources whose lifecycle should
 follow the ensemble. Register a `ManagedResource` (the canonical implementation is
-`McpServerLifecycle`) on the builder and the ensemble will start it when built and
-close it during `stop()`:
+`McpServerLifecycle`) on the builder and the ensemble will start it **immediately on
+registration** -- a synchronous side effect of `.managedResource(fs)`, not deferred to
+`.build()` or `start(int)` -- and close it during `stop()`:
 
 ```java
 McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);

--- a/docs/guides/long-running-ensembles.md
+++ b/docs/guides/long-running-ensembles.md
@@ -211,6 +211,43 @@ try (NetworkClientRegistry registry = new NetworkClientRegistry(config)) {
 
 See the [Cross-Ensemble Delegation](cross-ensemble-delegation.md) guide for details.
 
+## Managed Resources (MCP servers, etc.)
+
+Long-running ensembles can take ownership of external resources whose lifecycle should
+follow the ensemble. Register a `ManagedResource` (the canonical implementation is
+`McpServerLifecycle`) on the builder and the ensemble will start it when built and
+close it during `stop()`:
+
+```java
+McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);
+
+Ensemble kitchen = Ensemble.builder()
+    .chatLanguageModel(model)
+    .webDashboard(WebDashboard.onPort(7329))
+    .managedResource(fs)            // started immediately so fs.tools() is callable
+    .scheduledTask(ScheduledTask.builder()
+        .name("hourly-report")
+        .task(Task.builder()
+            .description("Summarize today's filesystem changes")
+            .tools(fs.tools())
+            .build())
+        .schedule(Schedule.every(Duration.ofHours(1)))
+        .build())
+    .build();
+
+kitchen.start(7329);
+// fs is alive across every scheduled firing
+kitchen.stop();                      // fs is closed (ensemble owns the lifecycle)
+```
+
+A resource that is **already running** when registered is treated as caller-owned and
+is **never** closed by the ensemble (same ownership rule as `webDashboard()`). Resources
+are NOT closed at the end of one-shot `run()` calls: the whole point of the binding is
+that one MCP subprocess can serve many runs from the same long-running process.
+
+See the [MCP guide](mcp.md) for the full lifecycle contract, including the revivable
+`start()` semantics that let tool instances survive a close/restart cycle.
+
 ## Related
 
 - [Cross-Ensemble Delegation](cross-ensemble-delegation.md)

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -111,17 +111,23 @@ try (McpServerLifecycle server = McpToolFactory.filesystem(projectDir)) {
 **State machine:**
 
 ```
+                    +-- close() ----+
+                    v               |
 CREATED  --start()-->  STARTED  --close()-->  CLOSED
-                            ^                    |
-                            +------- start() ----+
+   |                        ^                    |
+   |                        +------- start() ----+
+   +-- close() -> CLOSED  (close before start is safe)
 ```
 
 - `start()` spawns the server subprocess and performs a health check; idempotent when
   already running, and **revivable** -- calling it after `close()` spawns a fresh
   subprocess and rebuilds the connection.
-- `tools()` lists available tools (cached within a session; cache cleared on `close()`
-  so the next `start()` + `tools()` re-lists from the new connection).
-- `close()` shuts down the server; idempotent.
+- `tools()` lists available tools (cached within a session). The cache is dropped
+  inside `close()`, so a `close()` -> `start()` -> `tools()` sequence relists from the
+  fresh connection.
+- `close()` shuts down the server; idempotent and safe before `start()` (an
+  unstarted-then-closed lifecycle stays in `CLOSED`; calling `start()` afterwards
+  spawns a fresh subprocess).
 - `isAlive()` / `isRunning()` return true when started and not yet closed.
 
 Tool instances returned by `tools()` survive a close/restart cycle: they look up the
@@ -140,7 +146,9 @@ scope, or bind it to the ensemble (next section).
 ## Binding the Lifecycle to an Ensemble
 
 Long-running ensembles can take ownership of an MCP server lifecycle so it is started
-when the ensemble is built and closed during `Ensemble.stop()`:
+the moment `.managedResource(fs)` runs in the builder (a synchronous side effect of the
+builder method, not deferred to `.build()` or `start(int)`) and closed during
+`Ensemble.stop()`:
 
 ```java
 McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -112,14 +112,64 @@ try (McpServerLifecycle server = McpToolFactory.filesystem(projectDir)) {
 
 ```
 CREATED  --start()-->  STARTED  --close()-->  CLOSED
-                                       ^
-CREATED  --close()---->  CLOSED -------+
+                            ^                    |
+                            +------- start() ----+
 ```
 
-- `start()` spawns the server subprocess and performs a health check
-- `tools()` lists available tools (cached after first call)
-- `close()` shuts down the server; idempotent
-- `isAlive()` returns true when started and not yet closed
+- `start()` spawns the server subprocess and performs a health check; idempotent when
+  already running, and **revivable** -- calling it after `close()` spawns a fresh
+  subprocess and rebuilds the connection.
+- `tools()` lists available tools (cached within a session; cache cleared on `close()`
+  so the next `start()` + `tools()` re-lists from the new connection).
+- `close()` shuts down the server; idempotent.
+- `isAlive()` / `isRunning()` return true when started and not yet closed.
+
+Tool instances returned by `tools()` survive a close/restart cycle: they look up the
+active `McpClient` through a supplier on every call, so an `Agent` built once with
+`fs.tools()` keeps working after `fs.close()` followed by `fs.start()`.
+
+### Long-running processes
+
+For loops and request handlers that build an ensemble per iteration, do **not** wrap the
+inner `run()` in try-with-resources around the lifecycle -- closing per iteration would
+spawn a new `npx` subprocess every time. Instead, keep the lifecycle at the process
+scope, or bind it to the ensemble (next section).
+
+---
+
+## Binding the Lifecycle to an Ensemble
+
+Long-running ensembles can take ownership of an MCP server lifecycle so it is started
+when the ensemble is built and closed during `Ensemble.stop()`:
+
+```java
+McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);
+
+Ensemble kitchen = Ensemble.builder()
+    .chatLanguageModel(model)
+    .webDashboard(WebDashboard.onPort(7329))
+    .managedResource(fs)            // started immediately; closed on stop()
+    .scheduledTask(ScheduledTask.builder()
+        .name("hourly-report")
+        .task(Task.builder()
+            .description("Summarize today's filesystem changes")
+            .tools(fs.tools())      // tools() works because managedResource() started fs
+            .build())
+        .schedule(Schedule.every(Duration.ofHours(1)))
+        .build())
+    .build();
+
+kitchen.start(7329);                 // fs is already running; scheduled tasks fire against it
+// ... fs stays alive across every scheduled firing ...
+kitchen.stop();                      // fs is closed (ensemble owns the lifecycle)
+```
+
+**Ownership rule** (mirrors `webDashboard()`): a resource that is **already running**
+when registered is treated as caller-owned and is **never** closed by the ensemble. A
+not-yet-running resource is owned by the ensemble and is closed during `stop()`.
+
+`McpServerLifecycle` implements `ManagedResource`; any other `start()`/`close()`-style
+resource can be wired the same way.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes a bug reported in long-running processes that call ensembles which use MCP servers: the MCP server gets shut down at end of run (via `try-with-resources` around `Ensemble.run()`, the pattern every example/doc shows), and subsequent runs cannot restart it. `McpServerLifecycle.start()` after `close()` threw `IllegalStateException`, and even if you tore down and rebuilt the lifecycle, the `McpClient` reference was captured inside every `McpAgentTool` that was already attached to an `Agent` — so the agents kept pointing at the dead client.

Two changes, one PR:

### A. Restartable lifecycle + supplier-indirected client
- `McpServerLifecycle.start()` is **idempotent** when already running and **revivable** from `CLOSED`: it spawns a fresh transport + client, clears the tool cache, and re-runs the health check. State machine is now `CREATED → STARTED ⇄ CLOSED`.
- `McpAgentTool` resolves the `McpClient` via `Supplier<McpClient>` on every `execute()`, so an `Agent` built once with `fs.tools()` keeps working after `fs.close()` followed by `fs.start()`.

### B. Ensemble lifecycle binding
- New `ManagedResource` interface in `agentensemble-core` (avoids the `core → mcp → core` circular dep that an MCP-typed builder method would create).
- `McpServerLifecycle implements ManagedResource`.
- `EnsembleBuilder.managedResource(ManagedResource)` starts the resource immediately (so `fs.tools()` is callable in the same builder chain), tracks ownership the same way `webDashboard()` does, and `Ensemble.stop()` closes only owned resources. `run()` and `start(int)` revive a closed resource but never auto-close after a one-shot run — the resource is meant to outlive many runs.

### Resulting usage

Long-running process — MCP survives across many runs:

```java
McpServerLifecycle fs = McpToolFactory.filesystem(projectDir);
Ensemble e = Ensemble.builder()
    .managedResource(fs)
    .agent(Agent.builder().tools(fs.tools()).build())
    .task(...)
    .build();

while (...) e.run();   // fs stays up
```

Long-running ensemble — MCP cleaned up on stop:

```java
kitchen.start(7329);   // fs already started by managedResource()
// scheduled tasks fire against fs
kitchen.stop();        // fs.close() called
```

## Test plan
- [x] `agentensemble-mcp:check` — 60 tests pass (added: `start_whenClosed_revivesLifecycle`, `start_whenClosed_clearsCachedTools`, `start_whenAlreadyStarted_isNoOp`, `execute_resolvesClientFromSupplierEachCall`, `implementsManagedResource`, `isRunning_aliasesIsAlive`, `constructor_nullSupplier_throws`; updated `start_whenAlreadyStarted` and `start_whenClosed` from "throws" to the new behavior)
- [x] `agentensemble-core:check` — full suite passes including new `EnsembleManagedResourceTest` (7 tests covering owned/caller-owned ownership, start-by-builder, close-on-stop, revive-on-start)
- [x] Spotless / errorprone / PMD clean on both modules
- [x] `agentensemble-examples:compileJava` — no breaking signature changes