### PR TITLE
fix(viz): scroll vertically through tall completed-run timeline sections

### DIFF
--- a/agentensemble-viz/src/__tests__/TimelineView.live.test.tsx
+++ b/agentensemble-viz/src/__tests__/TimelineView.live.test.tsx
@@ -567,6 +567,54 @@ describe('TimelineView live mode', () => {
       // DOCUMENT_POSITION_FOLLOWING = 4 (liveScroll follows section)
       expect(sectionPos & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
+
+    // Regression: with many tasks per completed run, lower lanes used to render
+    // off the bottom of the column with no way to scroll to them. The fix wraps
+    // CompletedRunList + the active scroll in a single vertically scrollable
+    // container (data-testid="live-timeline-vscroll") that contains both
+    // every completed-run-section and the live-timeline-scroll, so the user can
+    // scroll the whole stack vertically.
+    it('wraps completed runs and the active run in a single vertical-scroll container', () => {
+      const state = makeLiveState({
+        tasks: [makeRunningTask(0)],
+        completedRuns: [
+          makeCompletedRunFixture(2, 30), // many tasks
+          makeCompletedRunFixture(1, 30),
+        ],
+      });
+      mockLiveServer(state);
+      renderLiveTimeline();
+
+      const vScroll = screen.getByTestId('live-timeline-vscroll');
+      expect(vScroll.className).toMatch(/overflow-y-auto/);
+      // Both completed-run sections and the active live-timeline-scroll
+      // must live inside this single vertical-scroll wrapper.
+      const sections = screen.getAllByTestId('completed-run-section');
+      expect(sections.length).toBe(2);
+      for (const section of sections) {
+        expect(vScroll.contains(section)).toBe(true);
+      }
+      const liveScroll = screen.getByTestId('live-timeline-scroll');
+      expect(vScroll.contains(liveScroll)).toBe(true);
+      // The active-run inner container is horizontal-only now (vertical scroll
+      // is owned by the wrapper above); jsdom doesn't lay out, so we just
+      // assert the class string.
+      expect(liveScroll.className).toMatch(/overflow-x-auto/);
+      expect(liveScroll.className).not.toMatch(/\boverflow-auto\b/);
+    });
+
+    it('shows the vertical-scroll wrapper even in the empty-tasks state when there are completed runs', () => {
+      const state = makeLiveState({
+        tasks: [],
+        completedRuns: [makeCompletedRunFixture(1, 30)],
+      });
+      mockLiveServer(state);
+      renderLiveTimeline();
+      const vScroll = screen.getByTestId('live-timeline-vscroll');
+      expect(vScroll.className).toMatch(/overflow-y-auto/);
+      const section = screen.getByTestId('completed-run-section');
+      expect(vScroll.contains(section)).toBe(true);
+    });
   });
 
   describe('HIERARCHICAL delegation lanes', () => {

--- a/agentensemble-viz/src/pages/TimelineView.tsx
+++ b/agentensemble-viz/src/pages/TimelineView.tsx
@@ -1154,9 +1154,15 @@ function LiveTimelineView() {
           className="flex-1 min-h-0 overflow-y-auto scrollbar-thin"
           data-testid="live-timeline-vscroll"
         >
-          <CompletedRunList completedRuns={completedRuns} groupBy={groupBy} />
-          <div className="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
-            Waiting for tasks to start...
+          {/* Inner flex column with min-h-full lets the "Waiting..." message
+              take all remaining space (and stay vertically centered) when
+              there are no completed runs, while still allowing the wrapper
+              to scroll once stacked completed runs exceed its height. */}
+          <div className="flex min-h-full flex-col">
+            <CompletedRunList completedRuns={completedRuns} groupBy={groupBy} />
+            <div className="flex flex-1 items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
+              Waiting for tasks to start...
+            </div>
           </div>
         </div>
       </div>

--- a/agentensemble-viz/src/pages/TimelineView.tsx
+++ b/agentensemble-viz/src/pages/TimelineView.tsx
@@ -878,7 +878,7 @@ function CompletedRunSection({
       </div>
 
       {/* Read-only SVG timeline */}
-      <div className="overflow-auto scrollbar-thin">
+      <div className="overflow-x-auto scrollbar-thin">
         <svg
           width={Math.max(svgWidth, LABEL_WIDTH + chartWidth + 40)}
           height={svgHeight}
@@ -1150,9 +1150,14 @@ function LiveTimelineView() {
           groupBy={groupBy}
           onToggleGroupBy={() => setGroupBy((g) => (g === 'task' ? 'agent' : 'task'))}
         />
-        <CompletedRunList completedRuns={completedRuns} groupBy={groupBy} />
-        <div className="flex flex-1 items-center justify-center text-sm text-gray-400 dark:text-gray-500">
-          Waiting for tasks to start...
+        <div
+          className="flex-1 min-h-0 overflow-y-auto scrollbar-thin"
+          data-testid="live-timeline-vscroll"
+        >
+          <CompletedRunList completedRuns={completedRuns} groupBy={groupBy} />
+          <div className="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
+            Waiting for tasks to start...
+          </div>
         </div>
       </div>
     );
@@ -1172,13 +1177,21 @@ function LiveTimelineView() {
           onToggleGroupBy={() => setGroupBy((g) => (g === 'task' ? 'agent' : 'task'))}
         />
 
+        {/* Unified vertical scroll across completed runs and the active run.
+            min-h-0 lets this flex child shrink below content height so the
+            scrollbar actually appears. */}
+        <div
+          className="flex-1 min-h-0 overflow-y-auto scrollbar-thin"
+          data-testid="live-timeline-vscroll"
+        >
         {/* Stacked completed run sections above the active run */}
         <CompletedRunList completedRuns={completedRuns} groupBy={groupBy} />
 
-        {/* Active run scrollable SVG */}
+        {/* Active run scrollable SVG (horizontal time-axis scroll only;
+            vertical scroll is owned by the wrapper above). */}
         <div
           ref={scrollRef}
-          className="flex-1 overflow-auto scrollbar-thin"
+          className="overflow-x-auto scrollbar-thin"
           onScroll={handleScroll}
           data-testid="live-timeline-scroll"
         >
@@ -1317,6 +1330,7 @@ function LiveTimelineView() {
               <LegendItem x={240} color="#22C55E" label="Tool call" />
             </g>
           </svg>
+        </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Fix a visual bug in `agentensemble-viz`'s live Timeline view: with many tasks in a completed/archived run, lower task lanes rendered off the bottom of the `completed-run-section` and there was no scrollbar to reach them.
- Root cause: `LiveTimelineView` rendered `CompletedRunList` directly inside a `flex-col overflow-hidden` column with no vertical-scroll container. Each `CompletedRunSection`'s SVG height grows linearly with task count, gets clipped by the column's `overflow-hidden`, and there is no scrollable ancestor.
- Fix: wrap `CompletedRunList` together with the active-run scroll container in a single `flex-1 min-h-0 overflow-y-auto` wrapper (`data-testid="live-timeline-vscroll"`). The active inner container becomes `overflow-x-auto` only — vertical scroll is owned by the new wrapper. Same shape applied to the empty-tasks branch. `CompletedRunSection`'s inner div changes from `overflow-auto` → `overflow-x-auto` so a redundant nested vertical scrollbar doesn't appear.
- `scrollRef` still points at the active horizontal scroll container, so `Follow latest` and the re-engage-on-scroll-right logic are unchanged.

## Test plan
- [x] `cd agentensemble-viz && npm test -- --run TimelineView.live` — 49 / 49 pass (47 existing + 2 new regression tests asserting the vertical-scroll wrapper contains every `completed-run-section` and the `live-timeline-scroll`, and that the active inner container is `overflow-x-auto` rather than `overflow-auto`).
- [x] `npm run build` — `tsc && vite build` clean, no TS errors.
- [x] Full viz unit suite — only the 4 pre-existing `cli.test.ts` failures (confirmed unrelated via `git stash`), all 381 other tests pass.
- [ ] Manual: connect the viz to a `WebDashboard` running two sequential ensembles with ≥ 15 tasks each so the first becomes an archived completed run; confirm the new vertical scrollbar lets you reach every lane in the completed-run section and that `Follow latest` still snaps horizontally to the right edge of the active run.
- [ ] Manual: drag the bottom `react-resizable-panels` separator to shrink the timeline pane; confirm scrolling continues to work at shorter heights without clipping.
