### PR TITLE
ci: run build job on ubuntu-latest instead of ubicloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
## What

Move the `Build and Test` job off `ubicloud-standard-4` onto `ubuntu-latest`, matching the other four CI jobs.

## Why

For a public repository, GitHub-hosted runners are free with unlimited minutes, and `ubuntu-latest` provides a 4 vCPU / 16 GB machine — effectively the same size as `ubicloud-standard-4`. This removes the third-party runner dependency at no cost to build capacity.

## Change

Single line in `.github/workflows/ci.yml`:

```diff
   build:
     name: Build and Test
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
```

No other workflow changes needed — the `setup-java` / `setup-node` / `playwright install` steps are unchanged.