### PR TITLE
docs: agent observability whitepaper and telemetry design docs

### DIFF
--- a/docs/design/31-otel-tracing-fidelity.md
+++ b/docs/design/31-otel-tracing-fidelity.md
@@ -1,0 +1,407 @@
+# 31 - OpenTelemetry Tracing Fidelity
+
+**Status:** Proposed
+**Target version:** 3.7.0
+**Date:** 2026-08-05
+
+## 1. Motivation
+
+`OTelTracingListener` exports spans at framework boundaries, and `ExecutionTrace` captures
+the complete reasoning tree. These are two projections of the same run, but they do not
+agree: the structured trace preserves the full hierarchy while the OpenTelemetry projection
+flattens it.
+
+The practical consequences for an operator looking at a run in Tempo or Jaeger:
+
+- **The trace is two levels deep regardless of actual structure.** Every span parents to the
+  root `ensemble.run` context, so a tool span appears as a sibling of the task that invoked
+  it. "What did this task do?" is not answerable from the trace.
+- **Tool spans have no width.** They are started and ended in the same statement, with
+  elapsed time recorded as an attribute. A waterfall view renders them as zero-duration
+  ticks, which is the one visualization a waterfall exists to provide.
+- **The ReAct loop is invisible.** No span is created per LLM call, so the reasoning
+  iterations -- the structure an operator most wants to inspect when an agent misbehaves --
+  are absent from the trace even though `LlmIterationStartedEvent` and
+  `LlmIterationCompletedEvent` carry everything needed to build them.
+- **Attributes are framework-private.** The `agentensemble.*` namespace is correct for
+  framework concepts but does not activate the LLM-aware views in Grafana, Langfuse, Arize
+  Phoenix, or other backends that key on the OpenTelemetry GenAI semantic conventions.
+
+This design closes the gap between the two projections, organized as five issues
+(OT-001 through OT-005).
+
+## 2. Current State
+
+### 2.1 What Works
+
+| Capability | Implementation |
+|------------|----------------|
+| Root span per run | `onEnsembleStarted` / `onEnsembleCompleted` -> `ensemble.run` |
+| Span per task | `onTaskStart` / `onTaskComplete` / `onTaskFailed` -> `task.execute` |
+| Span per tool call | `onToolCall` -> `tool.execute` |
+| Span per delegation | `onDelegationStarted` / `Completed` / `Failed` -> `network.delegate` (CLIENT) |
+| Trace ID exposed to framework | `getTraceId()` populates `ExecutionTrace.traceId` |
+| Cross-process continuity | `TraceContextPropagator` extract/inject of W3C `traceparent` |
+| Concurrency safety | `ConcurrentHashMap` for active spans, `volatile` trace ID and root context |
+| Listener isolation | Exceptions caught by `ExecutionContext.fire*` dispatch |
+
+### 2.2 Gaps
+
+| Gap | Root cause | Affected code |
+|-----|-----------|---------------|
+| Tool spans are siblings of tasks, not children | `spanBuilder.setParent(rootContext)` unconditionally | `OTelTracingListener.onToolCall` |
+| Delegation spans are siblings of tasks | Same | `OTelTracingListener.onDelegationStarted` |
+| Tool spans have zero duration | `startSpan()` immediately followed by `end()` | `OTelTracingListener.onToolCall` |
+| Tool outcome not reflected in span status | `ToolCallEvent.outcome()` ignored | `OTelTracingListener.onToolCall` |
+| No span per reasoning iteration | `onLlmIterationStarted` / `Completed` not overridden | `OTelTracingListener` |
+| LLM iteration events cannot be correlated to a task span | Events carry `agentRole` + `taskDescription` but no `taskIndex` | `LlmIterationStartedEvent`, `LlmIterationCompletedEvent` |
+| Delegation events cannot be correlated to a task span | `DelegationStartedEvent` has no `taskIndex` | `DelegationStartedEvent` |
+| No `gen_ai.*` attributes | Only `agentensemble.*` keys defined | `OTelAttributes` |
+| Model identity absent from telemetry | No event carries the model name | `LlmIteration*Event` |
+
+**Why `Context.current()` does not solve the parenting problem.** The obvious fix -- calling
+`Span.makeCurrent()` in `onTaskStart` and relying on implicit context propagation -- does not
+work here. OpenTelemetry's current context is a thread-local, and under `PARALLEL` workflows
+tasks execute on separate virtual threads; a scope opened on the dispatching thread is not
+visible on the executing one. Scoping would also require the listener to hold an open
+`Scope` across two callbacks, which leaks if a task never completes. The design below uses
+explicit parent keys instead, which is deterministic under any workflow strategy and holds
+no thread-affine state.
+
+## 3. Design
+
+### 3.1 OT-001: Task correlation identifiers on iteration and delegation events
+
+**Module:** `agentensemble-core`
+
+Spans can only be parented if the child event knows which task it belongs to. Three events
+currently lack that identifier. Add `taskIndex` as a trailing field to each, following the
+precedent set by IO-001 (design 27), which added `taskIndex` and `outcome` to
+`ToolCallEvent` the same way.
+
+```java
+public record LlmIterationStartedEvent(
+        String agentRole,
+        String taskDescription,
+        int iterationIndex,
+        List<CapturedMessage> messages,
+        int taskIndex) {                    // NEW
+
+    /** Backward-compatible constructor; sets taskIndex to UNKNOWN_TASK_INDEX. */
+    public LlmIterationStartedEvent(
+            String agentRole, String taskDescription, int iterationIndex,
+            List<CapturedMessage> messages) {
+        this(agentRole, taskDescription, iterationIndex, messages, UNKNOWN_TASK_INDEX);
+    }
+}
+```
+
+The same treatment applies to `LlmIterationCompletedEvent` and `DelegationStartedEvent`.
+`UNKNOWN_TASK_INDEX` is defined as `-1` on a shared constants holder; consumers treat it as
+"parent to the run root."
+
+**Emission changes.** `AgentExecutor` already holds the task index in its execution context
+when firing tool call events (added by IO-001); the same value is passed when firing
+iteration events. Delegation events are fired from `AgentDelegationTool` and
+`DelegateTaskTool`, both of which execute within a task's context.
+
+**Backward compatibility.** Records gain trailing fields with a compatibility constructor, so
+existing `EnsembleListener` implementations compile and run unchanged. Wire-format consumers
+in `agentensemble-web` are updated to pass the value through; `agentensemble-viz` needs no
+change because it already keys tool calls by task index.
+
+### 3.2 OT-002: Correct span parenting
+
+**Module:** `agentensemble-telemetry-opentelemetry`
+
+Replace the single `rootContext` field with an explicit registry of parent contexts.
+
+```java
+private final ConcurrentHashMap<Integer, Context> taskContexts = new ConcurrentHashMap<>();
+private final ConcurrentHashMap<String, Context> delegationContexts = new ConcurrentHashMap<>();
+private volatile Context rootContext;
+```
+
+`onTaskStart` records the task's context after creating its span:
+
+```java
+Span span = spanBuilder.startSpan();
+activeSpans.put(taskKey(...), span);
+taskContexts.put(event.taskIndex(), Context.root().with(span));
+```
+
+Child spans resolve their parent through a single helper, which degrades safely:
+
+```java
+private Context parentFor(int taskIndex) {
+    Context ctx = taskContexts.get(taskIndex);
+    if (ctx != null) {
+        return ctx;
+    }
+    return rootContext != null ? rootContext : Context.root();
+}
+```
+
+`onTaskComplete` and `onTaskFailed` both remove the task's entry. **Removal on the failure
+path is mandatory** -- omitting it leaks one `Context` per failed task for the lifetime of
+the listener, which for a long-lived ensemble service is an unbounded leak.
+
+The resulting hierarchy:
+
+```
+ensemble.run
+├── task.execute (index 0)
+│   ├── gen_ai.chat (iteration 0)          [OT-003]
+│   │   └── tool.execute
+│   ├── gen_ai.chat (iteration 1)
+│   └── network.delegate
+│       └── (worker ensemble spans, via traceparent)
+└── task.execute (index 1)
+    └── ...
+```
+
+**Nested delegation is explicitly out of scope for this issue.** A worker that delegates
+again produces a `DelegationStartedEvent` with `delegationDepth > 0`, but the event carries
+no parent delegation identifier, so the span parents to its task rather than to the
+enclosing delegation. The tree remains correct, just flatter than reality at depth > 1.
+Resolving it requires adding `parentDelegationId` to `DelegationStartedEvent`; tracked
+separately rather than expanding this issue.
+
+### 3.3 OT-003: Span per reasoning iteration
+
+**Module:** `agentensemble-telemetry-opentelemetry`
+
+Create a span spanning each LLM call, opened on `onLlmIterationStarted` and closed on
+`onLlmIterationCompleted`.
+
+```java
+@Override
+public void onLlmIterationStarted(LlmIterationStartedEvent event) {
+    if (!llmSpansEnabled) {
+        return;
+    }
+    Span span = tracer.spanBuilder(spanName(GenAi.OPERATION_CHAT, modelName))
+            .setSpanKind(SpanKind.CLIENT)
+            .setParent(parentFor(event.taskIndex()))
+            .setAttribute(GenAiAttributes.OPERATION_NAME, GenAi.OPERATION_CHAT)
+            .setAttribute(OTelAttributes.AGENT_ROLE, event.agentRole())
+            .setAttribute(OTelAttributes.ITERATION_INDEX, (long) event.iterationIndex())
+            .startSpan();
+    activeSpans.put(iterationKey(event.taskIndex(), event.iterationIndex()), span);
+    iterationContexts.put(
+            iterationKey(event.taskIndex(), event.iterationIndex()),
+            Context.root().with(span));
+}
+```
+
+On completion the span records usage and the branch the model took:
+
+| Attribute | Source |
+|-----------|--------|
+| `gen_ai.usage.input_tokens` | `event.inputTokens()` (omitted when negative) |
+| `gen_ai.usage.output_tokens` | `event.outputTokens()` (omitted when negative) |
+| `agentensemble.llm.response_type` | `event.responseType()` -- `TOOL_CALLS` or `FINAL_ANSWER` |
+| `agentensemble.llm.tool_request_count` | `event.toolRequests().size()` |
+| `agentensemble.duration_ms` | `event.latency().toMillis()` |
+
+`responseType` as a span attribute is what makes tool-selection drift visible in trace search
+without any metrics pipeline: a TraceQL query filtering on `response_type = "FINAL_ANSWER"`
+at iteration 0 finds every run where the model answered without consulting a tool.
+
+**Tool span re-parenting.** Once iteration spans exist, tool spans should parent to the
+iteration that requested them rather than to the task. `ToolCallEvent` does not carry an
+iteration index, so this issue keeps tool spans parented to the task and leaves the
+finer-grained attachment to a follow-up that adds `iterationIndex` to `ToolCallEvent`. The
+`iterationContexts` map is introduced here so that follow-up is a one-line change.
+
+**Volume.** A ReAct loop runs single-digit iterations per task, so this adds spans
+proportional to existing task spans, not to tokens. It is enabled by default, with an opt-out
+for users who want the previous span volume:
+
+```java
+OTelTracingListener.builder(openTelemetry)
+        .llmSpans(false)
+        .build();
+```
+
+The existing `OTelTracingListener.create(openTelemetry)` factory is retained and delegates to
+the builder with defaults.
+
+### 3.4 OT-004: Tool span duration and outcome status
+
+**Module:** `agentensemble-telemetry-opentelemetry`
+
+`onToolCall` fires after the tool has executed, carrying only a `Duration`. Backdate the
+start timestamp so the span occupies real width:
+
+```java
+Instant end = Instant.now();
+Instant start = end.minus(event.duration());
+
+Span span = tracer.spanBuilder("tool.execute")
+        .setSpanKind(SpanKind.INTERNAL)
+        .setParent(parentFor(event.taskIndex()))
+        .setStartTimestamp(start)
+        .setAttribute(OTelAttributes.TOOL_NAME, event.toolName())
+        .setAttribute(GenAiAttributes.TOOL_NAME, event.toolName())
+        .setAttribute(OTelAttributes.AGENT_ROLE, event.agentRole())
+        .startSpan();
+applyToolOutcome(span, event.outcome());
+span.end(end);
+```
+
+Using `Instant.now()` as the end timestamp introduces skew equal to the dispatch latency
+between tool completion and listener invocation -- sub-millisecond in practice. Eliminating
+it entirely would require adding `startedAt`/`completedAt` to `ToolCallEvent`;
+`ToolCallTrace` already carries both, so the data exists. Noted as an optional refinement
+rather than a prerequisite.
+
+**Outcome mapping.** `ToolCallEvent.outcome()` is a `String` carrying the name of a
+`ToolCallOutcome`. The three values map to two span statuses, and the distinction matters:
+
+| Outcome | Span status | Rationale |
+|---------|-------------|-----------|
+| `SUCCESS` | `StatusCode.OK` | Tool ran, produced a positive result |
+| `FAILURE` | `StatusCode.OK` + `agentensemble.tool.outcome=FAILURE` | Tool ran correctly and returned a negative result (no search hits, validation did not pass). Not an error. |
+| `ERROR` | `StatusCode.ERROR` | Tool malfunctioned |
+
+Marking `FAILURE` as a span error would make every empty search result look like an outage
+and would corrupt error-rate panels built on span status. This mirrors the three-way split
+already present in the `ToolMetrics` SPI.
+
+### 3.5 OT-005: GenAI semantic conventions
+
+**Module:** `agentensemble-telemetry-opentelemetry`
+
+Add a `GenAiAttributes` holder alongside `OTelAttributes` and **dual-emit**: framework
+concepts keep their `agentensemble.*` keys, and the standard equivalents are added
+alongside. Nothing is removed, so existing dashboards continue to work.
+
+| Standard key | Value | Emitted on |
+|--------------|-------|-----------|
+| `gen_ai.operation.name` | `chat` | iteration spans |
+| `gen_ai.provider.name` | provider identifier, when known | iteration spans |
+| `gen_ai.request.model` | model identifier, when known | iteration spans |
+| `gen_ai.usage.input_tokens` | prompt tokens | iteration spans |
+| `gen_ai.usage.output_tokens` | completion tokens | iteration spans |
+| `gen_ai.agent.name` | `agentRole` | task, iteration, tool spans |
+| `gen_ai.tool.name` | tool name | tool spans |
+
+Span naming for iteration spans follows the convention `{operation} {model}` (for example
+`chat claude-opus-4`), falling back to the operation alone when the model is unknown.
+
+**The model identity constraint.** AgentEnsemble is LLM-agnostic through LangChain4j, and
+LangChain4j's `ChatModel` interface does not expose a model identifier -- each provider
+implementation stores it privately in its builder. There is therefore no way to interrogate
+a configured model for its name at runtime.
+
+Three options were considered:
+
+1. Reflectively probe provider implementations for a model field. Rejected: brittle, breaks
+   on every provider release, and contradicts the framework's "no reflection tricks"
+   principle.
+2. Require the model name. Rejected: a breaking change to every builder for a
+   telemetry-only concern.
+3. Accept an **optional** `modelName(String)` on the `Agent`, `Task`, and `Ensemble`
+   builders, used purely for telemetry labelling and resolved with the same precedence as
+   model resolution itself (agent, then task, then ensemble).
+
+Option 3 is selected. When unset, `gen_ai.request.model` and `gen_ai.provider.name` are
+**omitted entirely** rather than emitted as `unknown`. An absent attribute is honest and
+filterable; a placeholder string pollutes group-by results and silently merges distinct
+models into one bucket.
+
+This constraint is worth stating in the guide: users who want model-attributed cost and
+latency must declare `modelName` explicitly.
+
+## 4. Issue Dependency Graph
+
+```
+OT-001 (task correlation IDs)
+   ├──> OT-002 (span parenting)
+   │        ├──> OT-003 (iteration spans)
+   │        └──> OT-004 (tool duration + status)
+   └──> OT-003
+
+OT-005 (GenAI semconv) ──> depends on OT-003 for iteration spans to attach to;
+                            modelName plumbing is independent and may land first
+```
+
+OT-001 is a pure enabler and unblocks everything else. OT-002 and OT-004 are independently
+valuable and could ship without OT-003. OT-005's attribute definitions can land at any point;
+its `modelName` builder plumbing touches `agentensemble-core` and should be reviewed
+separately from the telemetry module changes.
+
+## 5. Testing Strategy
+
+The OpenTelemetry SDK ships `opentelemetry-sdk-testing` with `InMemorySpanExporter`, which
+makes span assertions ordinary unit tests. Add it as a `testImplementation` dependency;
+`io.opentelemetry:opentelemetry-api` remains `compileOnly` so downstream users who do not
+want OTel are unaffected.
+
+### OT-001
+- Compatibility constructor sets `taskIndex` to `-1`.
+- Full constructor round-trips the supplied index.
+- `AgentExecutor` fires iteration events carrying the executing task's index; asserted with
+  a capturing listener under both `SEQUENTIAL` and `PARALLEL` workflows.
+
+### OT-002
+- Tool span's parent span ID equals the enclosing task span's span ID.
+- Under `PARALLEL` with three concurrent tasks, each tool span attaches to its own task --
+  the regression test for the virtual-thread case.
+- A task that fails removes its context entry: run N failing tasks, assert the internal map
+  is empty afterwards.
+- A tool event with `taskIndex == -1` parents to the run root without throwing.
+
+### OT-003
+- One iteration span per ReAct iteration, in order, with `iterationIndex` ascending.
+- Iteration span parents to its task span.
+- `responseType` attribute matches the event.
+- Negative token counts are omitted, not emitted as `-1`.
+- `llmSpans(false)` produces zero iteration spans and does not affect other span types.
+- An ensemble that fails mid-iteration does not leave an unended span.
+
+### OT-004
+- Span duration is within tolerance of `event.duration()` rather than zero.
+- `SUCCESS` and `FAILURE` both yield `StatusCode.OK`; only `ERROR` yields `StatusCode.ERROR`.
+- `FAILURE` carries the distinguishing attribute.
+
+### OT-005
+- Both `agentensemble.*` and `gen_ai.*` attributes are present on iteration spans.
+- With `modelName` unset, neither `gen_ai.request.model` nor `gen_ai.provider.name` appears
+  in the attribute set.
+- Span name is `chat <model>` when known and `chat` when not.
+
+Coverage must satisfy the module's existing gates: 90% line, 75% branch.
+
+## 6. Design Decisions
+
+**Explicit parent keys over `Context.makeCurrent()`.** Thread-local context does not survive
+the virtual-thread boundary in `PARALLEL` workflows, and holding a `Scope` open across two
+listener callbacks leaks whenever a task does not complete. Keying by `taskIndex` is
+deterministic under every workflow strategy and holds no thread-affine state. The cost is one
+map entry per in-flight task.
+
+**Dual-emit rather than migrate to `gen_ai.*`.** Replacing the `agentensemble.*` namespace
+would silently break every dashboard and alert rule built against the current attributes. The
+duplicated attributes cost a few bytes per span and buy ecosystem compatibility. A future
+major version may deprecate the framework-private keys where a standard equivalent exists.
+
+**Omit unknown model rather than emit a placeholder.** `unknown` as an attribute value merges
+distinct models into a single group-by bucket and makes the resulting panel confidently wrong.
+An absent attribute is visibly absent.
+
+**`FAILURE` is not a span error.** A tool that correctly reports "no results" has not failed
+in the observability sense. Conflating it with `ERROR` makes error-rate panels track the
+world's contents rather than the system's health -- the distinction the three-way
+`ToolMetrics` split already encodes.
+
+**Iteration spans default on.** Span volume grows with reasoning iterations, which are
+single-digit per task, not with tokens. The debugging value of seeing the ReAct loop in a
+waterfall outweighs a small constant-factor increase in span count. The opt-out exists for
+users with strict span budgets.
+
+**Nested delegation parenting deferred.** Correct attachment at `delegationDepth > 1`
+requires a new field on `DelegationStartedEvent`. Bundling it here would expand the change
+surface across the delegation subsystem for a case that only arises in deep hierarchical
+networks; the tree is still correct, only flatter, in the interim.

--- a/docs/design/32-behavioral-metrics.md
+++ b/docs/design/32-behavioral-metrics.md
@@ -1,0 +1,430 @@
+# 32 - Behavioral Metrics
+
+**Status:** Proposed
+**Target version:** 3.7.0
+**Date:** 2026-08-05
+
+## 1. Motivation
+
+AgentEnsemble emits process metrics -- durations, token counts, tool success and failure
+rates. These detect mechanical failure: a tool threw, an API timed out, a run errored.
+
+They do not detect the characteristic agent failure, in which the run succeeds, latency is
+normal, no exception is thrown, and the output is wrong. A model upgrade that causes a
+research agent to stop calling its search tool and answer from parametric memory *improves*
+every existing metric: latency falls because network round-trips disappear, token counts
+fall because retrieved context no longer enters the prompt, and the error rate stays at
+zero because nothing errored. The agent is now fabricating and the dashboard is green.
+
+What separates the healthy run from the fabricating one is *behavior*: how many reasoning
+iterations it took, which tools the model chose, whether it repeated itself, how deep it
+delegated. These are observable from events the framework already fires, and none of them
+are currently aggregated.
+
+The property that makes behavioral metrics worth building before any evaluation
+infrastructure is that **they require no ground truth**. There is no judge model, no labelled
+dataset, and no human in the loop. They detect that behavior changed, which in practice
+precedes any movement in outcome quality -- often by weeks.
+
+This design adds a behavioral metrics layer as five issues (BM-001 through BM-005).
+
+## 2. Current State
+
+### 2.1 Data Already Flowing
+
+Every signal below is derivable from events the framework fires today:
+
+| Signal | Source event | Field |
+|--------|--------------|-------|
+| Reasoning iterations per task | `LlmIterationCompletedEvent` | `iterationIndex` |
+| Model decision branch | `LlmIterationCompletedEvent` | `responseType` (`TOOL_CALLS` / `FINAL_ANSWER`) |
+| Tools the model *chose* | `LlmIterationCompletedEvent` | `toolRequests()` |
+| Tools that actually *ran* | `ToolCallEvent` | `toolName`, `outcome` |
+| Tool arguments (for repetition detection) | `ToolCallEvent` | `toolArguments` |
+| Delegation depth | `DelegationStartedEvent` | `delegationDepth` |
+| Per-iteration token usage | `LlmIterationCompletedEvent` | `inputTokens`, `outputTokens` |
+| Task boundaries | `TaskStartEvent` / `TaskCompleteEvent` / `TaskFailedEvent` | `taskIndex` |
+
+### 2.2 Gaps
+
+| Gap | Root cause |
+|-----|-----------|
+| No iteration-count aggregation | No listener consumes `LlmIterationCompletedEvent` for metrics |
+| No response-type distribution | `responseType` is carried but never counted |
+| No tool-selection distribution | `ToolMetrics` counts executions, not model choices |
+| No repetition detection | Nothing compares tool calls within a task |
+| No delegation depth distribution | `delegationDepth` is carried but never aggregated |
+| No metrics SPI for non-tool signals | `ToolMetrics` is tool-scoped: every method takes a `toolName` |
+| No guardrail, review, or output-repair events | `EnsembleListener` has no callbacks for these gates |
+| No way to attach deployment labels | No mechanism to tag metrics with `prompt_version` or similar |
+
+**An inconsistency worth resolving alongside BM-004.** `AuditingListener`'s Javadoc states
+that the `STANDARD` audit level records "task start/complete/fail, review decisions", but
+`EnsembleListener` defines no review callback and `AuditingListener` overrides none. The
+documented behavior is not implemented. BM-004 introduces the missing event; the Javadoc
+should be corrected either way.
+
+## 3. Design
+
+### 3.1 BM-001: `BehavioralMetrics` SPI
+
+**Module:** `agentensemble-core`, package `net.agentensemble.metrics`
+
+A new interface, following the same pluggable-sink pattern as `ToolMetrics`: the SPI and a
+no-op default live in core, backend implementations live in their own modules.
+
+```java
+public interface BehavioralMetrics {
+
+    /** Reasoning iterations consumed by a completed task. */
+    void recordIterations(String agentRole, String taskName, int iterations);
+
+    /** The branch the model took on one iteration: TOOL_CALLS or FINAL_ANSWER. */
+    void incrementResponseType(String agentRole, String responseType);
+
+    /** A tool the model requested. Counts intent, not execution. */
+    void incrementToolSelection(String agentRole, String toolName);
+
+    /** Distinct tool-call signatures divided by total tool calls, for one task. */
+    void recordNoveltyRatio(String agentRole, String taskName, double ratio);
+
+    /** Delegation depth observed on a handoff. */
+    void recordDelegationDepth(String agentRole, int depth);
+
+    /** Outcome of a validation gate. See BM-004. */
+    void incrementValidationOutcome(String gate, String agentRole, String outcome);
+}
+```
+
+`NoOpBehavioralMetrics` provides an empty implementation and is the default, mirroring
+`NoOpToolMetrics`. All methods return `void` and must not throw; implementations that wrap a
+registry are responsible for their own error containment.
+
+**Why not extend `ToolMetrics`.** Every `ToolMetrics` method takes a `toolName` as its
+subject, because the interface models measurements *about a tool*. Iteration counts,
+response-type distributions, and delegation depth have no tool. Forcing them through the
+existing generic `incrementCounter(metricName, toolName, tags)` escape hatch would require a
+synthetic tool name on every call and would make the metric names untyped strings at every
+call site. A separate interface keeps both contracts honest.
+
+### 3.2 BM-002: `BehavioralMetricsListener`
+
+**Module:** `agentensemble-core`, package `net.agentensemble.metrics`
+
+An `EnsembleListener` that accumulates per-task state and flushes derived signals at task
+boundaries. All computation is backend-agnostic; only the sink is pluggable.
+
+```java
+public final class BehavioralMetricsListener implements EnsembleListener {
+
+    private final BehavioralMetrics metrics;
+    private final ConcurrentHashMap<Integer, TaskAccumulator> accumulators =
+            new ConcurrentHashMap<>();
+    ...
+}
+```
+
+**Event handling.**
+
+| Callback | Action |
+|----------|--------|
+| `onTaskStart` | Create an accumulator keyed by `taskIndex` |
+| `onLlmIterationCompleted` | Increment iteration count; `incrementResponseType`; `incrementToolSelection` for each entry in `toolRequests()` |
+| `onToolCall` | Add the call's signature to the accumulator |
+| `onDelegationStarted` | `recordDelegationDepth`; track the task's maximum |
+| `onTaskComplete` / `onTaskFailed` | Flush `recordIterations` and `recordNoveltyRatio`; remove the accumulator |
+| `onEnsembleCompleted` | Clear all accumulators (safety net) |
+
+**Tool selection is measured from `toolRequests()`, not from `ToolCallEvent`.** These differ
+whenever a requested tool does not execute -- blocked by a delegation guard, rejected by a
+policy, or unavailable. The distinction is diagnostically important: a rising selection count
+paired with a flat execution count means the model is repeatedly asking for a capability it
+is not being granted, which is invisible if only executions are counted. `ToolMetrics`
+continues to own execution outcomes; the two are complementary and should not be merged.
+
+**Accumulator lifecycle and leak safety.** The accumulator map is the one place this listener
+can leak. Three guards:
+
+1. Removal happens on **both** `onTaskComplete` and `onTaskFailed`. Omitting the failure path
+   leaks one accumulator per failed task, unbounded over the life of a long-running ensemble
+   service.
+2. `onEnsembleCompleted` clears the map, catching tasks that terminated through a path that
+   fired neither callback.
+3. The distinct-signature set within an accumulator is capped (default 1,000 entries). Beyond
+   the cap, totals keep incrementing but new signatures are not retained, so the reported
+   novelty ratio becomes a lower bound. This is the correct direction to be wrong in: a
+   thrashing run under-reports its novelty and looks *worse*, never better.
+
+**Thread safety.** Listener callbacks may run concurrently on virtual threads under
+`PARALLEL` workflows. The map is a `ConcurrentHashMap`; each accumulator uses atomic counters
+and a synchronized signature set. Accumulators are per-task, so contention is limited to the
+rare case of concurrent tool calls within a single task.
+
+### 3.3 BM-003: Novelty ratio and call signatures
+
+**Module:** `agentensemble-core`
+
+The novelty ratio detects non-productive iteration -- an agent burning tokens re-invoking the
+same tool with equivalent arguments, making no progress. It is defined per task as:
+
+```
+novelty = distinct tool-call signatures / total tool calls
+```
+
+A value near 1.0 means every action was new. A value below roughly 0.5 means the agent
+repeated more than half of its actions.
+
+**Signature construction.**
+
+```
+signature = toolName + ":" + sha256(canonicalize(toolArguments)).substring(0, 16)
+```
+
+`canonicalize` attempts to parse the arguments as JSON and re-serialize with object keys
+sorted, so that `{"a":1,"b":2}` and `{"b":2,"a":1}` produce the same signature. Arguments
+that do not parse fall back to a trimmed raw string. Parsing failures are never propagated --
+a malformed argument string is hashed as-is.
+
+**Only the truncated hash is retained.** Raw arguments are never stored in the accumulator.
+This bounds memory to 16 bytes per distinct call regardless of payload size, and means an
+instrumentation path that runs on every request holds no user data. Sixteen hex characters
+give a collision probability that is negligible against the per-task call counts involved,
+and a collision would only slightly under-report novelty.
+
+**Emission threshold.** The ratio is emitted only when a task made at least two tool calls. A
+single-call task has a ratio of exactly 1.0 by construction, and including those datapoints
+pulls the distribution toward 1.0 in proportion to how many trivial tasks the workload
+contains -- which would mask thrashing in the tasks that actually do work.
+
+### 3.4 BM-004: Validation gate events
+
+**Module:** `agentensemble-core`, `agentensemble-review`
+
+Validation gates are the cheapest source of outcome signal available: every one of them is
+already computing a correctness judgment on live traffic and discarding it. Surfacing them
+requires new events, since `EnsembleListener` has no callbacks for guardrails, structured
+output repair, or review decisions.
+
+```java
+public record GuardrailEvaluatedEvent(
+        String guardrailName,
+        String guardrailType,   // "INPUT" or "OUTPUT"
+        String agentRole,
+        int taskIndex,
+        boolean passed,
+        String reason) {}
+
+public record OutputRepairEvent(
+        String agentRole,
+        int taskIndex,
+        int attempt,            // 1-based
+        boolean succeeded,
+        String failureKind) {}  // e.g. "PARSE_ERROR", "SCHEMA_MISMATCH"
+
+public record ReviewDecisionEvent(
+        String agentRole,
+        int taskIndex,
+        String reviewerId,
+        String decision) {}     // "APPROVED", "REJECTED", "REVISED"
+```
+
+Corresponding `EnsembleListener` callbacks (`onGuardrailEvaluated`, `onOutputRepair`,
+`onReviewDecision`) are added with default no-op bodies, and matching `fire*` methods on
+`ExecutionContext`. Emission sites: guardrail evaluation in the executor, the structured
+output parse-and-correct loop in `net.agentensemble.output`, and the review gate in
+`agentensemble-review`.
+
+`BehavioralMetricsListener` maps all three onto `incrementValidationOutcome`, using the gate
+name as the first argument and pass/fail (or the decision) as the outcome.
+
+**`OutputRepairEvent` deserves particular attention.** The rate at which structured output
+requires a correction prompt is a direct, continuous measurement of the model's
+instruction-following fidelity, computed on live traffic at zero marginal cost. It is among
+the earliest indicators of a provider-side model regression, and today the framework performs
+the repair silently and reports nothing.
+
+This issue is independently valuable: the events are useful to the live dashboard, to
+`ExecutionTrace`, and to audit sinks whether or not the metrics listener consumes them. It
+should be reviewable separately from BM-001 through BM-003.
+
+### 3.5 BM-005: Micrometer implementation and wiring
+
+**Module:** `agentensemble-metrics-micrometer`, `agentensemble-core`
+
+`MicrometerBehavioralMetrics` implements the SPI against a `MeterRegistry`, following the
+existing `MicrometerToolMetrics` pattern (`compileOnly` Micrometer dependency, so users who
+do not want it pull nothing transitively).
+
+| Metric | Type | Tags |
+|--------|------|------|
+| `agentensemble.task.iterations` | DistributionSummary | `agent_role`, `task_name` |
+| `agentensemble.llm.response_type` | Counter | `agent_role`, `response_type` |
+| `agentensemble.llm.tool_selection` | Counter | `agent_role`, `tool_name` |
+| `agentensemble.task.novelty_ratio` | DistributionSummary | `agent_role` |
+| `agentensemble.delegation.depth` | DistributionSummary | `agent_role` |
+| `agentensemble.validation.outcome` | Counter | `gate`, `agent_role`, `outcome` |
+
+Both distribution summaries are registered with `publishPercentileHistogram()`. Without it,
+Micrometer exports only count, sum, and max, and the tail-fattening that makes
+iteration-count the highest-value drift signal is exactly what a max cannot show. Percentile
+histograms are the reason this metric is worth collecting at all.
+
+**Common tags and version attribution.** Behavioral metrics are worthless for regression
+attribution unless they carry the version of the thing that changed. Prompt edits are not
+code deployments -- they do not appear in deploy markers and may not be in version control --
+so without a prompt-version dimension a drift can be detected but never attributed.
+
+The Micrometer implementation accepts common tags applied to every meter it registers:
+
+```java
+BehavioralMetrics metrics = MicrometerBehavioralMetrics.builder(registry)
+        .commonTag("prompt_version", "7")
+        .commonTag("model", "claude-opus-4")
+        .commonTag("deployment", "prod")
+        .build();
+```
+
+Users should be directed to set `prompt_version` in the guide, in the strongest terms the
+documentation tone allows.
+
+**Ensemble wiring.** A builder method mirroring the existing `toolMetrics` configuration
+constructs and registers the listener, so the common case needs no knowledge of the listener
+class:
+
+```java
+Ensemble.builder()
+        .behavioralMetrics(metrics)   // registers BehavioralMetricsListener internally
+        .build();
+```
+
+Registering `BehavioralMetricsListener` directly via `.listener(...)` remains supported for
+users who want to control ordering or wrap the sink.
+
+### 3.6 Cardinality
+
+Every tag in the table above is bounded by configuration rather than by traffic: agent roles,
+tool names, task names, response types, gate names, and decisions are all fixed at build
+time. This is deliberate and must stay true.
+
+The following must never become tags: task descriptions, prompt text, tool arguments, tool
+results, user input, session or run identifiers, or call signatures. Each is unbounded, and
+each new distinct value allocates a permanent time series in most registries. Signatures in
+particular exist only inside the accumulator and are never passed to the SPI -- the SPI
+receives the derived ratio, a single double.
+
+Per-run detail belongs in `ExecutionTrace` and in spans, where it can be queried after the
+fact without allocating a series. This division -- bounded aggregates in the metrics backend,
+high-dimensional detail in the trace backend -- is the single most important operational
+constraint in this design.
+
+## 4. Issue Dependency Graph
+
+```
+BM-001 (BehavioralMetrics SPI)
+   └──> BM-002 (BehavioralMetricsListener)
+            ├──> BM-003 (novelty ratio + signatures)
+            └──> BM-005 (Micrometer impl + wiring)
+
+BM-004 (validation gate events) ──> BM-002 consumes them
+                                    (independently valuable; ships standalone)
+
+Design 31 / OT-001 (taskIndex on iteration + delegation events)
+   └──> BM-002 keys accumulators by taskIndex
+```
+
+**BM-002 depends on OT-001 from design 31.** `LlmIterationCompletedEvent` and
+`DelegationStartedEvent` do not currently carry `taskIndex`, so per-task accumulation cannot
+key on them. OT-001 adds the field to both. Sequencing OT-001 first serves both designs;
+absent it, BM-002 would need to key on `(agentRole, taskDescription)`, which is ambiguous
+when the same role runs concurrent tasks under `PARALLEL`.
+
+BM-004 has no dependency on the rest and can be implemented, reviewed, and merged
+independently.
+
+## 5. Testing Strategy
+
+Micrometer's `SimpleMeterRegistry` makes assertions on emitted meters ordinary unit tests. No
+new test dependency is required beyond what `agentensemble-metrics-micrometer` already
+declares.
+
+### BM-001
+- `NoOpBehavioralMetrics` accepts every call without throwing, including nulls.
+
+### BM-002
+- Iteration count for a task equals the number of `LlmIterationCompletedEvent`s fired.
+- Response-type counter increments once per iteration with the correct label.
+- Tool selection increments once per entry in `toolRequests()`, including multiple requests
+  in a single iteration.
+- A requested-but-blocked tool increments selection but not `ToolMetrics` executions -- the
+  regression test for the selection/execution distinction.
+- **Leak tests:** after N failed tasks the accumulator map is empty; after an ensemble
+  completes with an abandoned task the map is empty.
+- Under `PARALLEL` with concurrent tasks sharing one agent role, accumulators do not
+  cross-contaminate.
+
+### BM-003
+- `{"a":1,"b":2}` and `{"b":2,"a":1}` produce identical signatures.
+- Malformed JSON arguments hash without throwing.
+- Ten identical calls yield a ratio of 0.1; ten distinct calls yield 1.0.
+- A task with one tool call emits no ratio datapoint.
+- Exceeding the signature cap keeps totals accurate and reports a lower-bound ratio.
+- Raw arguments are absent from the accumulator after recording (assert by reflection or by
+  exposing a test-visible view).
+
+### BM-004
+- Each new event fires from its emission site with correct field values.
+- Guardrail pass and fail both produce a datapoint, with distinct outcome labels.
+- A structured output requiring two correction attempts produces two `OutputRepairEvent`s
+  with `attempt` 1 and 2, the second marked succeeded.
+- Existing listeners compile and run unchanged against the extended interface.
+
+### BM-005
+- Every metric in the table is registered with expected name, type, and tag keys.
+- Distribution summaries expose percentile histogram buckets.
+- Common tags appear on every meter.
+- A registry that throws on `register` does not propagate the exception into task execution.
+
+Coverage must satisfy the existing gates: 90% line, 75% branch.
+
+## 6. Design Decisions
+
+**A separate SPI rather than extending `ToolMetrics`.** `ToolMetrics` models measurements
+about a tool; every method takes a `toolName`. Behavioral signals have no tool subject.
+Routing them through the generic escape hatch would require synthetic tool names and untyped
+metric-name strings at every call site.
+
+**Computation in core, sink pluggable.** Accumulation, canonicalization, hashing, and ratio
+arithmetic are identical regardless of backend. Putting them in the Micrometer module would
+force reimplementation for every future backend and would make the logic untestable without
+Micrometer on the classpath.
+
+**Tool *selection* measured separately from tool *execution*.** They diverge precisely when
+something is preventing the model from doing what it intends -- a guard, a policy, a missing
+tool -- which is a class of problem invisible to execution counters. Keeping both is a small
+cost for a signal that has no substitute.
+
+**Only hashes retained, never arguments.** Bounds memory to a constant per distinct call
+irrespective of payload size, and keeps an always-on instrumentation path free of user data.
+The privacy property matters independently of the memory one.
+
+**Novelty ratio suppressed below two calls.** Single-call tasks have a ratio of 1.0 by
+construction. Including them shifts the distribution toward 1.0 in proportion to how many
+trivial tasks the workload contains, masking thrashing in the tasks that do real work.
+
+**Signature cap under-reports rather than over-reports.** When the cap is hit, novelty is
+computed against a truncated distinct set, so a pathological run appears *more* repetitive
+than it is. An instrumentation approximation should fail toward raising an alarm, not toward
+silence.
+
+**Percentile histograms are mandatory, not optional.** The value of iteration-count as a
+drift signal is entirely in its tail. A metric exposing only count, sum, and max cannot show
+tail fattening, which makes the collection pointless.
+
+**Common tags exposed at the sink, not per call.** `prompt_version` and friends are constant
+for the lifetime of a process. Threading them through every SPI method would add a parameter
+to every signature for a value that never varies within a run.
+
+**Validation gate events kept as a standalone issue.** The events are useful to the live
+dashboard, the execution trace, and audit sinks regardless of whether metrics consume them,
+and they touch three modules. Bundling them with the metrics work would make a reviewable
+change unreviewable.

--- a/docs/whitepaper/agent-observability.md
+++ b/docs/whitepaper/agent-observability.md
@@ -1,0 +1,885 @@
+# Observability for Agentic Systems: Instrumenting Software That Fails Silently
+
+**Abstract** -- Classical application observability rests on an assumption that agentic
+systems violate: that failure is loud. Metrics, logs, and traces were designed for
+deterministic software in which a fault manifests as an exception, a non-2xx status, or a
+latency excursion. An AI agent's characteristic failure is none of these. It completes
+successfully, within normal latency, emitting no errors, and produces work that is wrong.
+Every dashboard built from classical signals reports a healthy system throughout. We argue
+that agent observability requires a four-layer instrumentation model -- process,
+behavioral, outcome, and economic -- and that the layers most people build first are the
+least informative. We describe how AgentEnsemble implements these layers in-process, where
+the framework owns the execution loop and can instrument any point within it. We then
+contrast this with the structurally different problem of observing CLI coding agents such
+as Claude Code and OpenAI Codex, where the loop is a vendor binary and instrumentation is
+limited to emitted exhaust, injected seams, and observable effects on the world. We show
+that the two regimes invert: the quality layer that is hardest in-process is nearly free
+out-of-process, because a human is supplying continuous labels; while the prompt-version
+dimension that is trivial in-process becomes structurally unavailable. We conclude with
+reference architectures for both regimes and identify the unattended-CLI case as the
+configuration where neither approach is adequate.
+
+---
+
+## 1. Introduction
+
+Production monitoring has a well-established vocabulary. The "golden signals" -- latency,
+traffic, errors, saturation [1] -- give operators a compact model of service health.
+Distributed tracing [2] reconstructs causality across process boundaries. Structured
+logging provides forensic depth. Together these three pillars are sufficient to operate
+most distributed systems, and the tooling ecosystem around them -- OpenTelemetry,
+Prometheus, Grafana, Tempo, Loki -- is mature and interoperable.
+
+Applying this vocabulary to AI agents produces dashboards that are simultaneously correct
+and useless.
+
+Consider a research agent that, following a model version upgrade, stops calling its web
+search tool and begins answering from parametric memory. Latency *improves*, because
+network round-trips disappear. Token consumption *falls*, because retrieved context no
+longer enters the prompt. The error rate is unchanged at zero: no exception is thrown,
+because nothing exceptional happened. The agent is now confidently fabricating, and every
+classical signal reports improvement.
+
+This is not a contrived example; it is the modal agent regression. The generalization is
+that **an agent's output correctness is statistically independent of its execution
+health.** No amount of refinement to latency histograms will recover the missing signal,
+because the signal was never in the latency.
+
+The instrumentation question for agents is therefore not "how do I export metrics from my
+agent" -- that is a solved plumbing problem. It is the prior question: *what is the
+agent-equivalent of an exception?* This paper argues there are four such equivalents,
+organizes them into layers, and examines how the layers are realized under two very
+different structural regimes.
+
+---
+
+## 2. The Failure Taxonomy
+
+### 2.1 Why classical signals under-fit
+
+Classical observability instruments the *machinery*. For deterministic software this is
+adequate, because the machinery and the work are tightly coupled: if the code executed
+without error, the work was almost certainly done, and the remaining risk is a logic bug
+that testing is supposed to catch.
+
+Agents decouple the machinery from the work. The machinery is a loop that calls a model,
+parses a response, dispatches tools, and repeats. That loop can execute flawlessly while
+the model inside it makes a sequence of poor decisions. There is no exception to throw,
+because "chose the wrong tool" is not an error condition -- it is a valid completion of the
+control flow.
+
+### 2.2 A taxonomy of agent failures
+
+We identify five failure modes, only the first of which classical observability detects:
+
+**F1 -- Mechanical failure.** A tool throws, an API times out, a rate limit is hit, a JSON
+parse fails irrecoverably. Detected by conventional error instrumentation. This is the
+easiest and least interesting class.
+
+**F2 -- Behavioral drift.** The agent still succeeds, but *differently* than it used to:
+more reasoning iterations, a shifted distribution over tool selection, deeper delegation
+chains. Drift is the leading indicator of most quality regressions, and it precedes any
+movement in error rate -- often by weeks. It is invisible to classical instrumentation
+because nothing failed.
+
+**F3 -- Non-productive iteration.** The agent expends resources without advancing:
+re-invoking the same tool with equivalent arguments, re-reading files it has already read,
+restating conclusions. Motion without progress. This class is unique to agents; there is no
+analogue in request/response software, where a request either progresses or errors.
+
+**F4 -- Silent quality collapse.** The output is well-formed, on-topic, delivered on time,
+and wrong. No layer of process instrumentation can detect this. It requires either a
+ground-truth comparison, a judge, or a human.
+
+**F5 -- Economic failure.** The work is completed correctly but at unacceptable cost. In
+conventional services, cost per request is roughly stable and roughly proportional to
+traffic; capacity planning handles it. In agents, cost per unit of completed work varies by
+two orders of magnitude according to model behavior, and can regress dramatically without
+any other signal moving.
+
+Modes F2 through F5 constitute the substance of agent observability. Each requires a
+distinct instrumentation layer.
+
+---
+
+## 3. A Four-Layer Instrumentation Model
+
+We organize agent instrumentation into four layers, each answering a different question and
+detecting a different failure class.
+
+### 3.1 Layer 1 -- Process: "Did the machinery work?"
+
+Conventional signals applied to agent-shaped boundaries: task duration, tool call latency
+and error rate, LLM API latency and failure rate, retry and rate-limit counts. Detects F1.
+
+This layer is necessary, well-understood, and insufficient. Its main value is that it is a
+prerequisite for the others: the boundaries you instrument here (task, tool call, LLM
+request, delegation) become the join points for higher-layer signals.
+
+### 3.2 Layer 2 -- Behavioral: "Did it act the way it usually acts?"
+
+The central insight of this layer is that **the unit of health is not the request, it is
+the trajectory.** In a conventional service a request is a request; its shape is fixed by
+the code path. In an agent, a task encloses a variable-length reasoning loop, and the
+*shape* of that loop carries the signal.
+
+The core behavioral instruments:
+
+- **Iterations to completion** (histogram). A healthy agent exhibits a tight distribution,
+  typically two to four reasoning turns. Degradation manifests first as tail fattening.
+  This is the single most valuable derived signal in agent observability, and it requires
+  no ground truth, no judge, and no labels.
+
+- **Response-type distribution** (counter over `TOOL_CALLS` vs `FINAL_ANSWER`). The ratio
+  is a behavioral fingerprint of the agent-model pairing. It moves the moment a prompt or
+  model version changes.
+
+- **Tool selection distribution** (counter over tool name). Distinct from tool *success*
+  rate. This measures which capability the model *chose*, and it is how the fabricating
+  research agent of Section 1 is caught: its search-tool selection rate goes to zero while
+  every other signal improves.
+
+- **Novelty ratio.** Distinct tool-call signatures (name plus hashed arguments) divided by
+  total tool calls, per task. A value below roughly 0.5 indicates thrashing. This is the
+  primary instrument for F3, and we are aware of no widely-deployed agent platform that
+  emits it by default.
+
+- **Delegation depth and fan-out.** In multi-agent systems, recursion depth and branching
+  factor. Runaway delegation is the agent analogue of a fork bomb, and it is expensive.
+
+Behavioral instrumentation is high-value and, when the framework owns the loop, nearly
+free -- every quantity above is derivable from events the executor already fires.
+
+### 3.3 Layer 3 -- Outcome: "Was the work any good?"
+
+This layer detects F4 and is the hardest to build, because it requires a notion of
+correctness external to the agent.
+
+There are three sources of outcome signal, in ascending order of cost:
+
+**Validation gates as sensors.** Any system with structured output, schema validation,
+guardrails, or review gates is already computing a correctness judgment on every run and
+usually discarding it. Structured-output repair attempts, guardrail trips, review
+rejections, and policy denials are quality telemetry available at zero marginal cost. The
+rate of automatic output-repair prompts in particular is a direct measurement of the
+model's instruction-following fidelity, and it is one of the earliest indicators of a model
+regression. Emitting these as counters is the highest return-on-effort action available in
+this layer.
+
+**Deterministic verification.** Where the domain admits it -- code that must compile, tests
+that must pass, JSON that must validate against a schema, numbers that must reconcile --
+the verifier is a free and unambiguous label. Coding agents are unusually fortunate here.
+
+**Model-based evaluation.** Sampling production runs and scoring them with a judge model or
+rubric. Expensive and imperfect, but the only option for open-ended generative work. The
+critical design requirement is that judge scores must be emitted **with the same label set
+as every other signal** -- agent role, model, prompt version, tool set -- so that quality
+can be sliced along the same dimensions as latency and cost. A quality score that cannot be
+joined to a deployment dimension identifies that something is wrong without identifying
+what changed.
+
+### 3.4 Layer 4 -- Economic: "What did it cost to get there?"
+
+Token consumption, cost, and cache utilization, attributed to model, agent, and task.
+
+The key derived metric is **cost per completed unit of work** -- tokens or dollars per task
+that reached an accepted terminal state, not per invocation. This is the agent equivalent
+of saturation. Unlike CPU utilization, it is not bounded by physical capacity, which means
+there is no natural backpressure and no upper limit on how badly it can regress. A prompt
+change that adds one reasoning iteration to the median task raises marginal cost by 30--50%
+with no other observable effect.
+
+Cache-hit ratio on prompt prefixes deserves separate treatment, since cached input tokens
+are typically an order of magnitude cheaper than uncached ones; a change that invalidates a
+stable prompt prefix can multiply cost without changing token counts materially.
+
+### 3.5 Two cross-cutting constraints
+
+**Cardinality discipline.** Metric labels must be bounded: agent role, stable task
+identifier, tool name, model, prompt version. Never task descriptions, prompt text, user
+input, or session identifiers. High-dimensional per-run data belongs in a trace or event
+store where it can be queried after the fact, not in a time-series database where each
+distinct label combination allocates a permanent series. The most common failure in agent
+observability deployments is attempting to express behavioral detail as Prometheus labels.
+
+**Version attribution is non-negotiable.** Every metric and span must carry the triple
+`(framework version, model identifier, prompt version)`. Agents change behavior when
+prompts change, and prompt edits are not code deployments -- they do not appear in deploy
+markers, they may not be in version control, and they may be made by someone who is not an
+engineer. Without a prompt-version dimension, a behavioral regression can be *detected* but
+never *attributed*. As Section 5.6 shows, this constraint is what most sharply distinguishes
+the two instrumentation regimes.
+
+---
+
+## 4. In-Process Instrumentation: The AgentEnsemble Approach
+
+When the framework owns the execution loop, instrumentation is a white-box problem: any
+quantity that can be computed at any point in the loop can be exported. AgentEnsemble
+exploits this through six mechanisms.
+
+### 4.1 The event model
+
+The `EnsembleListener` interface is the primary instrumentation seam. It defines callbacks
+at every semantically meaningful boundary in the execution loop:
+
+| Boundary | Events |
+|---|---|
+| Run | `onEnsembleStarted`, `onEnsembleCompleted` |
+| Task | `onTaskStart`, `onTaskInput`, `onTaskComplete`, `onTaskFailed` |
+| Reasoning iteration | `onLlmIterationStarted`, `onLlmIterationCompleted` |
+| Streaming | `onToken` |
+| Tool | `onToolCall` |
+| Delegation | `onDelegationStarted`, `onDelegationCompleted`, `onDelegationFailed` |
+| Control flow | `onLoopIterationCompleted`, `onGraphStateCompleted` |
+| Quality | `onTaskReflected` |
+| Side effects | `onFileChanged` |
+
+Three properties matter for observability. First, every method has a default no-op
+implementation, so an instrumentation listener declares only the boundaries it cares about.
+Second, listener exceptions are caught and logged by the framework -- a broken metrics
+exporter cannot abort a run, which is the correct failure semantic for instrumentation.
+Third, listeners may be invoked concurrently from multiple virtual threads under parallel
+workflows, so implementations must be thread-safe; this is a constraint, but it is the
+price of not serializing execution behind instrumentation.
+
+The presence of `onLlmIterationStarted` and `onLlmIterationCompleted` is what makes Layer 2
+instrumentation tractable. Iteration counts, response-type distributions, and per-iteration
+latency are all directly observable rather than inferred.
+
+### 4.2 The structured trace
+
+Alongside the event stream, every run produces an `ExecutionTrace`: a complete, serializable
+record of what happened, structured as a tree that mirrors the execution hierarchy.
+
+```
+ExecutionTrace
+├── ensembleId, workflow, startedAt, completedAt, totalDuration
+├── traceId                      -- W3C trace ID, when OTel is active
+├── inputs, agents[], errors[]
+├── metrics: ExecutionMetrics
+├── totalCostEstimate: CostEstimate
+├── loopTraces[], graphTrace, mapReduceLevels[]
+└── taskTraces[]: TaskTrace
+    ├── taskDescription, agentRole, duration
+    ├── prompts: TaskPrompts
+    ├── finalOutput, parsedOutput
+    ├── metrics: TaskMetrics
+    ├── delegations[]: DelegationTrace
+    └── llmInteractions[]: LlmInteraction
+        ├── iterationIndex, startedAt, completedAt, latency
+        ├── responseType: TOOL_CALLS | FINAL_ANSWER
+        ├── responseText
+        ├── messages[]: CapturedMessage      -- full conversation, tier-dependent
+        └── toolCalls[]: ToolCallTrace
+            ├── toolName, arguments, result, structuredOutput
+            ├── parsedInput                   -- tier-dependent
+            ├── startedAt, completedAt, duration
+            └── outcome: ToolCallOutcome
+```
+
+This structure is the framework's most distinctive observability asset. It is not a
+flattened event log that must be reassembled downstream; it is the reasoning tree itself,
+retaining parent-child relationships between tasks, iterations, and tool calls, with token
+counts and timing at every level. It serializes to JSON via `JsonTraceExporter` and is the
+substrate for offline analysis, regression comparison, and replay.
+
+`ExecutionMetrics` aggregates across the tree: input/output/total tokens, LLM latency, tool
+execution time, memory retrieval time, prompt build time, LLM call count, tool call count,
+delegation count, memory operation counts, and an aggregated cost estimate. Unknown token
+counts are represented as `-1` rather than `0`, preserving the distinction between "the
+provider did not report usage" and "no tokens were consumed" -- a distinction that silently
+corrupts cost dashboards when collapsed.
+
+### 4.3 Tiered capture
+
+Full-fidelity capture of every prompt, message, and tool payload is the only way to
+reproduce an agent failure, and is simultaneously too large to retain, too sensitive to
+centralize, and too slow to serialize on every run. `CaptureMode` resolves this with three
+tiers:
+
+| Tier | Captured | Size |
+|---|---|---|
+| `OFF` (default) | Prompts, tool arguments and results, timing, token counts | Minimal |
+| `STANDARD` | + full LLM message history per iteration, memory operation counts | Moderate |
+| `FULL` | + automatic JSON export to `./traces/`, parsed structured tool input | Larger |
+
+The design decision worth highlighting is the resolution order: explicit builder setting,
+then the `agentensemble.captureMode` JVM system property, then the
+`AGENTENSEMBLE_CAPTURE_MODE` environment variable, then `OFF`. Capture depth is therefore
+adjustable **without a code change or redeploy** -- a production incident can be escalated
+to full fidelity by restarting with a different environment variable. This mirrors the
+dynamic log-level adjustment that mature logging frameworks provide, applied to a far
+richer data stream.
+
+`CaptureMode` is orthogonal to log verbosity and to export destination; the three compose
+independently.
+
+### 4.4 Pluggable tool metrics
+
+The `ToolMetrics` interface decouples measurement from any specific metrics backend:
+
+```java
+void incrementSuccess(String toolName, String agentRole);
+void incrementFailure(String toolName, String agentRole);
+void incrementError(String toolName, String agentRole);
+void recordDuration(String toolName, String agentRole, Duration duration);
+void incrementCounter(String metricName, String toolName, Map<String,String> tags);
+void recordValue(String metricName, String toolName, double value, Map<String,String> tags);
+```
+
+The three-way outcome split -- success, failure, error -- is deliberate and matters more
+than it appears. "Failure" denotes a tool that executed correctly and returned a negative
+result (a search with no hits, a validation that did not pass); "error" denotes a tool that
+malfunctioned. Collapsing these, as a simple success/failure counter would, destroys the
+ability to distinguish "the world did not contain what the agent sought" from "our
+integration is broken" -- two conditions with entirely different remediations that a
+conventional error-rate metric renders identical.
+
+`MicrometerToolMetrics` provides the reference implementation, emitting
+`agentensemble.tool.executions` (counter; tags `tool_name`, `agent_role`, `outcome`) and
+`agentensemble.tool.duration` (timer; tags `tool_name`, `agent_role`), which reach
+Prometheus, Datadog, or any Micrometer-supported registry with no further code. The last
+two methods provide an escape hatch for domain-specific instrumentation from inside tool
+implementations.
+
+### 4.5 Distributed tracing
+
+`OTelTracingListener` bridges the event model to OpenTelemetry, producing spans at
+framework boundaries: `ensemble.run` as the root, `task.execute` per task, `tool.execute`
+per tool invocation, and `network.delegate` (span kind `CLIENT`) for cross-agent handoffs.
+Attributes use an `agentensemble.*` namespace to avoid collision with other
+instrumentation. The listener exposes `getTraceId()`, which the framework uses to stamp
+`ExecutionTrace.traceId` -- creating a join between the structured trace and the
+distributed trace, so that a span in Tempo can be resolved to a complete reasoning tree.
+
+`TraceContextPropagator` implements W3C Trace Context [2] extraction and injection, which is
+what allows an ensemble run to appear as a subtree of a larger distributed trace rather than
+as an orphaned root. An inbound HTTP request carrying `traceparent` produces ensemble spans
+correctly parented under the calling service; an outbound cross-ensemble delegation carries
+the header forward. In a network of long-lived ensembles [3], this is the difference between
+a debuggable system and a set of disconnected trace fragments.
+
+### 4.6 Adaptive audit
+
+`AuditingListener` implements audit capture with a policy-driven level that can escalate at
+runtime:
+
+| Level | Recorded |
+|---|---|
+| `MINIMAL` | Delegation events only |
+| `STANDARD` | + task start/complete/fail, review decisions |
+| `FULL` | + tool calls |
+
+`AuditPolicy` carries a default level plus rules that compute an effective level from the
+ensemble identifier and the most recent event, and `escalate(level, duration)` raises
+capture depth temporarily. Escalations are generation-counted so that a stale revert cannot
+overwrite a newer escalation -- a subtle but necessary correctness property when escalations
+overlap.
+
+This is the agent-appropriate answer to a problem that tail-based sampling solves poorly.
+Conventional tail sampling decides retention *after* a trace completes, on the basis of
+error status or duration. Agent runs need the opposite: a decision to *increase* capture
+depth mid-run, triggered by a behavioral signal -- a guardrail trip, an unusual iteration
+count, a delegation to a sensitive agent -- so that the remainder of the run is recorded in
+full. Escalation-on-behavior is, to our knowledge, not expressible in standard OpenTelemetry
+sampling configuration.
+
+### 4.7 Live inspection
+
+The embedded dashboard and the `agentensemble-viz` module consume the same event stream in
+real time over WebSocket, rendering the execution graph, task states, token accumulation,
+tool call detail, and per-agent conversation threads as a run proceeds. This addresses a
+need that has no conventional-service analogue: agent runs are long enough (minutes to
+hours) that operators want to watch them, and interpretable enough that watching is
+actually informative. A ten-minute run that has spent eight minutes re-reading the same
+file is obvious to a human watching a live view and nearly invisible in a post-hoc metric.
+
+### 4.8 Limitations and roadmap
+
+Honesty about current gaps is more useful than a description of an idealized system. Three
+limitations in the present implementation are worth stating explicitly.
+
+**The span model is flatter than the trace model.** `OTelTracingListener` parents every
+span to the root `ensemble.run` context rather than to the enclosing task, so tool and
+delegation spans appear as siblings of the tasks that invoked them. The `ExecutionTrace`
+retains the true hierarchy; the OpenTelemetry projection of it does not. This is a
+consequence of virtual-thread execution under parallel workflows, where `Context.current()`
+does not propagate across the thread boundary, and the correct fix is to carry each task's
+`Context` explicitly rather than falling back to the root.
+
+**Tool spans have no duration.** Because `onToolCall` fires after execution completes, tool
+spans are started and immediately ended with elapsed time recorded as an attribute. They
+render as zero-width in a waterfall view. Backdating the start timestamp would restore the
+visual.
+
+**There is no span per reasoning iteration.** The `onLlmIterationStarted` and
+`onLlmIterationCompleted` events carry message buffer, response type, token usage, and
+latency, but are not currently projected into spans. The consequence is that the ReAct loop
+-- the structure an operator most wants to see -- is absent from the distributed trace even
+though it is fully present in the structured trace.
+
+A fourth item is a matter of ecosystem alignment rather than defect. The `agentensemble.*`
+attribute namespace is appropriate for framework-specific concepts, but the OpenTelemetry
+GenAI semantic conventions [4] have converged on `gen_ai.*` for model, operation, and token
+usage. Dual-emitting `gen_ai.system`, `gen_ai.request.model`, `gen_ai.operation.name`, and
+`gen_ai.usage.input_tokens`/`output_tokens` would cause AgentEnsemble runs to render
+correctly in Grafana, Langfuse, Arize Phoenix, and other LLM-aware backends with no
+configuration. This is a small change with disproportionate ecosystem value.
+
+Finally, Layer 2 and Layer 3 signals identified in Section 3 -- iteration histograms,
+response-type and tool-selection distributions, novelty ratio, guardrail and output-repair
+counters -- are computable from existing events but are not emitted as metrics by default.
+The data is present; the aggregation is not yet wired.
+
+---
+
+## 5. Out-of-Process Instrumentation: CLI Coding Agents
+
+### 5.1 The structural inversion
+
+Claude Code and OpenAI Codex present a categorically different problem. The execution loop
+is a vendor-controlled binary running on a developer workstation. Nothing in Section 4 is
+available: there is no listener interface, no in-process trace object, no capture mode you
+control. Instrumentation is restricted to three channels:
+
+1. **Exhaust** -- telemetry the vendor chooses to emit, plus transcript files on disk.
+2. **Seams** -- points where you can inject your own code: lifecycle hooks and
+   self-hosted MCP servers.
+3. **World effects** -- the git history, the test suite, the CI pipeline, the review queue.
+
+The third channel is not a consolation prize. For coding agents it carries the strongest
+signal available in any regime, and it has no analogue in the in-process case.
+
+Two framing shifts follow. The unit of analysis moves from **run** to **session**, and the
+population moves from **requests** to **humans**. A CLI agent is an interactive system with
+a person in the loop, and that person changes what "good" means.
+
+### 5.2 Claude Code
+
+Claude Code's telemetry is native OpenTelemetry, enabled by `CLAUDE_CODE_ENABLE_TELEMETRY=1`
+and configured through standard `OTEL_*` environment variables [5].
+
+**Metrics.** `claude_code.session.count`, `claude_code.token.usage`, `claude_code.cost.usage`,
+`claude_code.lines_of_code.count`, `claude_code.commit.count`,
+`claude_code.pull_request.count`, `claude_code.code_edit_tool.decision`, and
+`claude_code.active_time.total`. Cost carries context-specific attributes including `model`,
+`agent.name`, `skill.name`, `mcp_server.name`, and `effort`, permitting genuine
+multi-dimensional cost attribution.
+
+**Events**, exported as OTel logs: `user_prompt`, `assistant_response`, `tool_result` (with
+`tool_name`, `success`, `duration_ms`, `error_type`), `tool_decision` (with `decision`,
+`source`, `tool_source`), `api_request` (with `model`, `cost_usd`, `input_tokens`,
+`output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `duration_ms`), `api_error`,
+`api_refusal`, `mcp_server_connection`, and others.
+
+**Traces**, currently beta behind `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1`, produce
+`claude_code.interaction` as a per-prompt root, with `claude_code.llm_request`,
+`claude_code.tool`, `claude_code.tool.blocked_on_user`, `claude_code.tool.execution`, and
+`claude_code.hook` beneath it. Subprocesses inherit `TRACEPARENT` for W3C propagation.
+
+This span decomposition is instructive, and the framework case should adopt its shape. It
+places a span at every LLM request -- precisely the gap identified in Section 4.8 -- and it
+separates `tool.blocked_on_user` from `tool.execution`, so that time spent awaiting a human
+permission decision does not contaminate tool latency. Conflating those two would make every
+latency percentile a measurement of human reaction time.
+
+**Content redaction is default-on.** Prompt text, assistant responses, tool details, tool
+content, and raw API bodies each require explicit opt-in (`OTEL_LOG_USER_PROMPTS`,
+`OTEL_LOG_ASSISTANT_RESPONSES`, `OTEL_LOG_TOOL_DETAILS`, `OTEL_LOG_TOOL_CONTENT`,
+`OTEL_LOG_RAW_API_BODIES`), with content truncation governed by
+`CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH`. This is the tiered-capture model of Section 4.3,
+implemented as deployment policy rather than as an application setting -- and correctly
+biased toward privacy, since the payload is a developer's source code.
+
+**Two defaults are inverted relative to operator interest.**
+`OTEL_METRICS_INCLUDE_SESSION_ID` defaults to *true*, attaching an unbounded-cardinality
+label to every metric datapoint -- one new time series per session, permanently. On a shared
+Prometheus this is the first thing to disable; session correlation belongs in logs and
+traces. Conversely `OTEL_METRICS_INCLUDE_VERSION` defaults to *false*, omitting
+`app.version` -- which, as Section 5.6 argues, is the closest available proxy for the
+prompt-version dimension and therefore the label an operator most needs. The recommended
+posture is the opposite of both defaults.
+
+**Hooks** are the injection seam [6], and the right mental model is an APM agent's bytecode
+instrumentation: you do not own the code, but you receive callbacks at defined points.
+Claude Code exposes an extensive set -- `SessionStart`, `SessionEnd`, `UserPromptSubmit`,
+`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`,
+`SubagentStart`, `SubagentStop`, `Stop`, `StopFailure`, `PreCompact`, `PostCompact`,
+`FileChanged`, `Notification`, and more. Each receives JSON on stdin carrying `session_id`,
+`prompt_id`, `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`, and where
+applicable `agent_id` and `agent_type`.
+
+Three consequences matter for instrumentation design. `PreToolUse`/`PostToolUse` reconstruct
+from outside exactly what the `ToolMetrics` SPI provides from inside.
+`SubagentStart`/`SubagentStop` with `agent_id` and `agent_type` permit reconstruction of the
+delegation tree -- the out-of-process equivalent of `network.delegate` spans. And `prompt_id`
+is the join key between the hook channel and the OTel channel; without it the two are
+disjoint universes, with it hooks become a way to *enrich* vendor traces rather than shadow
+them.
+
+The binding constraint is that hooks are subprocesses on the critical path, with timeouts
+ranging from 600 seconds down to 30 seconds for `UserPromptSubmit`, 10 seconds for
+`MessageDisplay`, and a shared budget of roughly 1.5 seconds across all `SessionEnd` hooks.
+Instrumentation hooks must therefore be strictly fire-and-forget: append a line to a local
+file and return. A hook that makes a network call has converted your observability pipeline
+into a latency dependency of the developer's editor.
+
+### 5.3 OpenAI Codex
+
+Codex offers the same two channels with a different maturity profile and different defaults.
+
+**Telemetry** is configured in `~/.codex/config.toml` under an `[otel]` table, disabled by
+default [7]. The relevant keys:
+
+| Key | Values / default |
+|---|---|
+| `otel.environment` | string, default `"dev"` |
+| `otel.exporter` | `none` \| `otlp-http` \| `otlp-grpc` |
+| `otel.metrics_exporter` | `none` \| `statsig` \| `otlp-http` \| `otlp-grpc`, default `statsig` |
+| `otel.trace_exporter` | `none` \| `otlp-http` \| `otlp-grpc` |
+| `otel.log_user_prompt` | boolean, opt-in raw prompt export |
+
+Each exporter accepts `.endpoint`, `.headers`, `.protocol` (`binary` \| `json`), and TLS
+material via `.tls.ca-certificate`, `.tls.client-certificate`, `.tls.client-private-key`.
+Session transcripts are governed by `history.persistence` (`save-all` \| `none`) and
+`history.max_bytes`; `log_dir` defaults to `$CODEX_HOME/log`; and `notify` registers a
+command that receives a JSON payload for notification events.
+
+Two differences from Claude Code deserve emphasis. First, `metrics_exporter` defaults to
+`statsig` rather than OTLP, so an operator who configures `otel.exporter` for logs and
+assumes metrics follow will silently receive no metrics at their collector -- it must be set
+explicitly. Second, and more consequentially, telemetry coverage is uneven across
+entrypoints: the `[otel]` configuration is honored by the interactive CLI, while `codex exec`
+and `codex mcp-server` have documented gaps in metrics and trace emission [8]. Since
+`codex exec` is the headless entrypoint used in CI and automation, this is precisely the
+inversion of where telemetry is most needed -- an unattended agent has no human observer to
+compensate for missing instrumentation. Operators building on Codex in CI should verify
+current emission empirically rather than assuming parity with the interactive path.
+
+**Hooks** are available and structurally similar to Claude Code's [9], configured in
+`~/.codex/hooks.json`, `<repo>/.codex/hooks.json`, or inline `[[hooks.EventName]]` tables in
+`config.toml`, organized as event → matcher group → handler array with pattern matching such
+as `shell:*` and `mcp:*`. The event set is narrower: `SessionStart`, `SessionEnd`,
+`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PermissionRequest`, `PreCompact`,
+`PostCompact`, `SubagentStart`, `SubagentStop`, and `Stop`. Handlers receive `session_id`,
+`hook_event_name`, `cwd`, `model`, `transcript_path`, and `permission_mode`, with `turn_id`
+on turn-scoped events, and respond with `continue`, `stopReason`, `systemMessage`, and
+`suppressOutput`. Timeouts default to 600 seconds, with `SessionEnd` at 1 second and a
+maximum of 3.
+
+The practical differences for an observability build: Codex has no distinct
+`PostToolUseFailure` event, so success and failure must be discriminated from the
+`PostToolUse` payload rather than from event type; there is no `PermissionDenied` observer
+event, making auto-denial harder to count; and the absence of a `prompt_id` equivalent means
+correlation between hooks and OTel signals runs through `session_id` and `turn_id` instead.
+The `model` field being present in the common payload is a genuine advantage -- it makes
+per-model attribution available in the hook channel without a separate join.
+
+### 5.4 The human as evaluator
+
+The most important asymmetry in this entire comparison is that **Layer 3, the hardest layer
+in-process, is nearly free out-of-process** -- because a human is watching, and their
+behavior is a continuous stream of labels that no judge model can match for accuracy.
+
+- **Interruption is the exception.** There is no stack trace when a coding agent goes wrong;
+  there is a person pressing Escape. Interrupt rate per session is the error rate for Layer 1
+  purposes, and it is a *human-validated* error rate.
+- **Permission denial is rejection.** `claude_code.code_edit_tool.decision` and the
+  `tool_decision` event carry an explicit human verdict on a proposed action. A rising
+  denial rate for a specific tool is a behavioral regression that arrives pre-labeled.
+- **Git is the verdict.** A commit is a positive label. A revert within a week is a negative
+  one. A human editing the same file within minutes of the agent writing it is partial
+  rejection. These labels are free, unambiguous, and already being recorded.
+- **Prompt rephrasing is a comprehension failure.** A user restating the same request in
+  different words is a signal the agent did not understand -- observable through
+  `UserPromptSubmit` and available in no other way.
+
+The corollary is a warning: per-run quality monitoring is *less* valuable for interactive
+agents than for unattended ones, because the human already performs it in real time and
+better. Effort spent building a judge pipeline for interactive coding sessions is largely
+redundant. What the human cannot see -- and what instrumentation must supply -- is the
+aggregate: whether the tool is making the team faster, and where it fails systematically.
+
+### 5.5 Git as the correlation backbone
+
+`claude_code.commit.count` and `claude_code.pull_request.count` are counters. They report how
+many, never which. The question that actually determines whether a coding agent is working
+-- *what fraction of agent-authored changes survived review and were not reverted?* -- cannot
+be answered from a counter.
+
+Constructing the join is straightforward and high-leverage. A `SessionEnd` hook records
+`{session_id, cwd, branch, HEAD sha, end_reason}` to a durable store; a periodic job joins
+that record against the forge's API for pull request state, review outcome, CI result, and
+subsequent reverts. Once this exists, the chain
+
+```
+session_id → cwd → branch → commits → pull request → CI result → revert-or-survive
+```
+
+is complete, and **the git branch becomes the trace identifier.** This is the out-of-process
+analogue of `ExecutionTrace.traceId`: the primary key that makes per-run signals joinable to
+outcomes. It is the single highest-value component an organization must build itself, and no
+vendor supplies it, because it necessarily spans the agent, the forge, and CI.
+
+### 5.6 What is irreducibly lost
+
+Three capabilities are structurally unavailable out-of-process, regardless of vendor
+cooperation.
+
+**Prompt version.** The vendor owns the system prompt. When it changes, agent behavior
+changes and there is no version dimension to attribute the change to. `app.version` and
+`model` are the available proxies, and they are correlational rather than causal -- a CLI
+upgrade bundles prompt changes, model routing changes, tool definition changes, and harness
+changes indivisibly. Section 3.5 identified prompt-version attribution as non-negotiable;
+out-of-process it is unobtainable. This is the strongest argument for owning the loop when a
+workload is production-critical.
+
+**Internal loop structure.** Tool calls are observable; the model's deliberation over which
+tool to select, the retry and repair machinery, context assembly, and compaction decisions
+are largely not. Some of this surfaces through `PreCompact`/`PostCompact` and permission
+events, but the mechanism remains opaque.
+
+**Deterministic replay.** A session cannot be re-executed against a pinned model version and
+prompt. Transcripts permit *inspection* of what happened but not *reproduction*, which means
+the standard debugging loop of "reproduce, instrument, fix, verify" is unavailable.
+
+---
+
+## 6. Comparative Analysis
+
+| Dimension | AgentEnsemble (in-process) | Claude Code / Codex (out-of-process) |
+|---|---|---|
+| Instrumentation model | White-box; any point in the loop | Exhaust + seams + world effects |
+| Primary seam | `EnsembleListener` (in-process, typed) | Lifecycle hooks (subprocess, JSON) |
+| Instrumentation cost | Object allocation, no process boundary | Subprocess spawn per hook, on critical path |
+| Unit of analysis | Run | Session |
+| Population | Requests / workloads | Humans |
+| Layer 1 (process) | Built; task, tool, LLM, delegation | Built by vendor; generally more complete |
+| Layer 2 (behavioral) | All inputs available; aggregation not yet wired | Partially reconstructable via hooks; some vendor-gated |
+| Layer 3 (outcome) | Hard; requires judges or validators | Nearly free; human supplies continuous labels |
+| Layer 4 (economic) | `CostEstimate`, `ExecutionMetrics` | First-class, per-model, per-session |
+| Trace structure | Full reasoning tree in `ExecutionTrace` | Vendor spans; reasoning tree not exposed |
+| Prompt-version attribution | Available and controlled | **Structurally unavailable** |
+| Deterministic replay | Possible from captured messages | Not possible |
+| Capture control | `CaptureMode`, runtime-escalatable audit policy | Vendor env vars, set at process start |
+| Correlation key | W3C `traceparent`, `ExecutionTrace.traceId` | `session_id`, `prompt_id`/`turn_id`, **git branch** |
+| Data volume | Production scale; statistical methods viable | Tens of sessions/day; forensic methods required |
+| Data location | Your infrastructure, your data | Developer workstation, their source code |
+| Failure of instrumentation | Caught and logged; run continues | Hook timeout degrades the developer's session |
+
+Two rows deserve amplification.
+
+**Volume changes the discipline.** An organization running fifty coding-agent sessions per
+day cannot detect a distribution shift in iterations-to-completion; the statistics are not
+there. The practice shifts from *monitoring* to *forensics* -- not alert rules but
+investigation -- and this changes the storage architecture. Metrics into a time-series
+database for cost and volume; the event stream into something supporting arbitrary
+after-the-fact queries: Loki, ClickHouse, or DuckDB over the transcript files already on
+disk. Building alerting rules for a population this small produces noise, not signal.
+
+**Privacy inverts.** In-process agents run on your infrastructure over your data under your
+retention policy, and full capture is a cost decision. CLI agents run on a developer's
+machine and the payload is their source code and their prompts, which may contain
+credentials and will certainly contain things people did not expect to be centrally logged.
+Enabling `OTEL_LOG_USER_PROMPTS` or `otel.log_user_prompt` fleet-wide is a policy decision
+requiring disclosure, not a configuration tweak. The correct default is metrics centrally,
+content locally.
+
+---
+
+## 7. The Fourth Pillar: Evaluation
+
+Conventional observability has three pillars: metrics, logs, traces. Agent observability
+requires a fourth -- **scored outcomes** -- because the first three describe the machinery
+and none of them describes the work.
+
+Evaluation is conventionally treated as a pre-deployment activity: a benchmark suite run in
+CI against a fixed dataset. This is necessary and insufficient. Offline evaluation measures
+the system against yesterday's distribution of inputs; production drift arrives as a change
+in the input distribution, a vendor-side model update, or a prompt edit, none of which the
+benchmark observes.
+
+Online evaluation -- sampling live runs and scoring them -- is the missing pillar, and its
+integration requirement is specific: **evaluation output must be emitted through the same
+pipeline, with the same label set, as every other signal.** A quality score living in a
+separate evaluation dashboard, keyed differently from the metrics, cannot answer "did
+quality drop for this agent role on this model after this change," which is the only
+question that matters.
+
+The layered model provides a natural cost gradient. Validation gates (Section 3.3) are free
+and should always run. Deterministic verifiers are cheap where the domain provides them.
+Judge models are expensive and should be sampled -- with the sample deliberately biased
+toward runs that behavioral instrumentation has already flagged as anomalous. This is the
+same escalation principle as the adaptive audit policy of Section 4.6: **let the cheap layer
+decide where to spend the expensive layer.** Uniform random sampling of an agent population
+wastes most of the evaluation budget on unremarkable runs.
+
+---
+
+## 8. Reference Architectures
+
+### 8.1 In-process
+
+```
+AgentEnsemble
+  ├── OTelTracingListener ──────────► OTLP ──► Collector ──► Tempo    (traces)
+  ├── MicrometerToolMetrics ────────► registry ──────────► Prometheus (metrics)
+  ├── Custom behavioral listener ───► registry ──────────► Prometheus (Layer 2)
+  ├── AuditingListener ─────────────► AuditSink ─────────► Loki/DB    (audit)
+  ├── JsonTraceExporter ────────────► object store ──────► offline analysis
+  └── Dashboard / viz WebSocket ────► operator browser               (live)
+```
+
+The behavioral listener is the piece not yet supplied by the framework. It consumes
+`onLlmIterationCompleted`, `onToolCall`, and `onTaskComplete`, and emits the Layer 2 metrics
+of Section 3.2. It is on the order of a hundred lines and is the highest-value addition to
+the current stack.
+
+Retention should be tiered along the same gradient as capture: metrics at full resolution
+for weeks, spans sampled with escalation-on-behavior, and full `ExecutionTrace` JSON retained
+only for runs that failed, tripped a guardrail, or were sampled for evaluation.
+
+### 8.2 Out-of-process
+
+```
+Claude Code / Codex
+  ├── OTLP exporters ───────────────► Collector ──► Prometheus + Tempo + Loki
+  │     (session_id OFF in metrics, app.version ON, content redacted)
+  ├── Hooks (fire-and-forget) ──────► local JSONL ──► Alloy ──► Loki
+  │     PreToolUse / PostToolUse / SubagentStart / SubagentStop / Stop
+  ├── SessionEnd hook ──────────────► session↔branch registry ─┐
+  ├── Transcripts on disk ──────────► batch ingest ──► ClickHouse (forensics)
+  └── Forge + CI APIs ──────────────► outcome records ─────────┴──► joined outcome table
+```
+
+The two components an organization must build are the session-to-branch registry and the
+outcome join. Everything else is configuration.
+
+### 8.3 The hybrid: MCP as an instrumentation seam
+
+A self-hosted MCP server [10] is white-box by construction: it is your process, so you
+observe every invocation completely -- arguments, results, latency, errors -- with no vendor
+cooperation required. This yields a useful hybrid: an opaque agent driving fully-instrumented
+tools, structurally analogous to service-mesh sidecar telemetry, where the workload is
+uninstrumented but every interaction crossing its boundary is observed.
+
+For AgentEnsemble the natural form of this pattern is to place an ensemble behind a boundary
+that a CLI agent can invoke. The entire in-process instrumentation stack of Section 4 then
+applies inside that invocation, and `traceparent` propagation joins the ensemble's spans to
+the CLI session's trace -- yielding a single trace spanning an opaque outer agent and a
+fully-observable inner one: black-box where it must be, white-box where it matters.
+
+A clarification on current capability is warranted. The `agentensemble-mcp` module is an MCP
+*client* bridge: `McpToolFactory` and `McpServerLifecycle` adapt tools exposed by external
+MCP servers into the `AgentTool` interface, so ensembles can consume the MCP ecosystem. It
+does not currently expose ensembles *as* MCP servers. The inbound direction is available
+today through the Ensemble Control API and the `agentensemble-web` HTTP surface, which a CLI
+agent can call directly; an MCP server facade over that API would make the integration
+idiomatic for CLI agents and is a natural extension. Either way, the observability property
+is the same, and it derives from process ownership rather than from protocol: whoever hosts
+the tool endpoint observes it completely.
+
+---
+
+## 9. Open Problems
+
+**The unattended CLI case.** Running `claude -p` or `codex exec` in CI removes the human,
+and with them every Layer 3 signal of Section 5.4 -- no interruptions, no permission
+decisions, no immediate manual edits. What remains is a black-box agent with no evaluator,
+which is strictly worse than either regime alone: framework-grade instrumentation is
+required and out-of-process constraints prevent it. That this is also where Codex's
+telemetry coverage is weakest [8] compounds the difficulty. Our position is that
+production-critical unattended work belongs in a framework whose loop you own, and that CLI
+agents in CI should be restricted to work whose output is verified deterministically -- tests
+that must pass, builds that must succeed.
+
+**Behavioral baselines without volume.** Every Layer 2 instrument presupposes a baseline
+distribution to compare against, and low-volume deployments cannot establish one
+statistically. Whether baselines can be transferred across agents, tasks, or organizations
+is unresolved.
+
+**Evaluating the evaluator.** Judge models drift, and a judge that drifts in the same
+direction as the agent it scores produces a quality metric that is stable and wrong. Judge
+calibration requires periodic human-labeled anchoring, and the sampling economics of that
+anchoring are not well understood.
+
+**Semantic conventions for multi-agent structure.** The OpenTelemetry GenAI conventions [4]
+cover model invocations well. They do not yet standardize delegation, handoff, review gates,
+or state-machine transitions -- the structures that distinguish multi-agent systems from
+single-agent ones. Until they do, cross-framework comparison of agent traces remains
+impossible.
+
+**Cross-boundary trace continuity.** When an ensemble delegates to an ensemble in another
+process [3], W3C propagation preserves the trace. When a CLI agent invokes an MCP-exposed
+ensemble, continuity depends on the CLI propagating `traceparent` into the MCP transport --
+which Claude Code does for subprocesses but which is not guaranteed across all transports or
+all vendors.
+
+---
+
+## 10. Conclusion
+
+Agent observability is not a plumbing problem. The exporters exist, the collectors are
+mature, and the wire protocols are settled. The problem is that the signals worth exporting
+are not the signals classical practice trained operators to collect.
+
+Three claims summarize our position.
+
+**First, instrument the trajectory, not the request.** The distribution of reasoning
+iterations, the distribution over tool selection, and the ratio of novel to repeated actions
+detect regressions weeks before any error rate moves, and they require no ground truth. They
+are the cheapest high-value signals in agent observability and are almost universally
+absent.
+
+**Second, the two regimes invert, and the inversion should drive strategy.** In-process, you
+control prompt versions, capture depth, and replay, but you must construct outcome
+measurement yourself. Out-of-process, outcome measurement is nearly free because a human
+labels every turn through interruptions, permission decisions, and git history, but
+prompt-version attribution is permanently unavailable. Neither is uniformly superior. The
+decision rule that follows is: **own the loop when correctness must be attributable; borrow
+the loop when a human is present to supply correctness.**
+
+**Third, let cheap layers direct expensive ones.** Full-fidelity capture, judge-model
+evaluation, and long-retention traces are all too expensive to apply uniformly and too
+valuable to omit. Behavioral instrumentation is cheap enough to run on every request and
+informative enough to identify which runs deserve the expensive treatment. AgentEnsemble's
+runtime-escalatable audit policy implements this principle for capture depth; the same
+principle should govern evaluation sampling and trace retention.
+
+The through-line is that agents fail silently, and silence is not the absence of signal --
+it is signal in a dimension classical instrumentation does not measure. Building the
+instruments for those dimensions is the work.
+
+---
+
+## References
+
+[1] B. Beyer, C. Jones, J. Petoff, N. R. Murphy, *Site Reliability Engineering*, O'Reilly,
+2016. Chapter 6, "Monitoring Distributed Systems" (the four golden signals).
+
+[2] W3C, *Trace Context*, W3C Recommendation. https://www.w3.org/TR/trace-context/
+
+[3] AgentEnsemble, *Ensemble Network: A Distributed Architecture for Autonomous Multi-Agent
+Systems*. `docs/whitepaper/ensemble-network-architecture.md`
+
+[4] OpenTelemetry, *Semantic Conventions for Generative AI Systems*.
+https://opentelemetry.io/docs/specs/semconv/gen-ai/
+
+[5] Anthropic, *Claude Code: Monitoring usage*. https://code.claude.com/docs/en/monitoring-usage
+
+[6] Anthropic, *Claude Code: Hooks*. https://code.claude.com/docs/en/hooks
+
+[7] OpenAI, *Codex configuration reference*.
+https://developers.openai.com/codex/config-reference
+
+[8] OpenAI, *codex exec emits no OTel metrics; codex mcp-server emits no OTel telemetry at
+all*, Issue #12913. https://github.com/openai/codex/issues/12913
+
+[9] OpenAI, *Codex: Hooks*. https://developers.openai.com/codex/hooks
+
+[10] Anthropic, *Model Context Protocol*. https://modelcontextprotocol.io/
+
+[11] AgentEnsemble, *Metrics and Observability guide*. `docs/guides/metrics.md`
+
+[12] AgentEnsemble, *CaptureMode guide*. `docs/guides/capture-mode.md`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,3 +171,5 @@ nav:
     - Viz Observability: design/27-viz-observability.md
     - Loops: design/29-loops.md
     - Graphs (state machines): design/30-graphs.md
+    - OpenTelemetry Tracing Fidelity: design/31-otel-tracing-fidelity.md
+    - Behavioral Metrics: design/32-behavioral-metrics.md


### PR DESCRIPTION
## Summary

Docs only -- no source changes. Adds a whitepaper on observability for agentic systems, plus two design docs covering the framework-side gaps it identifies.

## Whitepaper

[`docs/whitepaper/agent-observability.md`](docs/whitepaper/agent-observability.md) (~7,200 words), following the format of the existing Ensemble Network whitepaper.

The argument: classical observability assumes failure is loud -- an exception, a 5xx, a latency spike. An agent's characteristic failure is none of those. It completes successfully, within normal latency, and produces work that is wrong.

- A five-mode agent failure taxonomy; only the first is detected by classical signals
- A four-layer instrumentation model -- process, behavioral, outcome, economic
- **How AgentEnsemble does it**: `EnsembleListener` SPI, the `ExecutionTrace` tree, `CaptureMode` tiers, `ToolMetrics`/Micrometer, OTel spans + W3C propagation, adaptive audit policy, live dashboard
- **Contrast with CLI coding agents** (Claude Code and OpenAI Codex), with exact metric names, event names, span types, hook events, and config keys for both
- Reference architectures for both regimes, and open problems

The central finding is that the two regimes invert. In-process you control prompt version, capture depth, and replay, but must build outcome measurement yourself. Out-of-process outcome measurement is nearly free -- the human labels every turn through interrupts, permission denials, and git history -- but prompt-version attribution is structurally unavailable, because the vendor owns the system prompt.

Section 4.8 is candid about three current gaps in `OTelTracingListener`, which is what the design docs below address.

## Design 31 -- OpenTelemetry Tracing Fidelity

[`docs/design/31-otel-tracing-fidelity.md`](docs/design/31-otel-tracing-fidelity.md)

`ExecutionTrace` preserves the full reasoning tree; the OTel projection of it flattens to two levels. Five issues:

| Issue | Change |
|---|---|
| OT-001 | `taskIndex` on `LlmIterationStarted/CompletedEvent` and `DelegationStartedEvent` (enabler) |
| OT-002 | Correct span parenting via an explicit parent-context registry |
| OT-003 | Span per reasoning iteration -- the ReAct loop is currently absent from traces |
| OT-004 | Tool span duration (currently zero-width) and outcome status |
| OT-005 | `gen_ai.*` semantic conventions, dual-emitted alongside `agentensemble.*` |

Notable decisions:

- **Explicit parent keys rather than `Context.makeCurrent()`** -- OTel's current context is a thread-local and does not survive the virtual-thread boundary under `PARALLEL`; holding a `Scope` across two callbacks also leaks when a task never completes.
- **`FAILURE` maps to `StatusCode.OK`, not ERROR.** A search returning no hits is not an outage. Conflating it with `ERROR` makes error-rate panels track the world's contents rather than system health -- the distinction the three-way `ToolMetrics` split already encodes.
- **`gen_ai.request.model` has a real constraint.** LangChain4j's `ChatModel` exposes no model identifier, so there is nothing to interrogate at runtime. Reflection and a required parameter were both rejected; the doc proposes an optional `modelName()` for telemetry labelling, omitting the attribute when unset rather than emitting `unknown`.

## Design 32 -- Behavioral Metrics

[`docs/design/32-behavioral-metrics.md`](docs/design/32-behavioral-metrics.md)

Every signal is derivable from events already fired, and none requires ground truth, a judge model, or a human. SPI and listener in core, Micrometer implementation in its own module -- mirroring the existing `ToolMetrics` pattern.

| Issue | Change |
|---|---|
| BM-001 | `BehavioralMetrics` SPI + `NoOpBehavioralMetrics` |
| BM-002 | `BehavioralMetricsListener` -- per-task accumulation |
| BM-003 | Novelty ratio and call signatures (thrash detection) |
| BM-004 | Guardrail, output repair, and review decision events |
| BM-005 | Micrometer implementation, common tags, ensemble wiring |

Notable decisions:

- **Tool *selection* measured from `toolRequests()`, not `ToolCallEvent`.** They diverge when a guard or policy blocks a requested tool: rising selection against flat execution means the model keeps asking for a capability it is not being granted, which execution counters cannot see.
- **Only truncated hashes of canonicalized arguments are retained**, never the arguments -- bounds memory to 16 bytes per distinct call and keeps an always-on path free of user data.
- **Percentile histograms are mandatory.** Iteration-count's value is entirely in its tail; a metric exposing only count/sum/max cannot show tail fattening.
- **`OutputRepairEvent` is worth landing on its own** -- the rate at which structured output needs a correction prompt is a continuous measurement of instruction-following fidelity that the framework currently computes and discards.

## Sequencing

**BM-002 depends on OT-001.** Per-task accumulation needs `taskIndex` on the iteration events; without it, keying falls back to `(agentRole, taskDescription)`, which is ambiguous when one role runs concurrent tasks under `PARALLEL`. OT-001 is a pure enabler and serves both tracks.

## Also surfaced

`AuditingListener`'s Javadoc states that the `STANDARD` audit level records "review decisions", but `EnsembleListener` defines no review callback and `AuditingListener` overrides none. The documented behavior is not implemented. BM-004 introduces the missing event; the Javadoc needs correcting either way.

## Notes for review

- Both design docs are added to the mkdocs nav. The whitepaper is not, matching the existing whitepaper, which is also absent from `nav`.
- Section 4.8 of the whitepaper names current limitations in a public document. Happy to soften or cut it if that is the wrong call for a published paper.
- No issues opened yet for OT-001..005 / BM-001..005.
